### PR TITLE
Atualização para o Patch 1.33

### DIFF
--- a/translate/pt-BR/strings_pt_BR.txt
+++ b/translate/pt-BR/strings_pt_BR.txt
@@ -6,13 +6,13 @@ add.player=Adicionar Jogador
 ai.turn=Turno da IA
 aiplayername.AutomatedAlliance=Aliança Automatizada
 aiplayername.ElectricEyrie=Rapinas Elétricas
-aiplayername.eyriedynasties=Dinastias das Rapinas
+aiplayername.eyriedynasties=Dinastia das Rapinas
 aiplayername.marquisedecat=Marqueses
 aiplayername.MechanicalMarquise=Marquês Mecânico
 aiplayername.vagabond=Malandro
-aiplayername.Vagabot=Malandrobot
+aiplayername.Vagabot=Automalandro
 aiplayername.woodlandalliance=Aliança da Floresta
-aiplayername.unassigned=Não atribuido
+aiplayername.unassigned=Não atribuído
 android.externalpermissions.query=Como este aplicativo está em armazenamento externo, é recomendável permitir o acesso ao armazenamento externo para que ele possa ser atualizado sem precisar ser reinstalado.
 android.externalpermissions.reminder=Este aplicativo deve solicitar permissão novamente na próxima vez que for iniciado?
 android.externalpermissions.warning=As permissões para permitir o acesso ao armazenamento externo para este aplicativo podem ser alteradas nas Configurações de Apps do Android.
@@ -35,18 +35,19 @@ auto.update.cancel=Fechar
 auto.update.confirm=Atualizar
 Automated.Alliance.Challenging=<b>Desafiador:</b> A Aliança Automatizada se organiza se uma clareira tiver dois ou mais guerreiros da Aliança.
 Automated.Alliance.Easy=<b>Fácil:</b> A Aliança Automatizada se organiza se uma clareira tiver quatro ou mais guerreiros da Aliança.
-Automated.Alliance.Nightmare=<b>Pesadelo:</b> A Aliança Automatizada se organiza se uma clareira tiver dois ou mais guerreiros da Aliança. No final da Noite, eles ganham um ponto de vitória.
+Automated.Alliance.Nightmare=<b>Pesadelo:</b> A Aliança Automatizada se organiza se uma clareira tiver dois ou mais guerreiros da Aliança. No final do Anoitecer eles ganham um ponto de vitória.
 automatedallianceWithColor=<color=#008D3F>Aliança Automatizada</color>
 battledamage.fx.ambush=Emboscada!
 battledamage.fx.autoambush=Emboscada Automatizada!
+battledamage.fx.ambushblocked=Emboscada Bloqueada!
 battledamage.fx.brutaltactics=Táticas Brutais!
 battledamage.fx.commander=<sprite name="eyrie"> Comandante!
-battledamage.fx.defenseless=Sem Defesa!
+battledamage.fx.defenseless=Indefeso!
 battledamage.fx.electriceyrie=Bônus do Decreto!
 battledamage.fx.format=-$quantidade
-battledamage.fx.sappers=Sapadores!
+battledamage.fx.sappers=Armadilheiros!
 battledamage.fx.swiftstrike=Golpe Rápido
-battledamage.fx.wrathful=Furioso!
+battledamage.fx.wrathful=Colérico!
 battledamage.fx.stubborn=Teimoso!
 battledamage.fx.devoutknights=Cavaleiros Devotos!
 battledamage.fx.looting=Saqueando!
@@ -91,9 +92,9 @@ challenges.winagame=Vença uma partida.
 changePassword.newPassword=Nova Senha
 changePassword.oldPassword=Senha Antiga
 changePassword.title=Alterar Senha
-character.ranger.difficult=Guarda
+character.ranger.difficult=Andarilho
 character.thief.easy=Ladrão
-character.tinker.moderate=Artífice
+character.tinker.moderate=Funileiro
 clearing.costhint.label=Custo:
 Clockwork.Normal=<b>Normal:</b> Nada muda.
 configuresolo.four=4 Jogadores
@@ -109,7 +110,7 @@ createaccount.screenname=Nome de Exibição
 creategame.availablefactions=Facções Disponíveis
 creategame.coopmode=Jogo Cooperativo
 creategame.deckselection=Seleção de Baralho
-creategame.exilesandpartisans=Exilados e Partidários
+creategame.exilesandpartisans=Exilados e Partisans
 creategame.mapselection=Seleção de Mapa
 creategame.matchsettings=Configurações de Jogo
 creategame.randomclearingsuits=Naipes Aleatórios de Clareiras
@@ -168,23 +169,23 @@ dwd.referral.email.error.throttled=Você atingiu o número máximo de convites p
 dwd.referral.email.error.userDeclined=Este usuário optou por não receber convites.
 Electric.Eyrie.Challenging=<b>Desafiador:</b> Durante a preparação, pegue uma carta de Emboscada de Pássaro do baralho e adicione-a à coluna de pássaros do Decreto.
 Electric.Eyrie.Easy=<b>Fácil:</b> Durante a preparação, adicione apenas um Vizir Leal ao Decreto das Rapinas Elétricas.
-Electric.Eyrie.Nightmare=<b>Pesadelo:</b> Durante a preparação, pegue uma carta de Emboscada de Pássaro do baralho e adicione-a à coluna de pássaros do Decreto das Rapinas Elétricas. No final da Noite, as Rapinas Elétricas ganham um ponto de vitória.
+Electric.Eyrie.Nightmare=<b>Pesadelo:</b> Durante a preparação, pegue uma carta de Emboscada de Pássaro do baralho e adicione-a à coluna de pássaros do Decreto das Rapinas Elétricas. No final do Anoitecer, as Rapinas Elétricas ganham um ponto de vitória.
 electriceyrieWithColor=<color=#3A63CB>Rapinas Elétricas</color>
 end.turn=Terminar Turno
 endofgame.1st!=1º Lugar!
 endofgame.defeat=Derrota!
 endofgame.title=Detalhes
 endofgame.victory=Vitória!
-eyrieWithColor=<color=#3A63CB>Dinastias das Rapinas</color>
+eyrieWithColor=<color=#3A63CB>Dinastia das Rapinas</color>
 factionnames.AutomatedAlliance=Aliança Automatizada
 factionnames.ElectricEyrie=Rapinas Elétricas
-factionnames.eyriedynasties=Dinastias das Rapinas
+factionnames.eyriedynasties=Dinastia das Rapinas
 factionnames.invalid=Facção Aleatória
 factionnames.marquisedecat=Marqueses
 factionnames.MechanicalMarquise=Marquês Mecânico
 factionnames.SecondVagabond=Malandro
 factionnames.vagabond=Malandro
-factionnames.Vagabot=Malandrobot
+factionnames.Vagabot=Automalandro
 factionnames.woodlandalliance=Aliança da Floresta
 feedback.sendLogs=Enviar Registros
 friend.request.from=Pedido de Amizade: {0}
@@ -212,7 +213,7 @@ gameoptions.AIdifficultyHard=Difícil
 gameoptions.AIdifficultyMedium=Médio
 gameoptions.AIdifficultyNightmare=Pesadelo
 gameoptions.creategame=Criar Partida
-gameoptions.deck.EnP=Exilados & Partidários
+gameoptions.deck.EnP=Exilados & Partisans
 gameoptions.deck.standard=Padrão
 gameoptions.gametype=Selecionar um Tipo de Jogo
 gameoptions.header=Opções de Jogo
@@ -289,7 +290,7 @@ marquiseWithColor=<color=#CC6633>Marqueses</color>
 match.start.failure=Falha ao carregar a Partida
 Mechanical.Marquise.Challenging=<b>Desafiador:</b> Sempre que o Marquês Mecânico recrutar, posicione dois guerreiros na clareira ordenada de maior prioridade que ele governa.
 Mechanical.Marquise.Easy=<b>Fácil:</b> Sempre que o Marquês Mecânico recrutar, em vez disso, posicione apenas dois guerreiros.
-Mechanical.Marquise.Nightmare=<b>Pesadelo:</b> Sempre que o Marquês Mecânico recrutar, ele coloca também dois guerreiros extras na clareira com o menor número de prioridade que controla. No final da Noite, ele recebe um ponto de vitória adicional.
+Mechanical.Marquise.Nightmare=<b>Pesadelo:</b> Sempre que o Marquês Mecânico recrutar, ele coloca também dois guerreiros extras na clareira com o menor número de prioridade que controla. No final do Anoitecer, ele recebe um ponto de vitória adicional.
 mechanicalmarquiseWithColor=<color=#CC6633>Marquês Mecânico</color>
 moregames.header=Mais Jogos
 moveworkernoopability.button=Pular
@@ -357,60 +358,60 @@ pile.reveal.no.units=Nenhuma Carta Disponível.
 player.name.self=Você
 playerhand.title=Mão de {0}
 playerinfo.alliance.Birdsongrev=1º: Revolta - Gaste 2 apoiadores que correspondam a uma clareira simpática. Remova todas as peças de lá. Coloque uma base correspondente e guerreiros iguais ao total de clareiras simpáticas correspondentes. Ganhe um Oficial.
-playerinfo.alliance.Birdsongsym=2º: Espalhar Simpatia - Pague o custo de apoiadores para colocar simpatia e ganhe <style="vptext">PVs</style> igual ao valor atual mostrado na trilha de simpatia.
-playerinfo.alliance.daylight=Você pode realizar estas ações qualquer número de vezes.<br><line-indent=15%>• Produzir<br>• Mobilizar<br>• Treinar
-playerinfo.alliance.evening=1º: Operações Militares - Você tem ações iguais ao número de oficiais.<br><line-indent=15%>• Mover<br>• Recrutar<br>• Combater<br>• Organizar<br><br><line-indent=-15%>2º: Compre uma carta (+1 carta para cada base no mapa) e descarte até ter 5 cartas.
+playerinfo.alliance.Birdsongsym=2º: Distribua Simpatia - Pague o custo de apoiadores para colocar simpatia e ganhe <style="vptext">PVs</style> igual ao valor atual mostrado na trilha de simpatia.
+playerinfo.alliance.daylight=Você pode realizar estas ações qualquer número de vezes.<br><line-indent=15%>• Criar<br>• Mobilizar<br>• Treinar
+playerinfo.alliance.evening=1º: Operações Militares - Você tem ações iguais ao número de oficiais.<br><line-indent=15%>• Mover<br>• Recrutar<br>• Batalha<br>• Organizar<br><br><line-indent=-15%>2º: Compre uma carta (+1 carta para cada base no mapa) e descarte até ter 5 cartas.
 playerinfo.alliance.martiallaw=Você deve gastar outro apoiador correspondente se a clareira alvo tiver pelo menos 3 guerreiros de outro jogador.
 playerinfo.alliance.martiallawtitle=Lei Marcial
 playerinfo.autoalliance.autoambush=Em combate como defensor com qualquer guerreiro da Aliança, você causa um golpe extra.
 playerinfo.autoalliance.autoambushtitle=Emboscada Automatizada
 playerinfo.autoalliance.autooutrage=Sempre que um humano remover um marcador de simpatia ou mover guerreiros para uma clareira simpática, ele deve descartar uma carta correspondente. Se não puder, você ganha +1 .
-playerinfo.autoalliance.autooutragetitle=Indignação Automatizada
-playerinfo.autoalliance.Birdsong=1º: Revele uma carta de ordem.<br><br>2º: Produza a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><br>3º: Revolta<br>Remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas e coloque a base ordenada lá. Se a carta de ordem for um <sprite name="birdicon">, faça isso durante o amanhecer.<br><br>4º: Piedade Pública<br>Se você não se revoltou neste turno, espalhe simpatia duas vezes se tiver quatro ou menos clareiras simpáticas ou espalhe simpatia uma vez se tiver cinco ou mais.
+playerinfo.autoalliance.autooutragetitle=Ultraje Automatizado
+playerinfo.autoalliance.Birdsong=1º: Revele uma carta de ordem.<br><br>2º: Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><br>3º: Revolta<br>Remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas e coloque a base ordenada lá. Se a carta de ordem for um <sprite name="birdicon">, faça isso durante o Amanhecer.<br><br>4º: Piedade Pública<br>Se você não se revoltou neste turno, espalhe simpatia duas vezes se tiver quatro ou menos clareiras simpáticas ou espalhe simpatia uma vez se tiver cinco ou mais.
 playerinfo.autoalliance.daylight=1º: Espalhar Simpatia<br>Coloque um marcador de simpatia na clareira ordenada com menos guerreiros inimigos adjacente a qualquer clareira simpática. Se não houver tal clareira, em vez disso, coloque simpatia na clareira com menos peças inimigas. Se não puder colocar um marcador de simpatia, ganhe <style="vpnum">5 .<br><br>2º: Revolta Surpresa<br>Se a carta de ordem for um <sprite name="birdicon">, revolte em uma clareira que corresponda ao naipe de uma base não utilizada.
 playerinfo.autoalliance.evening=1º: Organizar<br>Em cada clareira com uma base e três ou mais guerreiros da Aliança, remova todos os guerreiros da Aliança lá e espalhe simpatia.<br><br>2º: Recrutar<br>Coloque um guerreiro em cada clareira com uma base.
 playerinfo.autoalliance.title=Aliança Automatizada
 playerinfo.Birdsong=Amanhecer
-playerinfo.craftedcards=Cartas Produzidas
-playerinfo.crafteditems=Itens Produzidos
+playerinfo.craftedcards=Cartas Criadas
+playerinfo.crafteditems=Itens Criados
 playerinfo.daylight=Dia
-playerinfo.electriceyrie.Birdsong=<b>1º:</b> Revele uma carta de ordem.<br><b>2º:</b> Produza a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><b>3º:</b> Adicione a carta de ordem à coluna correspondente do Decreto.
-playerinfo.electriceyrie.daylight=<b>1º:</b> Resolva o Decreto—recrute para cada coluna com pelo menos uma carta da esquerda para a direita, depois mova dessa forma e então combata dessa forma.<br><br>    <b>-Recrutar -</b> Recrute guerreiros, igual ao número de cartas nessa coluna, em uma clareira correspondente com um poleiro.<br><br>        -Empates de Clareira - Recrute em tal clareira com mais peças inimigas, depois menos guerreiros Rapinas, depois menor prioridade.<br><br>    <b>-Mover</b> - Mova da clareira correspondente que você governa com mais guerreiros Rapinas. Mova para uma clareira adjacente sem poleiro—se todas tiverem poleiro, mova para a com menos peças inimigas. Deixe guerreiros suficientes para exatamente governar a clareira de origem ou igual ao número de cartas nesta coluna, o que for maior.<br><br>        -Empates de Destino - Mova para tal clareira com menos peças inimigas, depois menor prioridade.<br><br>    <b>-Combater</b> - Combata em uma clareira correspondente. O defensor é o jogador com mais edifícios. Se esta coluna tiver mais cartas, cause um golpe extra.<br><br>        -Empates de Clareira - Combata em tal clareira sem poleiro, depois mais edifícios indefesos, depois menor prioridade.<br><br>        -Empates de Defensor - Combata tal jogador com mais peças lá, depois mais pontos de vitória.<br><br><b>2º:</b> Construa Coloque um poleiro na clareira que você governa de maior prioridade sem poleiro. Se não puder colocar um poleiro, você entra em tumulto.
-playerinfo.electriceyrie.evening=Marque os <style="vptext">PVs</style> listados no espaço vazio mais à direita na trilha de Poleiros.
-playerinfo.evening=Noite
-playerinfo.eyriedynasties.Birdsong=1º: Se sua mão estiver vazia, compre uma carta <sprite name="DrawCard">.<br><br>2º: Adicione uma ou duas cartas ao Decreto. Apenas uma carta adicionada pode ser do naipe de pássaro <sprite name="birdicon">.<br><br>3º: Se você não tiver poleiros <sprite name="Roost">, coloque um poleiro e três guerreiros na clareira com menos guerreiros.
-playerinfo.eyriedynasties.daylight=1º: Produza usando poleiros.<br><br>2º: Resolva o decreto da esquerda para a direita, realizando uma ação por carta em uma clareira correspondente.
-playerinfo.eyriedynasties.decree.battle=Combate
+playerinfo.electriceyrie.Birdsong=<b>1º:</b> Revele uma carta de ordem.<br><b>2º:</b> Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><b>3º:</b> Adicione a carta de ordem à coluna correspondente do Decreto.
+playerinfo.electriceyrie.daylight=<b>1º:</b> Resolva o Decreto—recrute para cada coluna com pelo menos uma carta da esquerda para a direita, depois mova dessa forma e então combata dessa forma.<br><br>    <b>-Recrutar -</b> Recrute guerreiros, igual ao número de cartas nessa coluna, em uma clareira correspondente com um ninho.<br><br>        -Empates de Clareira - Recrute em tal clareira com mais peças inimigas, depois menos guerreiros Rapinas, depois menor prioridade.<br><br>    <b>-Mover</b> - Mova da clareira correspondente que você governa com mais guerreiros Rapinas. Mova para uma clareira adjacente sem ninho—se todas tiverem ninho, mova para a com menos peças inimigas. Deixe guerreiros suficientes para exatamente governar a clareira de origem ou igual ao número de cartas nesta coluna, o que for maior.<br><br>        -Empates de Destino - Mova para tal clareira com menos peças inimigas, depois menor prioridade.<br><br>    <b>-Combater</b> - Combata em uma clareira correspondente. O defensor é o jogador com mais edifícios. Se esta coluna tiver mais cartas, cause um golpe extra.<br><br>        -Empates de Clareira - Combata em tal clareira sem ninho, depois mais edifícios indefesos, depois menor prioridade.<br><br>        -Empates de Defensor - Combata tal jogador com mais peças lá, depois mais pontos de vitória.<br><br><b>2º:</b> Construa um ninho na clareira que você governa de maior prioridade sem ninho. Se não puder colocar um ninho, você entra em tumulto.
+playerinfo.electriceyrie.evening=Pontue os <style="vptext">PVs</style> listados no espaço vazio mais à direita na trilha de Ninhos.
+playerinfo.evening=Anoitecer
+playerinfo.eyriedynasties.Birdsong=1º: Se sua mão estiver vazia, compre uma carta <sprite name="DrawCard">.<br><br>2º: Adicione uma ou duas cartas ao Decreto. Apenas uma carta adicionada pode ser do naipe de pássaro <sprite name="birdicon">.<br><br>3º: Se você não tiver ninhos <sprite name="Roost">, coloque um ninho e três guerreiros na clareira com menos guerreiros.
+playerinfo.eyriedynasties.daylight=1º: Criar usando ninhos.<br><br>2º: Resolver o Decreto da esquerda para a direita, realizando uma ação por carta em uma clareira correspondente.
+playerinfo.eyriedynasties.decree.battle=Batalha
 playerinfo.eyriedynasties.decree.battle.desc=...em uma clareira correspondente.
 playerinfo.eyriedynasties.decree.build=Construir
-playerinfo.eyriedynasties.decree.build.desc=...em uma clareira correspondente que você governa sem um poleiro.
+playerinfo.eyriedynasties.decree.build.desc=...em uma clareira correspondente que você governa sem um ninho.
 playerinfo.eyriedynasties.decree.description=coloque uma carta na ação que desejar no seu decreto
 playerinfo.eyriedynasties.decree.move=Mover
 playerinfo.eyriedynasties.decree.move.desc=...guerreiros de uma clareira correspondente.
 playerinfo.eyriedynasties.decree.recruit=Recrutar
-playerinfo.eyriedynasties.decree.recruit.desc=...guerreiros em uma clareira correspondente com um poleiro.
+playerinfo.eyriedynasties.decree.recruit.desc=...guerreiros em uma clareira correspondente com um ninho.
 playerinfo.eyriedynasties.decree.title=Decreto
-playerinfo.eyriedynasties.disdainfortrade.description=Ao produzir itens, você marca apenas um ponto de vitória.
-playerinfo.eyriedynasties.disdainfortrade.title=Desdém pelo Comércio
-playerinfo.eyriedynasties.evening=1º: Marque <style="vptext">PVs igual à sua posição na trilha de poleiros.2º: Compre uma carta (+1 carta para cada  obtido na trilha de poleiros) e depois descarte até ter 5 cartas.
-playerinfo.eyriedynasties.leader.builder=Construtor: Ignore seu Desdém pelo Comércio ao produzir.
-playerinfo.eyriedynasties.leader.charismatic=Carismático: Você coloca dois guerreiros, não um, cada vez que recrutar.
-playerinfo.eyriedynasties.leader.commander=Comandante: Como atacante em combate, você causa um golpe extra.
+playerinfo.eyriedynasties.disdainfortrade.description=Ao criar itens, você marca apenas um ponto de vitória.
+playerinfo.eyriedynasties.disdainfortrade.title=Desprezo pelo Comércio
+playerinfo.eyriedynasties.evening=1º: Receba<style="vptext">PVs igual à sua posição na trilha de ninhos. 2º: Compre uma carta (+1 carta para cada <sprite name="DrawCard"> obtido na trilha de ninhos) e depois descarte até ter 5 cartas.
+playerinfo.eyriedynasties.leader.builder=<b>Construtor:</b> Ignore seu Desprezo pelo Comércio ao criar.
+playerinfo.eyriedynasties.leader.charismatic=<b>Carismático:</b> Você coloca dois guerreiros, não um, cada vez que recrutar.
+playerinfo.eyriedynasties.leader.commander=<b>Comandante:</b> Como atacante em combate, você causa um golpe extra.
 playerinfo.eyriedynasties.leader.despot=<b>Déspota:</b> Se você remover pelo menos um edifício ou marcador inimigo em combate, marque um ponto.
 playerinfo.eyriedynasties.lordsoftheforest.description=Você governa qualquer clareira onde estiver empatado em presença.
-playerinfo.eyriedynasties.lordsoftheforest.title=Senhores da Floresta
+playerinfo.eyriedynasties.lordsoftheforest.title=Lordes da Floresta
 playerinfo.eyriedynasties.rooststitle=Ninhos
 playerinfo.eyriedynasties.summary=Em um momento de fraqueza, os Marqueses tomaram o poder. Agora, você reuniu forças e está pronto para recapturar seu direito de nascença.
 playerinfo.eyriedynasty.title=Dinastia das Rapinas
 playerinfo.label.cardsinhand=Cartas na Mão
 playerinfo.label.warriors=Guerreiros Restantes
 playerinfo.marquise.Birdsong=Coloque uma madeira <sprite name="Wood"> em cada serraria <sprite name="CatSawmill">.
-playerinfo.marquise.daylight=1º: Produzir<br>2º: Realize até 3 ações<br><line-indent=15%>• Combater<br>• Marchar<br>• Recrutar<br>• Construir<br>• Sobrecarregar
+playerinfo.marquise.daylight=1º: Crie<br>2º: Realize até 3 ações<br><line-indent=15%>• Batalha<br>• Marcha<br>• Recrutamento<br>• Erguer<br>• Hora Extra
 playerinfo.marquise.evening=Compre uma carta (+1 carta para cada <sprite name="DrawCard"> obtido na trilha de recrutadores) e depois descarte até ter 5 cartas.
-playerinfo.marquisedecat.fieldhospital.description=Quando um guerreiro morrer, você pode gastar uma carta correspondente para devolvê-lo ao Forte.
+playerinfo.marquisedecat.fieldhospital.description=Quando um guerreiro morrer, você pode gastar uma carta correspondente para devolvê-lo à Torre da Guarda.
 playerinfo.marquisedecat.fieldhospital.title=Hospital de Campo
-playerinfo.marquisedecat.keep.description=Somente você pode colocar peças na clareira com o marcador de forte.
-playerinfo.marquisedecat.keep.title=O Forte
+playerinfo.marquisedecat.keep.description=Somente você pode colocar peças na clareira com o marcador de Torre da Guarda.
+playerinfo.marquisedecat.keep.title=A Torre da Guarda
 playerinfo.marquisedecat.recruiters.title=Recrutadores
 playerinfo.marquisedecat.recruiterstitle=Recrutadores
 playerinfo.marquisedecat.sawmills.title=Serrarias
@@ -419,73 +420,73 @@ playerinfo.marquisedecat.summary=Você conquistou a floresta. Agora precisa cons
 playerinfo.marquisedecat.title=Marqueses
 playerinfo.marquisedecat.workshops.title=Oficinas
 playerinfo.marquisedecat.workshopstitle=Oficinas
-playerinfo.mechmarq.Birdsong=1º: Revele uma carta de ordem<br><br>2º: Produza a carta de ordem por <style="vpone">1</style> se houver um item disponível.
+playerinfo.mechmarq.Birdsong=1º: Revele uma carta de ordem<br><br>2º: Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.
 playerinfo.mechmarq.blitz=<size=125%><b>Relâmpago</b></size><br>Depois de se mover, encontre a clareira que você governa de maior prioridade sem peças inimigas. Mova todos os guerreiros, exceto um, dessa clareira. Em seguida, combata na clareira de destino.
 playerinfo.mechmarq.challenging=<size=125%><b>Desafiador</b></size><br> - Sempre que você Recrutar, coloque também dois guerreiros na clareira ordenada de maior prioridade que você governa.
-playerinfo.mechmarq.daylight=Se a carta de ordens for uma carta de <sprite name="birdicon">, resolva a Fase de Dia Escalonada em vez disso.<br>1º: Batalha<br>Inicie uma batalha em cada clareira ordenada. O defensor será o jogador com mais peças na clareira de batalha ou, em caso de empate, aquele com mais <style="vptext">PV</style>.<br><br>2º: Recrutar<br>Coloque quatro guerreiros entre as clareiras ordenadas que você governa, distribuídos igualmente. Se você governar três dessas clareiras, coloque o quarto guerreiro na clareira de maior prioridade.<br><br>3º: Erguer<br>Coloque uma construção na clareira que você governa com mais guerreiros dos Marqueses. Coloque uma serraria se a carta de ordens for uma carta de <sprite name="ClearingFox">, uma oficina se for uma carta de <sprite name="ClearingRabbit"> ou um recrutador se for uma carta de <sprite name="ClearingMouse">.<br><br>4º: Mover<br>Mova todos os seus guerreiros, exceto três, de cada clareira ordenada para a clareira adjacente com mais peças inimigas.<br><br>5º: Expandir<br>Se você não colocou uma construção nesta rodada e tiver cinco ou menos construções no mapa, descarte a carta de ordens atual, compre e revele uma nova carta de ordens (mas não crie o item), e retorne ao início da Fase de Dia.
+playerinfo.mechmarq.daylight=Se a carta de ordens for uma carta de <sprite name="birdicon">, resolva a Fase de Dia Expandido em vez disso.<br>1º: Batalha<br>Inicie uma batalha em cada clareira ordenada. O defensor será o jogador com mais peças na clareira de batalha ou, em caso de empate, aquele com mais <style="vptext">PV</style>.<br><br>2º: Recrutar<br>Coloque quatro guerreiros entre as clareiras ordenadas que você governa, distribuídos igualmente. Se você governar três dessas clareiras, coloque o quarto guerreiro na clareira de maior prioridade.<br><br>3º: Erguer<br>Coloque uma construção na clareira que você governa com mais guerreiros dos Marqueses. Coloque uma serraria se a carta de ordens for uma carta de <sprite name="ClearingFox">, uma oficina se for uma carta de <sprite name="ClearingRabbit"> ou um recrutador se for uma carta de <sprite name="ClearingMouse">.<br><br>4º: Mover<br>Mova todos os seus guerreiros, exceto três, de cada clareira ordenada para a clareira adjacente com mais peças inimigas.<br><br>5º: Expandir<br>Se você não colocou uma construção nesta rodada e tiver cinco ou menos construções no mapa, descarte a carta de ordens atual, compre e revele uma nova carta de ordens (mas não crie o item), e retorne ao início da Fase de Dia.
 playerinfo.mechmarq.easy=<size=125%><b>Fácil</b></size><br> - Sempre que você Recrutar, em vez disso, coloque apenas dois guerreiros.
 playerinfo.mechmarq.escalateddaylight=1º: Batalha<br>Inicie uma batalha em cada clareira. Os critérios de desempate são os mesmos do combate no Dia padrão.<br><br>2º: Recrutamento<br>Coloque dois guerreiros em cada uma das duas clareiras de menor prioridade que você controla. Se você controlar apenas uma clareira, coloque todos os quatro guerreiros nela.<br><br>3º: Construir<br>Coloque uma construção do tipo com mais peças no mapa na clareira que você controla com mais guerreiros do Marquês. Em caso de empate, priorize serrarias, depois recrutadores e, por último, oficinas.<br><br>4º: Marcha<br>Mova todos, exceto três de seus guerreiros, de cada clareira para a clareira adjacente com mais peças inimigas. Em seguida, inicie uma batalha em cada clareira para onde se moveu.
-playerinfo.mechmarq.escalateddaylighttitle=Luz do Dia Escalonada
+playerinfo.mechmarq.escalateddaylighttitle=Dia Expandido
 playerinfo.mechmarq.evening=Receba os pontos de vitória indicados no espaço vazio mais à direita da sua trilha de construções ordenada. Se a carta de ordens for uma carta de pássaro, use a trilha que conceder mais pontos de vitória. (Diferente dos Marqueses, você não ganha pontos de vitória ao posicionar construções.)
 playerinfo.mechmarq.fortified=<size=125%><b>Fortificado</b></size><br>Suas construções precisam de dois golpes para serem removidas. Um único golpe em uma construção não tem efeito.
 playerinfo.mechmarq.hatesurp=Detesta Surpresas
 playerinfo.mechmarq.hatesurpdesc=Cartas de emboscada não podem ser jogadas contra bots.
-playerinfo.mechmarq.hospitals=<size=125%><b>Hospitais</b></size><br>No final de uma batalha como defensor, se dois ou mais guerreiros dos Marqueses foram removidos na batalha, coloque dois guerreiros na clareira com o marcador de torre da guarda.
-playerinfo.mechmarq.ironwill=<size=125%><b>Força de Vontade</b></size><br>Sempre que você Recrutar durante a Luz do Dia Escalonada, coloque o dobro de guerreiros.
+playerinfo.mechmarq.hospitals=<size=125%><b>Hospitais</b></size><br>No final de uma batalha como defensor, se dois ou mais guerreiros dos Marqueses foram removidos na batalha, coloque dois guerreiros na clareira com o marcador de Torre da Guarda.
+playerinfo.mechmarq.ironwill=<size=125%><b>Força de Vontade</b></size><br>Sempre que você Recrutar durante o Dia Expandido, coloque o dobro de guerreiros.
 playerinfo.mechmarq.manualdex=Pouca Destreza Manual
 playerinfo.mechmarq.manualdexdesc=Não tem mão. Se um humano fosse pegar uma carta de um bot, esse humano compra uma carta em vez disso. Se um humano fosse dar uma carta a um bot, ele marca 1 <style="vptext">PV</style> em vez disso.
 playerinfo.mechmarq.nametitle=Marquês Mecânico
-playerinfo.mechmarq.nightmare=<size=125%><b>Pesadelo</b></size><br> - Sempre que você Recrutar, coloque também dois guerreiros na clareira ordenada de maior prioridade que você governa. No fim da Noite, marque um ponto de vitória.
+playerinfo.mechmarq.nightmare=<size=125%><b>Pesadelo</b></size><br> - Sempre que você Recrutar, coloque também dois guerreiros na clareira ordenada de maior prioridade que você governa. No fim do Anoitecer, marque um ponto de vitória.
 playerinfo.mechmarq.normal=<size=125%><b>Normal</b></size><br> - Nada muda.
 playerinfo.order=Ordem
 playerinfo.traits=Características
 playerinfo.turnorder=Ordem de Turno
 playerinfo.vagabond.attackformat=Ataque: {0}
-playerinfo.vagabond.Birdsong=1º: Renove 3 itens + 2 itens para cada <sprite name="teapot"> que você tem.<br><br>2º: Deslize para uma clareira ou floresta sem custo.
-playerinfo.vagabond.daylight=• Realize ações usando itens.<br>• Resolva Missões.
-playerinfo.vagabond.evening=1º: Descanso Noturno - Se estiver em uma floresta, repare todos os itens.<br><br>2º: Compre uma carta (+1 carta para cada <sprite name="coinstack"> que você tem) e depois descarte até ter 5 cartas.<br><br>3º: Descarte itens até o limite da sua sacola (6 + 2 para cada <sprite name="bag"> que você tem).
-playerinfo.vagabond.eveningsrest=Descanso Noturno
-playerinfo.vagabond.eveningsrest.description=Se estiver em uma floresta durante a noite, repare todos os itens.
-playerinfo.vagabond.hostile.description=Marque 1 PV por peça hostil removida em combate.
+playerinfo.vagabond.Birdsong=1º: Reanime 3 itens + 2 itens para cada <sprite name="teapot"> que você tem.<br><br>2º: Deslize para uma clareira ou floresta sem custo.
+playerinfo.vagabond.daylight=• Realize ações usando itens.<br>• Resolva Tarefas.
+playerinfo.vagabond.evening=1º: Descanso ao Pôr do Sol - Se estiver em uma floresta, repare todos os itens.<br><br>2º: Compre uma carta (+1 carta para cada <sprite name="coinstack"> que você tem) e depois descarte até ter 5 cartas.<br><br>3º: Descarte itens até o limite da sua mochila (6 + 2 para cada <sprite name="bag"> que você tem).
+playerinfo.vagabond.eveningsrest=Descanso ao Pôr do Sol
+playerinfo.vagabond.eveningsrest.description=Se estiver em uma floresta durante o Anoitecer, repare todos os itens.
+playerinfo.vagabond.hostile.description=Pontue 1 PV por peça hostil removida em combate.
 playerinfo.vagabond.hostile.exhaust=Deve exaurir uma bota extra para entrar em clareiras Hostis.
 playerinfo.vagabond.hostile.title=Hostil
 playerinfo.vagabond.lonewanderer.description=Seu Peão não é um guerreiro, não pode ser removido do mapa e pode se mover sem governar uma clareira.
-playerinfo.vagabond.lonewanderer.title=Vagante Solitário
-playerinfo.vagabond.quests.title=Missões
-playerinfo.vagabond.refreshformat=Renovar: {0}
+playerinfo.vagabond.lonewanderer.title=Andarilho Solitário
+playerinfo.vagabond.quests.title=Tarefas
+playerinfo.vagabond.refreshformat=Reanimar: {0}
 playerinfo.vagabond.relationships.description=Ajude uma facção X vezes durante um turno para mover seu marcador de relação para a direita.
 playerinfo.vagabond.relationships.title=Relações
-playerinfo.vagabond.satchel.title=Sacola
+playerinfo.vagabond.satchel.title=Mochila
 playerinfo.vagabond.startingitems=Itens Iniciais
 playerinfo.vagabond.summary=Você vaga pela floresta, buscando garantir um lugar na nova sociedade que está se formando.
-playerinfo.vagabond.title=Vagabundo
+playerinfo.vagabond.title=Malandro
 playerinfo.vagabot.12thitem=12º Item
 playerinfo.vagabot.6thitem=6º Item
 playerinfo.vagabot.9thitem=9º Item
-playerinfo.vagabot.aid=Ajudar
+playerinfo.vagabot.aid=Ajuda
 playerinfo.vagabot.battle=Combate
 playerinfo.vagabot.battletrack=Trilha de Combate
-playerinfo.vagabot.Birdsong=<b>1º:</b> Revele uma carta de ordem.<br><br><b>2º:</b> Produza a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><br><b>3º:</b> Deslize<br>Se você tiver dois ou menos itens não danificados, mova-se para uma floresta adjacente aleatória e depois avance para a noite.
-playerinfo.vagabot.daylight=Realize as ações ordenadas em Ações da Luz do Dia.<br><br><b>Explorar</b><br>Mova-se para a ruína mais próxima, exaurindo um item por movimento, depois exaure um item para pegar um item dessa ruína.<br><br><b>Missão</b><br>Mova-se para a clareira mais próxima que corresponda à missão. Depois, exaure dois itens quaisquer para descartar a missão e marcar <style="vpone>1</style>.<br><br><b>Ajudar</b><br>Escolha o jogador na sua clareira com itens e menos <style="vptext">PVs</style> entre eles. Exaure o maior número possível de itens até o total de itens que ele tem, pegue essa quantidade de itens dele e marque essa quantidade de <style="vptext">PVs</style>. Em seguida, ele compra a mesma quantidade de cartas.<br><br><b>Combate</b><br>Mova-se para a clareira mais próxima com peças do inimigo com mais <style="vptext">PVs</style>, depois exaure um item para combater esse jogador. Marque <style="vpone>1</style> por guerreiro inimigo removido. Repita essa ação, exaurindo dois itens por combate extra, quantas vezes for possível.<br>Se o defensor alvo estiver em múltiplas clareiras a igual distância, mova-se para a clareira onde ele tem mais edifícios e marcadores e depois menos guerreiros.<br><br><b>Reparar</b><br>Se você tiver itens danificados, exaure um item para reparar um item danificado.<br><br><b>Especial</b><br>Exaure um item para usar a habilidade especial do seu personagem.
-playerinfo.vagabot.daylightactions=Ações da Luz do Dia
-playerinfo.vagabot.evening=<b>1º:</b> Se você tiver itens danificados, renove quatro itens não danificados. Se não tiver, renove seis itens.<br><br><b>2º:</b> Se você estiver em uma floresta, repare todos os itens. Caso contrário, repare um item.
+playerinfo.vagabot.Birdsong=<b>1º:</b> Revele uma carta de ordem.<br><br><b>2º:</b> Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><br><b>3º:</b> Deslize<br>Se você tiver dois ou menos itens não danificados, mova-se para uma floresta adjacente aleatória e depois avance para o Anoitecer.
+playerinfo.vagabot.daylight=Realize as ações ordenadas em Ações do Dia.<br><br><b>Explorar</b><br>Mova-se para a ruína mais próxima, exaurindo um item por movimento, depois exaura um item para pegar um item dessa ruína.<br><br><b>Tarefas</b><br>Mova-se para a clareira mais próxima que corresponda à tarefa. Depois, exaura dois itens quaisquer para descartar a tarefa e marcar <style="vpone>1</style>.<br><br><b>Ajuda</b><br>Escolha o jogador na sua clareira com itens e menos <style="vptext">PVs</style> entre eles. Exaura o maior número possível de itens até o total de itens que ele tem, pegue essa quantidade de itens dele e marque essa quantidade de <style="vptext">PVs</style>. Em seguida, ele compra a mesma quantidade de cartas.<br><br><b>Batalhar</b><br>Mova-se para a clareira mais próxima com peças do inimigo com mais <style="vptext">PVs</style>, depois exaura um item para combater esse jogador. Pontue <style="vpone>1</style> por guerreiro inimigo removido. Repita essa ação, exaurindo dois itens por combate extra, quantas vezes for possível.<br>Se o defensor alvo estiver em múltiplas clareiras a igual distância, mova-se para a clareira onde ele tem mais edifícios e marcadores e depois menos guerreiros.<br><br><b>Reparar</b><br>Se você tiver itens danificados, exaura um item para reparar um item danificado.<br><br><b>Ação Especial</b><br>Exaura um item para usar a habilidade especial do seu personagem.
+playerinfo.vagabot.daylightactions=Ações do Dia
+playerinfo.vagabot.evening=<b>1º:</b> Se você tiver itens danificados, reanime quatro itens não danificados. Se não tiver, reanime seis itens.<br><br><b>2º:</b> Se você estiver em uma floresta, repare todos os itens. Caso contrário, repare um item.
 playerinfo.vagabot.explore=Explorar
 playerinfo.vagabot.extra=Como atacante, cause um golpe extra.
-playerinfo.vagabot.items=Apenas o total de itens importa para o Vagabot.
+playerinfo.vagabot.items=Apenas o total de itens importa para o Automalandro.
 playerinfo.vagabot.maxhits=O máximo de golpes rolados começa em um.
 playerinfo.vagabot.maxthree=Máximo de golpes: três.
 playerinfo.vagabot.maxtwo=Máximo de golpes: dois.
-playerinfo.vagabot.quest=Missão
-playerinfo.vagabot.quest.title=Missão
+playerinfo.vagabot.quest=Tarefa
+playerinfo.vagabot.quest.title=Tarefa
 playerinfo.vagabot.repair=Reparar
 playerinfo.vagabot.special=Especial
 playerinfo.woodlandalliance.bases.title=Bases
 playerinfo.woodlandalliance.guerrillawar.description=Em combate como defensor, você usa o maior resultado e o atacante usa o menor.
-playerinfo.woodlandalliance.guerrillawar.title=Guerra de Guerrilha
+playerinfo.woodlandalliance.guerrillawar.title=Guerrilha
 playerinfo.woodlandalliance.officers.label=Oficiais
 playerinfo.woodlandalliance.outrage.description=Quando um inimigo encontrar ou destruir simpatia, ele deve adicionar uma carta correspondente à clareira aos seus apoiadores.
-playerinfo.woodlandalliance.outrage.exclaimation=Indignação!
-playerinfo.woodlandalliance.outrage.title=Indignação
+playerinfo.woodlandalliance.outrage.exclaimation=Ultraje!
+playerinfo.woodlandalliance.outrage.title=Ultraje
 playerinfo.woodlandalliance.removingbases.desc=Se uma base for removida do mapa, descarte todos os apoiadores correspondentes (incluindo pássaros) e remova metade dos oficiais (arredondado para cima). Se não houver bases restantes no mapa, descarte apoiadores até ter 5.
 playerinfo.woodlandalliance.removingbases.title=Remover Bases
 playerinfo.woodlandalliance.summary=Você tem a simpatia da população. Construa apoio e se levante para expulsar os opressores da floresta!
@@ -495,19 +496,19 @@ playerinfo.woodlandalliance.sympathy.placementlimits=<b>Limites de Colocação</
 playerinfo.woodlandalliance.sympathy.title=Trilha de Simpatia
 playerinfo.woodlandalliance.title=Aliança da Floresta
 playernames.guestdisplayname=Você
-playerui.craftedcards.label=Cartas Produzidas
+playerui.craftedcards.label=Cartas Criadas
 playerui.label.damage=Dano
 playerui.label.drawrate=Taxa de Compra
-playerui.label.refreshrate=Taxa de Renovar
-playmat.aid=Ajudar!
+playerui.label.refreshrate=Taxa de Reanimação
+playmat.aid=Ajuda!
 playmat.battledecree=Decreto de Combate!
 playmat.builddecree=Decreto de Construção!
 playmat.claimed=Reivindicado!
-playmat.daylabor=Trabalho Diário!
+playmat.daylabor=Dia de Trabalho!
 playmat.dominanceavailable=Carta de Dominação Disponível!
 playmat.explore=Explorar!
 playmat.fieldhospital=Hospital de Campo!
-playmat.hawksforhire=Falcões para Contratar!
+playmat.hawksforhire=Rapinas para Contratar!
 playmat.hideout=Esconderijo!
 playmat.leaderdeposed=Líder Deposto!
 playmat.liz.fearofthefaithful=Medo dos Fiéis
@@ -515,17 +516,18 @@ playmat.mobilize=Mobilizar!
 playmat.movedecree=Decreto de Movimento!
 playmat.newleader=Novo Líder!
 playmat.order=Ordem
-playmat.overwork=Sobrecarregar!
-playmat.questcomplete=Missão Completa!
+playmat.overwork=Hora Extra!
+playmat.questcomplete=Tarefa Completa!
 playmat.recruit=Recrutar!
 playmat.recruitdecree=Decreto de Recrutamento!
 playmat.repair=Reparar!
 playmat.repairX3=Reparar x3
 playmat.repairXNumber=Reparar x[number]
+playmat.selectcard.supporters=Apoiadores
 playmat.selectcard.lostsouls=Almas Perdidas
 playmat.steal=Roubar!
 playmat.stinger.hated=Odiado
-playmat.stinger.outcast=Exilado
+playmat.stinger.outcast=Pária
 playmat.strike=Golpear!
 playmat.train=Treinar!
 playonline.afterJoin=O jogo começa quando todos os jogadores tiverem entrado.
@@ -540,8 +542,8 @@ playonline.casual.joinqueue=Entrar na Fila
 playonline.casual.leavequeue=Sair da Fila
 playonline.casual.playersInQueue=Jogadores na Fila:
 playonline.casual.title=Assíncrono
-playonline.Clockworkplayer.label=Relógio
-playonline.clockworkplayer.label=Relógio
+playonline.Clockworkplayer.label=Autômato
+playonline.clockworkplayer.label=Autômato
 playonline.confirmresign=Tem certeza de que deseja desistir desta partida?
 playonline.continueGame=Continuar Online
 playonline.cpuplayer.label=IA
@@ -593,7 +595,7 @@ presents.screen.presents=Apresentam
 prompt.continuesaved.buttonnewgame=Novo Jogo
 prompt.continuesaved.desc=Você tem um jogo salvo em andamento. Gostaria de continuar esse jogo ou excluí-lo e iniciar um novo?
 prompt.continuesaved.title=Continuar Jogo
-prompt.coopdescription=Jogue em equipe contra oponentes mecânicos. Para vencer, os jogadores (e IA) devem cada um marcar 30 pontos de vitória antes que qualquer oponente mecânico marque 30 pontos de vitória. Cartas de Dominação são removidas.
+prompt.coopdescription=Jogue em equipe contra oponentes Autômatos. Para vencer, os jogadores (e IA) devem cada um marcar 30 pontos de vitória antes que qualquer oponente Autômato marque 30 pontos de vitória. Cartas de Dominação são removidas.
 prompt.expand=Expandir
 prompt.leaderboard.name.label=Nome
 prompt.leaderboard.rank.label=Classificação
@@ -601,24 +603,26 @@ prompt.leaderboard.score.label=Pontuação
 prompt.login.banned=Sua conta foi banida.
 prompt.minimize=Minimizar
 prompt.time.out.removed=Você foi removido deste jogo por exceder o tempo de turno por dois turnos seguidos.
-prompt.time.out.removed.setup=Você foi removido deste jogo por exceder o tempo de turno durante a configuração.
+prompt.time.out.removed.setup=Você foi removido deste jogo por exceder o tempo de turno durante a preparação.
 prompts.aid.automatedalliance=Ajudando a Aliança Autômata
 prompts.aid.electriceyrie=Ajudando as Rapinas Elétricas
-prompts.aid.eyriedynasties=Ajudando as Dinastias das Rapinas
-prompts.aid.lizardcult=Ajudando o Culto dos Lagartos
+prompts.aid.eyriedynasties=Ajudando a Dinastia das Rapinas
+prompts.aid.lizardcult=Ajudando os Lagartos Cultistas
 prompts.aid.marquisedecat=Ajudando os Marqueses
 prompts.aid.mechanicalmarquise=Ajudando o Marquês Mecânico
-prompts.aid.riverfolkcompany=Ajudando a Companhia do Rio
+prompts.aid.riverfolkcompany=Ajudando a Companhia Ribeirinha
 prompts.aid.woodlandalliance=Ajudando a Aliança da Floresta
 prompts.aid.SecondVagabond=Ajudando o Automalandro
 prompts.aid.Vagabond=Ajudando o Malandro
 prompts.aid.undergroundduchy=Ducado Subterrâneo
 prompts.aid.corvidconspiracy=Conspiração Corvídea
+prompts.aid.keepersiniron=Ajudando os Guardiões de Ferro
+prompts.aid.lordofthehundreds=Ajudando o Senhor das Centenas
 prompts.demolanding.playgame=Jogar Partida
 prompts.demolanding.tutorial1=Tutorial 1 - O Básico
 prompts.demolanding.tutorial2=Tutorial 2 - Os Marqueses
 prompts.eyriedynasties.move.label=Mover
-prompts.eyriescoreroosts.label={0} Poleiros
+prompts.eyriescoreroosts.label={0} Ninhos
 prompts.gameresults.coalitionwinner=Vitória por Coalizão
 prompts.gameresults.cooperativewinner=Vitória Cooperativa
 prompts.gameresults.nowinner=Desistiu
@@ -627,11 +631,13 @@ prompts.gameresults.tutorialcomplete=Tutorial Concluído
 prompts.gameresults.winner.automatedalliance=Aliança Autômata Venceu
 prompts.gameresults.winner.electriceyrie=Rapinas Elétricas Venceram
 prompts.gameresults.winner.eyriedynasties=Rapinas Venceram
-prompts.gameresults.winner.marquisedecat=Marqueses Venceu
+prompts.gameresults.winner.marquisedecat=Marqueses Venceram
 prompts.gameresults.winner.mechanicalmarquise=Marquês Mecânico Venceu
 prompts.gameresults.winner.vagabond=Malandro Venceu
 prompts.gameresults.winner.vagabot=Automalandro Venceu
 prompts.gameresults.winner.woodlandalliance=Aliança Venceu
+prompts.gameresults.winner.lordofthehundreds=Centenas Venceram
+prompts.gameresults.winner.keepersiniron=Guardiões Venceram
 prompts.loginfailure.eulanotaccepted=Por favor, aceite o EULA para fazer login.
 prompts.marquisebuild.recruiter=Recrutador
 prompts.marquisebuild.sawmill=Serraria
@@ -641,7 +647,7 @@ prompts.movenumber.displayformat={0}/{1}
 prompts.passtoplayer.ai.text=Turno de {0}
 prompts.passtoplayer.text=Passe para {0}
 prompts.playerturn.yourturn=Sua Vez
-prompts.quests.title=Missões Disponíveis
+prompts.quests.title=Tarefas Disponíveis
 prompts.relentless.title=Implacável
 prompts.revolt.title=Revolta
 prompts.selectfaction.title=Selecione uma Facção
@@ -649,10 +655,10 @@ prompts.shop.availableitems=Itens Criáveis
 prompts.shop.claim=Reivindicar
 prompts.shop.dominance=Dominação Disponível
 prompts.shop.title=Suprimento
-prompts.turmoil.faileddecree.battle=Não foi possível <nobr><size=150%><sprite name="EyrieBattle"></size> combater</nobr> em uma <nobr><size=150%><sprite name="{0}"></size> clareira</nobr>
-prompts.turmoil.faileddecree.build=Não foi possível <nobr><size=150%><sprite name="EyrieBuild"></size> construir</nobr> em uma <nobr><size=150%><sprite name="{0}"></size> clareira</nobr>
-prompts.turmoil.faileddecree.move=Não foi possível <nobr><size=150%><sprite name="EyrieMove"></size> mover</nobr> de uma <nobr><size=150%><sprite name="{0}"></size> clareira</nobr>
-prompts.turmoil.faileddecree.recruit=Não foi possível <nobr><size=150%><sprite name="EyrieRecruit"></size> recrutar</nobr> em uma <nobr><size=150%><sprite name="{0}"></size> clareira</nobr>
+prompts.turmoil.faileddecree.battle=Não foi possível <nobr><size=150%><sprite name="EyrieBattle"></size> combater</nobr> em uma clareira de <nobr><size=150%><sprite name="{0}"></size></nobr>
+prompts.turmoil.faileddecree.build=Não foi possível <nobr><size=150%><sprite name="EyrieBuild"></size> construir</nobr> em uma clareira de  <nobr><size=150%><sprite name="{0}"></size></nobr>
+prompts.turmoil.faileddecree.move=Não foi possível <nobr><size=150%><sprite name="EyrieMove"></size> mover</nobr> de uma clareira de  <nobr><size=150%><sprite name="{0}"></size></nobr>
+prompts.turmoil.faileddecree.recruit=Não foi possível <nobr><size=150%><sprite name="EyrieRecruit"></size> recrutar</nobr> em uma clareira de <nobr><size=150%><sprite name="{0}"></size></nobr>
 prompts.turmoil.title=As Rapinas entraram em
 prompts.turmoil.title2=Tumulto
 prompts.turmoil.vpgained.label=ganhou
@@ -662,9 +668,9 @@ prompts.vagabonditems.damageallies=Aliados Danificados
 prompttitles.generic.success=Sucesso
 quitapplication.confirm.message=Tem certeza de que deseja sair?
 rankedselect.errors.connectfailed=Sua conexão expirou. Verifique sua conexão com a internet e tente novamente.
-root.vagabot.ranger=Guarda
+root.vagabot.ranger=Andarilho
 root.vagabot.thief=Ladrão
-root.vagabot.tinker=Artífice
+root.vagabot.tinker=Funileiro
 savedgames.continueGames=Continuar Jogos
 savedgames.description=Você não tem jogos ativos.
 savedgames.joinGame=Entrar no Jogo
@@ -676,7 +682,7 @@ select.card.cancel=Pular
 select.card.confirm=OK
 select.card.description=Selecione uma carta.
 set.expansion.base=Jogo Base
-set.expansion.riverfolk=Expansão Companhia do Rio
+set.expansion.riverfolk=Expansão Ribeirinhos
 set.expansion.vagabond=Expansão do Malandro
 setting.undobutton=Permitir Desfazer
 settings.about=Sobre
@@ -686,6 +692,8 @@ settings.android.uiscale.0=Pequena
 settings.android.uiscale.1=Grande
 settings.audio.effectsvolume=Volume dos Efeitos
 settings.audio.musicvolume=Volume da Música
+settings.audio.mastervolume=Volume Principal
+settings.audio.ambiencevolume=Volume Ambiente
 settings.audio.muteMusic=Silenciar Música
 settings.audio.muteSound=Silenciar Som
 settings.audio.title=Áudio
@@ -729,7 +737,7 @@ shop.featured=Destaques
 shop.noitems=Itens em breve!
 shop.purchase=Comprar
 shop.purchased=Comprado
-singleplayer.difficulty.heroic=Heroico
+singleplayer.difficulty.heroic=Heróico
 singleplayer.difficulty.label=Dificuldade: {0}
 singleplayer.difficulty.legendary=Lendário
 singleplayer.difficulty.normal=Normal
@@ -747,7 +755,7 @@ steam.initialize.genericerror=Steam não encontrado
 tax.message=Preço Inclui Impostos
 their.turn.indicator=Turno deles
 title.subtitle=Um jogo de Poder e Direito na Floresta da Madeira
-tooltip.deck.EnP=Baralho Exilados & Partidários
+tooltip.deck.EnP=Baralho Exilados & Partisans
 tooltip.deck.standard=Baralho Padrão
 turn.indicator=Turno de {0}
 turn.lastRound=Última Rodada
@@ -757,13 +765,13 @@ tutorial.goals.title=Objetivos
 tutorial.title=Bem-vindo!
 undochoiceentity.button=Desfazer
 unlockedCardsDialog.Ok=OK
-vagabond.title.vagabond_ranger=Guardabosques Vagabundo
-vagabond.title.vagabond_thief=Ladrão Vagabundo
-vagabond.title.vagabond_tinker=Artífice Vagabundo
+vagabond.title.vagabond_ranger=Malandro Andarilho
+vagabond.title.vagabond_thief=Malandro Ladrão
+vagabond.title.vagabond_tinker=Malandro Funileiro
 vagabondWithColor=<color=#436979>Vagabundo</color>
-Vagabot.Challenging=<b>Desafiador:</b> Na Noite, o Automalandro renova um item a mais.
-Vagabot.Easy=<b>Fácil:</b> Na Noite, o Automalandro renova um item a menos.
-Vagabot.Nightmare=<b>Pesadelo:</b> Na Noite, o Automalandro renova um item a mais e marca um ponto de vitória.
+Vagabot.Challenging=<b>Desafiador:</b> No Anoitecer, o Automalandro reanima um item a mais.
+Vagabot.Easy=<b>Fácil:</b> No Anoitecer, o Automalandro reanima um item a menos.
+Vagabot.Nightmare=<b>Pesadelo:</b> No Anoitecer, o Automalandro reanima um item a mais e marca um ponto de vitória.
 vagabotWithColor=<color=#436979>Automalandro</color>
 view.results=Ver Resultados
 waitingforplayers.aidifficulty.label=Dificuldade da IA: {0}
@@ -774,7 +782,7 @@ waitingforplayers.password.label=Protegido por Senha
 waitingforplayers.timer.label=Limite de tempo de turno: {0}
 woodlandWithColor=<color=#008D3F>Aliança da Floresta</color>
 your.turn.indicator=Sua Vez
-playerinfo.keepersiniron.retinue.title=Reunir Seguidores
+playerinfo.keepersiniron.retinue.title=Receba o Séquito
 playerinfo.keepersiniron.retinue.move=Mover
 playerinfo.keepersiniron.retinue.move.desc=...de uma clareira correspondente
 playerinfo.keepersiniron.retinue.battledelve=Combater e Explorar
@@ -783,63 +791,87 @@ playerinfo.keepersiniron.retinue.moverecover=Mover ou Recuperar
 playerinfo.keepersiniron.retinue.moverecover.desc=...de uma clareira correspondente
 loading.fastforward=Pulando replay...
 button.skipreplay=Pular Replay
-playerinfo.liz.Birdsong=1º: Ajuste o Exilado. <br><br>2º: Descarte Almas Perdidas. <br><br> 3º: Execute Conspirações<size=90%> <i>em Clareiras Exiladas.</I><br><br><style=RB>Cruzada:</style> Gaste dois acólitos para combater em uma clareira Exilada ou mover-se de uma clareira Exilada e depois, se desejar, combater na clareira de destino. <br><br><style=RB>Converter:</style> Gaste dois acólitos para remover um guerreiro inimigo de uma clareira Exilada e depois colocar um guerreiro lá. <br><br><style=RB>Santificar:</style> Gaste três acólitos para remover um edifício inimigo de uma clareira Exilada e depois colocar um jardim lá.
-playerinfo.liz.daylight=Revele qualquer número de cartas da sua mão e execute um ritual para cada uma. <br><br><sprite index=75>Construir<br>Coloque um jardim em uma clareira correspondente que você governa. <br><br><sprite index=75>Recrutar<br>Coloque um guerreiro em uma clareira correspondente.<br><br><sprite index=75>Marcar Pontos<br>Descarte esta carta para marcar <style="vptext">PVs</style> do espaço vazio mais à direita, correspondente, na trilha de Jardins.<br><br><sprite index=73>Sacrificar<br>Coloque um guerreiro na caixa de Acólitos.
-playerinfo.liz.evening=1º: Retorne as cartas reveladas à mão.<br><br>2º: Produza usando jardins que correspondam ao naipe do Exilado. <br><br>3º: Compre 1 carta para cada <sprite index=31> exibido.<br><br>Descarte até ter 5 cartas.
-factionnames.lizardcult=O Culto dos Lagartos
+prompts.loot.automatedalliance=Saqueando a Aliança Automatizada
+prompts.loot.electriceyrie=Saqueando as Rapinas Elétricas
+prompts.loot.eyriedynasties=Saqueando a Dinastia das Rapinas
+prompts.loot.lizardcult=Saqueando os Lagartos Cultistas
+prompts.loot.marquisedecat=Saqueando os Marqueses
+prompts.loot.mechanicalmarquise=Saqueando o Marquês Mecânico
+prompts.loot.riverfolkcompany=Saqueando a Companhia Ribeirinha
+prompts.loot.woodlandalliance=Saqueando a Aliança da Floresta
+prompts.loot.SecondVagabond=Saqueando Outro Malandro
+prompts.loot.Vagabond=Saqueando o Malandro
+prompts.loot.undergroundduchy=Saqueando o Ducado Subterrâneo
+prompts.loot.corvidconspiracy=Saqueando a Conspiração Corvídea
+prompts.loot.keepersiniron=Saqueando os Guardiões de Ferro
+prompts.loot.lordofthehundreds=Saqueando o Senhor das Centenas
+shortfactionnames.AutomatedAlliance=Aliança
+shortfactionnames.ElectricEyrie=Rapinas
+shortfactionnames.eyriedynasties=Rapinas
+shortfactionnames.invalid=Facção Aleatória
+shortfactionnames.marquisedecat=Marqueses
+shortfactionnames.MechanicalMarquise=Marqueses
+shortfactionnames.SecondVagabond=Malandro
+shortfactionnames.vagabond=Malandro
+shortfactionnames.Vagabot=Automalandro
+shortfactionnames.woodlandalliance=Aliança
+playerinfo.liz.Birdsong=1º: Ajuste o Pária. <br><br>2º: Descarte as Almas Perdidas. <br><br> 3º: Realize Conspirações<size=90%> <i>em Clareiras Párias.</I><br><br><style=RB>Cruzada:</style> Gaste dois acólitos para combater em uma clareira Pária ou mover-se de uma clareira Pária e depois, se desejar, combater na clareira de destino. <br><br><style=RB>Conversão:</style> Gaste dois acólitos para remover um guerreiro inimigo de uma clareira Pária e depois colocar um guerreiro lá. <br><br><style=RB>Santificação:</style> Gaste três acólitos para remover um edifício inimigo de uma clareira Pária e depois colocar um jardim lá.
+playerinfo.liz.daylight=Revele qualquer número de cartas da sua mão e execute um ritual para cada uma. <br><br><sprite index=75>Construir<br>Coloque um jardim em uma clareira correspondente que você governa. <br><br><sprite index=75>Recrutar<br>Coloque um guerreiro em uma clareira correspondente.<br><br><sprite index=75>Pontuar<br>Descarte esta carta para marcar <style="vptext">PVs</style> do espaço vazio mais à direita, correspondente, na trilha de Jardins.<br><br><sprite index=73>Sacrificar<br>Coloque um guerreiro na caixa de Acólitos.
+playerinfo.liz.evening=1º: Retorne as cartas reveladas à mão.<br><br>2º: Crie usando jardins que correspondam ao naipe do Pária. <br><br>3º: Compre 1 carta para cada <sprite index=31> exibido.<br><br>Descarte até ter 5 cartas.
+factionnames.lizardcult=Lagartos Cultistas
 playerinfo.lizardcult.revenge.title=Vingança
 playerinfo.lizardcult.revenge.description=Seus guerreiros defensores removidos se tornam acólitos.
 playerinfo.lizardcult.conquest.title=Conquista
 playerinfo.lizardcult.conquest.description=Ao atacar, os guerreiros inimigos que você remover em combate se tornam acólitos.
 playerinfo.lizardcult.hatredofbirds.title=Ódio aos Pássaros
 playerinfo.lizardcult.hatredofbirds.description=Cartas de pássaro não são coringas para seus rituais.
-playerinfo.lizardcult.pilgrims.title=Peregrinos
+playerinfo.lizardcult.pilgrims.title=Peregrino
 playerinfo.lizardcult.pilgrims.description=Você governa qualquer clareira onde tenha jardins.
-playerinfo.lizardcult.theoutcast.title=O Exilado
+playerinfo.lizardcult.theoutcast.title=O Pária
 playerinfo.lizardcult.gardens.title=Jardins
-tooltip.lizardcult.theoutcast.description=Durante o Amanhecer, o naipe mais comum entre as Almas Perdidas, ignorando pássaros, torna-se Exilado. Se já for Exilado, mude para Exilado Odiado.<br><br><i>Se o naipe Exilado for Odiado, todas as conspirações custam um acólito a menos.
+tooltip.lizardcult.theoutcast.description=Durante o Amanhecer, o naipe mais comum entre as Almas Perdidas, ignorando pássaros, torna-se Pária. Se já for Pária, mude para Odiado.<br><br><i>Se o naipe do Pária for Odiado, todas as conspirações custam um acólito a menos.
 playerinfo.riverfolkcompany.services.title=Serviços
 playerinfo.riverfolkcompany.handcard.title=Carta na Mão
-playerinfo.riverfolkcompany.riverboats.title=Barcos do Rio
+playerinfo.riverfolkcompany.riverboats.title=Botes
 playerinfo.riverfolkcompany.mercenaries.title=Mercenários
-playerinfo.riverfolkcompany.commitments.title=Compromissos
+playerinfo.riverfolkcompany.commitments.title=Comprometidos
 playerinfo.riverfolkcompany.funds.title=Fundos
 playerinfo.riverfolkcompany.payments.title=Pagamentos
 playerinfo.riverfolkcompany.forsale.title=À Venda
 playerinfo.riverfolkcompany.forsale.description=Você tem uma mão pública.
 playerinfo.riverfolkcompany.swimmers.title=Nadadores
 playerinfo.riverfolkcompany.swimmers.description=Você trata rios como caminhos e pode se mover ao longo dos rios, independentemente de quem governa.
-playerinfo.riverfolkcompany.tradingpost.removed=Posto Comercial Removido: Este posto comercial foi removido do mapa, mas ainda pode ser usado para produzir itens.
-playerinfo.riverfolkcompany.Birdsong=1º: Protecionismo - Se a caixa de Pagamentos estiver vazia, coloque dois guerreiros nela.<br><br>2º: Marcar Dividendos - Se houver postos comerciais no mapa, marque um ponto de vitória por cada dois fundos. (Você não marca pontos por guerreiros nas caixas de Pagamentos ou Compromissos.)<br><br>3º: Reunir Fundos - Mova todos os guerreiros do seu tabuleiro de facção para a caixa de Fundos.
+playerinfo.riverfolkcompany.tradingpost.removed=Entreposto Comercial Removido: Este posto comercial foi removido do mapa, mas ainda pode ser usado para criar itens.
+playerinfo.riverfolkcompany.Birdsong=1º: Protecionismo - Se a caixa de Pagamentos estiver vazia, coloque dois guerreiros nela.<br><br>2º: Dividendos - Se houver entrepostos comerciais no mapa, marque um ponto de vitória por cada dois fundos. (Você não marca pontos por guerreiros nas caixas de Pagamentos ou Comprometidos.)<br><br>3º: Angariando Fundos - Mova todos os guerreiros do seu tabuleiro de facção para a caixa de Fundos.
 playerinfo.riverfolkcompany.daylight=Comprometa ou gaste fundos para realizar ações<br>
-<sprite index=76>Estabelecer Posto Comercial com Guarnição
-playerinfo.riverfolkcompany.evening=1º: Descarte até ter 5 cartas.<br><br>2º: Defina os Custos de Serviço.
-prompt.riverfolkcompany.hand.title=Mão da Companhia do Rio
+<sprite index=76>Estabeleça um Entreposto Comercial com Guarnição
+playerinfo.riverfolkcompany.evening=1º: Descarte até ter 5 cartas.<br><br>2º: Ajuste os preços dos Serviços.
+prompt.riverfolkcompany.hand.title=Mão da Companhia Ribeirinha
 prompts.buyservices.description=Empreste guerreiros do seu suprimento para comprar serviços.
-prompts.buyservices.vagabond.description=Exaure itens para comprar serviços.
+prompts.buyservices.vagabond.description=Exaura itens para comprar serviços.
 prompts.riverfolkscoredividends.label=Marcando Dividendos
-tooltip.playmat.tradepost=<size=125%><b>Posto Comercial da Companhia do Rio</b></size><br>• Contribui com o naipe dessa clareira para a produção de itens.<br>• Inimigos nessa clareira podem comprar um serviço adicional.<br>• Você não pode marcar dividendos sem ao menos um posto comercial no mapa.<br>• Quando um posto comercial é removido, perca metade dos seus fundos, arredondado para cima.<br>• Cada clareira só pode ter um posto comercial.
-tooltip.playmat.otterstack=<size=125%><b>Guerreiros da Companhia do Rio</b></size>
-tooltip.ui.riverfolk.publichand=Veja a mão do jogador da Companhia do Rio.
-tooltip.ui.riverfolk.craftingslots=<size=125%><b>Peças de Produção Disponíveis</b></size>
-tooltip.ability.riverfolk.battle=<size=125%><b>Combater</b></size>\nComprometa um fundo para combater.
-tooltip.ability.riverfolk.craft=<size=125%><b>Produzir</b></size>\nComprometa fundos usando postos comerciais para produzir itens.
-tooltip.ability.riverfolk.export=<size=125%><b>Exportar</b></size>\nComprometa fundos usando postos comerciais para produzir itens. Em vez de ganhar o efeito da carta, descarte-a e adicione um guerreiro à sua caixa de pagamentos.
-tooltip.ability.riverfolk.draw=<size=125%><b>Comprar Carta</b></size>\nComprometa um fundo para comprar uma carta.
+tooltip.playmat.tradepost=<size=125%><b>Entreposto Comercial da Companhia Ribeirinha</b></size><br>• Contribui com o naipe dessa clareira para a criação de itens.<br>• Inimigos nessa clareira podem comprar um serviço adicional.<br>• Você não pode marcar dividendos sem ao menos um entreposto comercial no mapa.<br>• Quando um entreposto comercial é removido, perca metade dos seus fundos, arredondado para cima.<br>• Cada clareira só pode ter um entreposto comercial.
+tooltip.playmat.otterstack=<size=125%><b>Guerreiros da Companhia Ribeirinha</b></size>
+tooltip.ui.riverfolk.publichand=Veja a mão do jogador da Companhia Ribeirinha.
+tooltip.ui.riverfolk.craftingslots=<size=125%><b>Peças de Criação Disponíveis</b></size>
+tooltip.ability.riverfolk.battle=<size=125%><b>Batalhar</b></size>\nComprometa um fundo para batalhar.
+tooltip.ability.riverfolk.craft=<size=125%><b>Criar</b></size>\nComprometa fundos usando entrepostos comerciais para criar itens.
+tooltip.ability.riverfolk.export=<size=125%><b>Exportar</b></size>\nComprometa fundos usando postos comerciais para criar itens. Em vez de ganhar o efeito da carta, descarte-a e adicione um guerreiro à sua caixa de pagamentos.
+tooltip.ability.riverfolk.draw=<size=125%><b>Comprar</b></size>\nComprometa um fundo para comprar uma carta.
 tooltip.ability.riverfolk.move=<size=125%><b>Mover</b></size>\nComprometa um fundo para mover.
 tooltip.ability.riverfolk.recruit=<size=125%><b>Recrutar</b></size>\nGaste um fundo para colocar um guerreiro em uma clareira com um rio.
-tooltip.ability.riverfolk.establishtradepost=<size=125%><b>Estabelecer Posto Comercial</b></size>\nGaste 2 fundos do governante de uma clareira para colocar um posto comercial correspondente e um guerreiro lá. Essa clareira não pode já ter um posto comercial.
-tooltip.ui.riverfolk.services=No início do Amanhecer, outros jogadores podem comprar 1 serviço, mais 1 por clareira com um posto comercial e qualquer peça deles.
-tooltip.ui.riverfolk.handcard=<size=125%><b>Carta na Mão</b></size><br>O comprador pega qualquer carta da mão da Companhia do Rio e a adiciona à sua mão.
-tooltip.ui.riverfolk.riverboats=<size=125%><b>Barcos do Rio</b></size><br>O comprador trata os rios como caminhos até o final do turno.
-tooltip.ui.riverfolk.mercenaries=<size=125%><b>Mercenários</b></size><br>Durante a Luz do Dia e a Noite deste turno, o comprador trata os guerreiros da Companhia do Rio como se fossem seus, apenas para governar e para combater facções que não sejam a Companhia do Rio. O comprador deve dividir igualmente os golpes sofridos entre suas peças e os guerreiros da Companhia do Rio, ficando com os golpes ímpares.
-tooltip.ui.riverfolk.commitments=<size=125%><b>Compromissos</b></size>\nGuerreiros que foram comprometidos para o turno. Retornam como fundos durante o Amanhecer.
-tooltip.ui.riverfolk.funds=<size=125%><b>Fundos</b></size>\nPara realizar muitas ações, a Companhia do Rio compromete e gasta fundos representados por guerreiros na sua caixa de Fundos.
+tooltip.ability.riverfolk.establishtradepost=<size=125%><b>Estabeleça um Entreposto Comercial com Guarnição</b></size>\nGaste 2 fundos do governante de uma clareira para colocar um entreposto comercial correspondente e um guerreiro lá. Essa clareira não pode já ter um entreposto comercial.
+tooltip.ui.riverfolk.services=No início do Amanhecer, outros jogadores podem comprar 1 serviço, mais 1 por clareira com um entreposto comercial e qualquer peça deles.
+tooltip.ui.riverfolk.handcard=<size=125%><b>Cartas da Mão</b></size><br>O comprador pega qualquer carta da mão da Companhia Ribeirinha e a adiciona à sua mão.
+tooltip.ui.riverfolk.riverboats=<size=125%><b>Botes</b></size><br>O comprador trata os rios como caminhos até o final do turno.
+tooltip.ui.riverfolk.mercenaries=<size=125%><b>Mercenários</b></size><br>Durante o Dia e o Anoitecer deste turno, o comprador trata os guerreiros da Companhia Ribeirinha como se fossem seus, apenas para governar e para combater facções que não sejam a Companhia Ribeirinha. O comprador deve dividir igualmente os golpes sofridos entre suas peças e os guerreiros da Companhia Ribeirinha, ficando com os golpes ímpares.
+tooltip.ui.riverfolk.commitments=<size=125%><b>Comprometidos</b></size>\nGuerreiros que foram comprometidos para o turno. Retornam como fundos durante o Amanhecer.
+tooltip.ui.riverfolk.funds=<size=125%><b>Fundos</b></size>\nPara realizar muitas ações, a Companhia Ribeirinha compromete e gasta fundos representados por guerreiros na sua caixa de Fundos.
 tooltip.ui.riverfolk.payments=<size=125%><b>Pagamentos</b></size>\nGuerreiros são colocados aqui para pagar por serviços. Movidos para fundos durante o Amanhecer.
-tooltip.ui.riverfolk.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nA Companhia do Rio compra cartas adicionais ao comprometer Fundos.
-tooltip.ui.riverfolk.warriorcount=<size=125%><b>Guerreiros em Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não pode recrutar guerreiros.
-tooltip.ui.riverfolk.crafteditems=<size=125%><b>Itens Produzidos</b></size>\nO Malandro pode trocar cartas para pegar esses itens. A Companhia do Rio produz itens usando Postos Comerciais.
-tooltip.ui.riverfolk.tradeposts=<size=125%><b>Postos Comerciais</b></size>\nConstruir postos comerciais concede 2 pontos de vitória e permite que inimigos na mesma clareira comprem um serviço adicional. Você não pode marcar dividendos sem ao menos um posto comercial no mapa. Quando um posto comercial é removido, perca metade dos seus fundos, arredondado para cima. Postos comerciais removidos do mapa não retornam ao seu suprimento. Cada clareira só pode ter um posto comercial.
+tooltip.ui.riverfolk.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nA Companhia Ribeirinha compra cartas adicionais ao comprometer Fundos.
+tooltip.ui.riverfolk.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros na reserva, ele não pode recrutar guerreiros.
+tooltip.ui.riverfolk.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas para pegar esses itens. A Companhia Ribeirinha produz itens usando Entrepostos Comerciais.
+tooltip.ui.riverfolk.tradeposts=<size=125%><b>Entrepostos Comerciais</b></size>\nConstruir entrepostos comerciais concede 2 pontos de vitória e permite que inimigos na mesma clareira comprem um serviço adicional. Você não pode marcar dividendos sem ao menos um entreposto comercial no mapa. Quando um entreposto comercial é removido, perca metade dos seus fundos, arredondado para cima. Entrepostos comerciais removidos do mapa não retornam ao seu suprimento. Cada clareira só pode ter um entreposto comercial.
 settings.skins.title=Skins
 settings.controls.title=Controles
 settings.controls.lefttrigger=Aproximar : <sprite name="Switch_LeftTrigger">
@@ -848,14 +880,16 @@ settings.controls.minus=Registro de Ações : <sprite name="Switch_Minus">
 settings.controls.leftstick=Mover entre seleções : <sprite name="Switch_LeftStickButton">
 settings.controls.dpad=Mesmo que Left Stick : <sprite name="Switch_DPad">
 settings.controls.capture=Capturar : <sprite name="Switch_Capture">
-settings.controls.home=Switch Home : <sprite name="Switch_Home">
+settings.controls.home=<font="F_bdy_BaskervilleTenPro">H</font><smallcaps>ome</smallcaps>  Button : <sprite name="Switch_Home">
 settings.controls.righttrigger=<sprite name="Switch_RightTrigger"> : Afastar
 settings.controls.rightbumper=<sprite name="Switch_RightBumper"> : Suprimento
 settings.controls.plus=<sprite name="Switch_Plus"> : Configurações
 settings.controls.action1=<sprite name="Switch_Action1"> : Selecionar/ Confirmar
 settings.controls.action2=<sprite name="Switch_Action2"> : Cancelar/ Desfazer
 settings.controls.action3=<sprite name="Switch_Action3"> : Dica/ Expandir Carta
+settings.controls.action3.xbox=<sprite name="Switch_Action3"> : Finalizar Turno/ Pular/ Finalizar Fase
 settings.controls.action4=<sprite name="Switch_Action4"> : Finalizar Turno/ Pular/ Finalizar Fase
+settings.controls.action4.xbox=<sprite name="Switch_Action4"> : Dicas/ Expandir Carta
 settings.controls.rightstick=<sprite name="Switch_RightStickButton"> : Mover Mapa
 settings.controls.lefttrigger.xbox=Aproximar : <sprite name="Xbox_LeftTrigger">
 settings.controls.leftbumper.xbox=Info da Facção : <sprite name="Xbox_LeftBumper">
@@ -867,92 +901,92 @@ settings.gen.title=Geral
 playerinfo.used.title=Usado
 settings.gameplay.title=Jogabilidade
 button.commit=Comprometer
-RFT.Thematic.Intro=<color=#397F7F>A Companhia do Rio</color> montou seu comércio no grande rio que atravessa a floresta. Conforme as outras facções compram <color=#397F7F>serviços</color>, a <color=#397F7F>Companhia do Rio</color> poderá financiar novos postos comerciais pela floresta. A construção desses postos é uma maneira viável de marcar pontos de vitória, mas também são os dividendos obtidos ao acumular riquezas.
+RFT.Thematic.Intro=<color=#397F7F>A Companhia Ribeirinha</color> montou seu comércio no grande rio que atravessa a floresta. Conforme as outras facções compram <color=#397F7F>serviços</color>, a <color=#397F7F>Companhia Ribeirinha</color> poderá financiar novos entrepostos comerciais pela floresta. A construção desses entrepostos é uma maneira viável de marcar pontos de vitória, mas também são os dividendos obtidos ao acumular riquezas.
 RFT.character.intro=Ora, aí está, camarada. Deixe-me lavar as mãos rapidamente, elas cheiram a mariscos.
-RFT.set.up=Enquanto isso, cuide da configuração para mim e coloque 4 <color=#397F7F>guerreiros</color> em clareiras ao longo do rio.
+RFT.set.up=Enquanto isso, cuide da preparação para mim e coloque 4 <color=#397F7F>guerreiros</color> em clareiras ao longo do rio.
 RFT.services.1=Temos os melhores <color=#397F7F>serviços</color> da região!
 RFT.services.2=No início do Amanhecer, seus oponentes podem comprar <color=#397F7F>serviços</color> pegando guerreiros do suprimento deles e adicionando-os à sua área de <color=#397F7F>pagamentos</color>.
 RFT.services.3=Esses <color=#397F7F>pagamentos</color> se tornam os <color=#397F7F>fundos</color> que determinam as ações que você pode realizar no seu turno.
-rft.set.price=Durante a configuração e cada Noite, você define os preços dos <color=#397F7F>serviços</color>. Vamos jogar pesado e definir todos a 3.
+rft.set.price=Durante a preparação e cada Anoitecer, você define os preços dos <color=#397F7F>serviços</color>. Vamos jogar pesado e definir todos a 3.
 rft.bs.intro.funds=Nossos preços de <color=#397F7F>serviços</color> estavam tão altos que não tivemos nenhum comprador. No entanto, em cada partida começamos com três <color=#397F7F>pagamentos</color> representados por ícones de guerreiros.
-rft.gather.funds=Durante o Amanhecer, você move todos os <color=#397F7F>pagamentos</color> para os seus <color=#397F7F>fundos</color> para gastar em ações durante a Luz do Dia.
-rft.basic.funds=Você pode se mover, combater e comprar cartas ao comprometer <color=#397F7F>fundos</color>. Esses <color=#397F7F>fundos</color> vão para sua área de <color=#397F7F>compromissos</color> e não estarão disponíveis para gastar novamente até o seu próximo turno.
+rft.gather.funds=Durante o Amanhecer, você move todos os <color=#397F7F>pagamentos</color> para os seus <color=#397F7F>fundos</color> para gastar em ações durante o Dia.
+rft.basic.funds=Você pode se mover, combater e comprar cartas ao comprometer <color=#397F7F>fundos</color>. Esses <color=#397F7F>fundos</color> vão para sua área de <color=#397F7F>comprometidos</color> e não estarão disponíveis para gastar novamente até o seu próximo turno.
 rft.basic.battle=Comprometa um <color=#397F7F>fundo</color> para iniciar uma batalha contra os Marqueses na clareira <sprite name="ClearingRabbit"> que você controla, antes que eles recrutem mais guerreiros.
 rft.battle.2=Muito bem. Você é mais brigão do que eu esperava!
 rft.battle.enemy=Você realmente teve coragem de atacar os Marqueses? Que ousadia!
 rft.recruit=Agora recrute na clareira em que você combateu para substituir o <color=#397F7F>guerreiro</color> que perdemos em combate.
-rft.recruit.2=Recrutar é caro. <color=#397F7F>Fundos</color> usados para Recrutar vão para o seu suprimento em vez dos compromissos. Isso significa que eles não retornarão aos seus <color=#397F7F>fundos</color> no turno seguinte.
+rft.recruit.2=Recrutar é caro. <color=#397F7F>Fundos</color> usados para Recrutar vão para o seu suprimento em vez dos comprometidos. Isso significa que eles não retornarão aos seus <color=#397F7F>fundos</color> no turno seguinte.
 rft.draw=Diferente de muitas outras facções, você não compra cartas no final do turno. Para comprar cartas, você deve comprometer um <color=#397F7F>fundo</color> e usar a ação de comprar carta.
-rft.set.cost=Durante a Noite, você pode alterar os preços dos seus <color=#397F7F>serviços</color>. Vamos fazer uma promoção! Reduza o custo de <color=#397F7F>barcos do rio</color> para 1 e os outros <color=#397F7F>serviços</color> para 2.
+rft.set.cost=Durante o Anoitecer, você pode alterar os preços dos seus <color=#397F7F>serviços</color>. Vamos fazer uma promoção! Reduza o custo de <color=#397F7F>botes</color> para 1 e os outros <color=#397F7F>serviços</color> para 2.
 rtf.marquise.hand.card=Esses produtos assados que você está oferecendo parecem deliciosos!
 rtf.marquise.hand.card.2=Bolo de marisco de novo? Com licença enquanto eu engasgo com uma bola de pelo...
-rft.lizard.riverboats=Seus <color=#397F7F>barcos do rio</color> serão muito úteis para o culto. Bênçãos do escamoso para você.
+rft.lizard.riverboats=Seus <color=#397F7F>botes</color> serão muito úteis para o culto. Bênçãos do escamoso para você.
 rft.enemy.funds=Nossa promoção foi um sucesso! Temos uma boa variedade de fundos para usar em nossas ações neste turno.
-rft.trade.post=Você pode gastar 2 <color=#397F7F>fundos</color> correspondentes à facção do governante de uma clareira para colocar um <sprite name="TradePost"><color=#397F7F>posto comercial</color> e um <color=#397F7F>guerreiro</color> lá (desde que essa clareira ainda não tenha um <color=#397F7F>posto comercial</color>).
-rft.trade.post.2=Quando você coloca um posto comercial, marca <style="vpnum">2</style>. <sprite name="TradePost"><color=#397F7F>Postos comerciais</color> são usados para produzir, permitem que você marque dividendos e possibilitam que outros jogadores comprem mais <color=#397F7F>serviços</color> de você.
-rtf.craft=Cada <sprite name="TradePost"><color=#397F7F>posto comercial</color> que você constrói também contribui com seu naipe para produzir cartas.
-rtf.fund.choice=Você deve comprometer um <color=#397F7F>fundo</color> para cada <sprite name="TradePost"><color=#397F7F>posto comercial</color> usado durante a produção. Você pode escolher qual tipo de facção gastar. Selecione uma delas.
-RFT.Swimmers=Nós, da Companhia do Rio, somos ótimos nadadores. Tratamos os rios como caminhos durante o movimento e ignoramos a restrição do governante ao atravessar os rios.
-rtf.trade.post.protect=Vamos mover 2 <color=#397F7F>guerreiros</color> pelo rio até nosso <sprite name="TradePost"><color=#397F7F>posto comercial</color> para protegê-lo.
+rft.trade.post=Você pode gastar 2 <color=#397F7F>fundos</color> correspondentes à facção do governante de uma clareira para colocar um <sprite name="TradePost"><color=#397F7F>entreposto comercial</color> e um <color=#397F7F>guerreiro</color> lá (desde que essa clareira ainda não tenha um <color=#397F7F>entreposto comercial</color>).
+rft.trade.post.2=Quando você coloca um entreposto comercial, marca <style="vpnum">2</style>. <sprite name="TradePost"><color=#397F7F>Entrepostos comerciais</color> são usados para criar, permitem que você receba dividendos e possibilitam que outros jogadores comprem mais <color=#397F7F>serviços</color> de você.
+rtf.craft=Cada <sprite name="TradePost"><color=#397F7F>entreposto comercial</color> que você constrói também contribui com seu naipe para criar cartas.
+rtf.fund.choice=Você deve comprometer um <color=#397F7F>fundo</color> para cada <sprite name="TradePost"><color=#397F7F>entreposto comercial</color> usado durante a criação. Você pode escolher qual tipo de facção gastar. Selecione uma delas.
+RFT.Swimmers=Nós, da Companhia Ribeirinha, somos ótimos nadadores. Tratamos os rios como caminhos durante o movimento e ignoramos a restrição do governante ao atravessar os rios.
+rtf.trade.post.protect=Vamos mover 2 <color=#397F7F>guerreiros</color> pelo rio até nosso <sprite name="TradePost"><color=#397F7F>entreposto comercial</color> para protegê-lo.
 rtf.battle.workshop=Aquela oficina dos Marqueses está vulnerável. Ataque!
 rft.marquise.traitor=De comerciante a traidor, entendi. Você pagará por isso, escória do rio!
 rft.set.service.t2=Vamos deixar os custos dos nossos <color=#397F7F>serviços</color> como estão por enquanto. Se não está quebrado, não conserte!
-rtf.t3.enemy.service=Cada inimigo pode comprar um <color=#397F7F>serviço</color> seu por turno, mais um <color=#397F7F>serviço</color> adicional por cada clareira com um <sprite name="TradePost"><color=#397F7F>posto comercial</color> e uma de suas peças.
+rtf.t3.enemy.service=Cada inimigo pode comprar um <color=#397F7F>serviço</color> seu por turno, mais um <color=#397F7F>serviço</color> adicional por cada clareira com um <sprite name="TradePost"><color=#397F7F>entreposto comercial</color> e uma de suas peças.
 rtf.t3.mercenaries.split=O comprador dos seus mercenários deve dividir as baixas igualmente entre suas peças e seus guerreiros contratados, ficando com os golpes ímpares.
-rtf.alt.craft=Nós, <color=#397F7F>da Companhia do Rio</color>, somos artesãos inovadores. Em vez de resolver o efeito de uma carta produzida, podemos adicionar um guerreiro ao nosso <color=#397F7F>pagamento</color>. Use o botão <color=#397F7F>Exportar</color> para produzir com essa recompensa.
-rtf.t3.recruit=Cada vez que um <color=#397F7F>posto comercial</color> é destruído, perdemos metade dos nossos <color=#397F7F>fundos</color> (arredondado para cima). Vamos recrutar outro <color=#397F7F>guerreiro</color> para garantir que nossos <sprite name="TradePost"><color=#397F7F>postos comerciais</color> estejam bem protegidos.
-rtf.t3.dividends=Durante nosso Amanhecer, marcamos dividendos enquanto tivermos um <sprite name="TradePost"><color=#397F7F>posto comercial</color> no mapa. Dividendos marcam <style="vpone">1</style> para cada 2 <color=#397F7F>fundos</color> que não usamos no turno anterior. Passe o turno para economizar <color=#397F7F>fundos</color> para dividendos.
+rtf.alt.craft=Nós, <color=#397F7F>da Companhia Ribeirinha</color>, somos artesãos inovadores. Em vez de resolver o efeito de uma carta criada, podemos adicionar um guerreiro ao nosso <color=#397F7F>pagamento</color>. Use o botão <color=#397F7F>Exportar</color> para criar com essa recompensa.
+rtf.t3.recruit=Cada vez que um <color=#397F7F>entreposto comercial</color> é destruído, perdemos metade dos nossos <color=#397F7F>fundos</color> (arredondado para cima). Vamos recrutar outro <color=#397F7F>guerreiro</color> para garantir que nossos <sprite name="TradePost"><color=#397F7F>entrepostos comerciais</color> estejam bem protegidos.
+rtf.t3.dividends=Durante nosso Amanhecer, marcamos dividendos enquanto tivermos um <sprite name="TradePost"><color=#397F7F>entreposto comercial</color> no mapa. Dividendos marcam <style="vpone">1</style> para cada 2 <color=#397F7F>fundos</color> que não usamos no turno anterior. Passe o turno para economizar <color=#397F7F>fundos</color> para dividendos.
 rff.t3.set.service=Você tem um bom instinto para comércio. Vá em frente e defina os <color=#397F7F>serviços</color> como preferir.
 rft.bs.protectionism=Parece que não recebemos nenhum pagamento nesta rodada. Não importa, você move dois guerreiros do seu suprimento para pagamentos como prêmio de consolação.
-rft.off.rails=Estabeleça outro <sprite name="TradePost"><color=#397F7F>posto comercial</color> e marque <style="vpnumddteen">15</style> para provar que nós, <color=#397F7F>da Companhia do Rio</color>, somos mais do que simples mercadores.
-rft.goal.vp=Marque <style="vpnumddteen">15</style> ({0}/{1})
-rft.goal.tradepost=Construa mais um <sprite name="TradePost"><color=#397F7F>Posto Comercial</color>.
-FTT.Riverfolk.removed.TP=Postos Comerciais destruídos não retornam ao seu suprimento e continuam a fornecer sua habilidade de produção, mesmo que não estejam mais no mapa.
-lct.intro=O <color=#748421>Culto dos Lagartos</color> deseja espalhar nosso evangelho pela floresta. Você deve buscar <color=#748421>exilados</color> e <color=#748421>acólitos</color> para cruzar espadas por sua causa e defender seu santuário. Mas sua luta não é apenas com dentes e garras. Cuidar dos seus <sprite name="Garden"><color=#748421>Jardins</color> revela um caminho para a vitória por meio de rituais misteriosos.
+rft.off.rails=Estabeleça outro <sprite name="TradePost"><color=#397F7F>entreposto comercial</color> e marque <style="vpnumddteen">15</style> para provar que nós, <color=#397F7F>da Companhia Ribeirinha</color>, somos mais do que simples mercadores.
+rft.goal.vp=Pontue <style="vpnumddteen">15</style> ({0}/{1})
+rft.goal.tradepost=Construa mais um <sprite name="TradePost"><color=#397F7F>Entreposto Comercial</color>.
+FTT.Riverfolk.removed.TP=Postos Comerciais destruídos não retornam ao seu suprimento e continuam a fornecer sua habilidade de criação, mesmo que não estejam mais no mapa.
+lct.intro=Os <color=#748421>Lagartos Cultistas</color> desejam espalhar o evangelho pela floresta. Você deve buscar <color=#748421>párias</color> e <color=#748421>acólitos</color> para cruzar espadas por sua causa e defender seu santuário. Mas sua luta não é apenas com dentes e garras. Cuidar dos seus <sprite name="Garden"><color=#748421>Jardins</color> revela um caminho para a vitória por meio de rituais misteriosos.
 lct.place.warriors=Você começa o jogo com 4 humildes <color=#748421>guerreiros</color> e uma construção <sprite name="Garden"><color=#748421>Jardim</color> na clareira do canto oposto à Torre da Guarda dos Marqueses.
 lct.adjacent.warriors=Além disso, você coloca um guerreiro em cada clareira adjacente ao seu <sprite name="Garden"><color=#748421>Jardim</color> inicial.
-lct.explain.reveal=Durante a Luz do Dia, você realiza ações de <color=#748421>ritual</color> revelando cartas da sua mão.
+lct.explain.reveal=Durante o Dia, você realiza ações de <color=#748421>ritual</color> revelando cartas da sua mão.
 lct.recruit.intro=Usando o ritual <color=#748421>Recrutar</color>, você pode revelar uma carta da sua mão para recrutar um guerreiro em uma clareira correspondente ao seu naipe.
 lct.reveal.icon=As cartas reveladas são movidas para a área <sprite name="eyeicon"> e não podem ser usadas novamente para rituais até o próximo turno.
 lct.first.build=Vamos tentar outro <color=#748421>ritual</color> usando uma carta diferente da nossa mão. Use o ritual <color=#748421>Construir</color> para revelar uma carta <sprite name="mouseicon"> e colocar um <sprite name="Garden"><color=#748421>Jardim</color> em uma clareira correspondente que você governa.
 lct.pilgrims=Você automaticamente governa qualquer clareira onde tenha um <sprite name="Garden"><color=#748421>Jardim</color>. Até mesmo os descrentes ficam maravilhados com suas propriedades divinas.
-lct.garden=Os <sprite name="Garden"><color=#748421>Jardins</color> podem ser usados para marcar pontos com o ritual <color=#748421>Marcar Pontos</color>. Toque no seu avatar para saber mais sobre os <sprite name="Garden"><color=#748421>Jardins</color>.
-lct.garden.gamepad=Os <sprite name="Garden"><color=#748421>Jardins</color> podem ser usados para marcar pontos com o ritual <color=#748421>Marcar Pontos</color>. Pressione <sprite name="Switch_LeftBumper"> para saber mais sobre os <sprite name="Garden"><color=#748421>Jardins</color>.
-lct.garden.track=Quanto mais <sprite name="Garden"><color=#748421>Jardins</color> você tiver no mapa de um naipe, mais pontos marcará ao usar o ritual <color=#748421>Marcar Pontos</color>.
-lct.garden.draw=Você revela um <sprite name="DrawCard"> quando tem dois <sprite name="Garden"><color=#748421>Jardins</color> do mesmo naipe no mapa. Isso aumenta o número de cartas que você compra durante a Noite.
-lct.score=Use o ritual <color=#748421>Marcar Pontos</color> para descartar uma carta <sprite name="mouseicon"> e ganhar <style="vpnum">2</style>. Esse é um ritual único e poderoso que exige que você descarte a carta usada em vez de revelá-la.
-lct.score.2=Você pode realizar o ritual <color=#748421>Marcar Pontos</color> apenas uma vez por naipe em cada turno.
+lct.garden=Os <sprite name="Garden"><color=#748421>Jardins</color> podem ser usados para marcar pontos com o ritual <color=#748421>Pontuar</color>. Toque no seu avatar para saber mais sobre os <sprite name="Garden"><color=#748421>Jardins</color>.
+lct.garden.gamepad=Os <sprite name="Garden"><color=#748421>Jardins</color> podem ser usados para marcar pontos com o ritual <color=#748421>Pontuar</color>. Pressione <sprite name="Switch_LeftBumper"> para saber mais sobre os <sprite name="Garden"><color=#748421>Jardins</color>.
+lct.garden.track=Quanto mais <sprite name="Garden"><color=#748421>Jardins</color> você tiver no mapa de um naipe, mais pontos marcará ao usar o ritual <color=#748421>Pontuar</color>.
+lct.garden.draw=Você revela um <sprite name="DrawCard"> quando tem dois <sprite name="Garden"><color=#748421>Jardins</color> do mesmo naipe no mapa. Isso aumenta o número de cartas que você compra durante o Anoitecer.
+lct.score=Use o ritual <color=#748421>Pontuar</color> para descartar uma carta <sprite name="mouseicon"> e ganhar <style="vpnum">2</style>. Esse é um ritual único e poderoso que exige que você descarte a carta usada em vez de revelá-la.
+lct.score.2=Você pode realizar o ritual <color=#748421>Pontuar</color> apenas uma vez por naipe em cada turno.
 lct.return=As cartas reveladas para rituais agora são devolvidas à sua mão.
 lct.strategy=Gerenciar cuidadosamente os naipes na sua mão é essencial para o sucesso do culto.
 lct.marquise.dialog.attack=Hora de mandar esses fanáticos de volta à idade da pedra! En garde!
 lct.revenge=Esses hereges bigodudos deram um golpe nos nossos guerreiros. Felizmente, nossa habilidade <color=#748421>Vingança</color> nos permite transformar os guerreiros defensores caídos em <color=#748421>acólitos</color>.
-lct.pick.outcast=O <color=#748421>Exilado</color> determina os naipes de clareira com os quais você pode interagir usando seus <color=#748421>acólitos</color>. Escolher <sprite name="mouseicon"> permitirá que você declare guerra a inimigos em clareiras <sprite name="mouseicon"> neste turno.
-lct.pick.outcast.2=Em um jogo típico, você escolherá o naipe inicial do <color=#748421>Exilado</color> durante a configuração, mas o culto faz exceções para verdadeiros crentes como você.
-lct.intro.conspiracy=Agora que temos um <color=#748421>Exilado</color> e acólitos suficientes, podemos realizar <color=#748421>conspirações</color> durante o Amanhecer. As <color=#748421>Conspirações</color> são um conjunto de ações focadas em conflitos, que usam <color=#748421>acólitos</color> em vez de cartas da mão.
-lct.crusade=Gaste dois <color=#748421>acólitos</color> para usar a Conspiração <color=#748421>Cruzada</color>. Isso permitirá mover 2 guerreiros de uma clareira correspondente ao naipe do <color=#748421>Exilado</color> para combater em uma clareira adjacente.
+lct.pick.outcast=O <color=#748421>Pária</color> determina os naipes de clareira com os quais você pode interagir usando seus <color=#748421>acólitos</color>. Escolher <sprite name="mouseicon"> permitirá que você declare guerra a inimigos em clareiras <sprite name="mouseicon"> neste turno.
+lct.pick.outcast.2=Em um jogo típico, você escolherá o naipe inicial do <color=#748421>Pária</color> durante a preparação, mas o culto faz exceções para verdadeiros crentes como você.
+lct.intro.conspiracy=Agora que temos um <color=#748421>Pária</color> e acólitos suficientes, podemos realizar <color=#748421>conspirações</color> durante o Amanhecer. As <color=#748421>Conspirações</color> são um conjunto de ações focadas em conflitos, que usam <color=#748421>acólitos</color> em vez de cartas da mão.
+lct.crusade=Gaste dois <color=#748421>acólitos</color> para usar a Conspiração <color=#748421>Cruzada</color>. Isso permitirá mover 2 guerreiros de uma clareira correspondente ao naipe do <color=#748421>Pária</color> para combater em uma clareira adjacente.
 lct.t2.marquise=Esses malucos de novo? Um punhado de aço deve mostrar quem manda!
 lct.flavor.battle=Que esta pira ardente de serragem agrade aos deuses.
-lct.hatred.birds=Devido ao seu <color=#748421>Ódio aos Pássaros</color>, suas cartas <sprite name="birdicon"> não podem ser usadas como qualquer naipe para realizar rituais. Em vez disso, elas são usadas para um ritual único chamado <color=#748421>Sacrifício</color>.
-lct.intro.sacrifice=Revele cartas <sprite name="birdicon"> para o ritual <color=#748421>Sacrifício</color> e transforme guerreiros do seu suprimento em mais <color=#748421>Acólitos</color>, que podem ser usados para <color=#748421>Conspirações</color>.
+lct.hatred.birds=Devido ao seu <color=#748421>Ódio aos Pássaros</color>, suas cartas <sprite name="birdicon"> não podem ser usadas como qualquer naipe para realizar rituais. Em vez disso, elas são usadas para um ritual único chamado <color=#748421>Sacrificar</color>.
+lct.intro.sacrifice=Revele cartas <sprite name="birdicon"> para o ritual <color=#748421>Sacrificar</color> e transforme guerreiros do seu suprimento em mais <color=#748421>Acólitos</color>, que podem ser usados para <color=#748421>Conspirações</color>.
 lct.t2.ritual=Nossos rituais oferecem flexibilidade sobre onde recrutar e construir no mapa. Vamos <color=#748421>Recrutar</color> para uma nova área do mapa agora.
 lct.t2.craft=Revele uma <sprite name="rabbiticon"> para adicionar um <sprite name="Garden"><color=#748421>Jardim</color> na clareira onde você destruiu a serraria do inimigo.
-lct.t2.craft.2=Os <sprite name="Garden"><color=#748421>Jardins</color> que correspondem ao naipe do exilado contribuem para a produção durante a noite. Use o poder de produção deles para marcar Chá de Root.
-lct.lost.souls=Cartas usadas e descartadas por todos os jogadores vão para a pilha de <color=#748421>Almas Perdidas</color>, em vez de irem para a pilha de descarte. O naipe mais comum dessas <color=#748421>Almas Perdidas</color> determinará o naipe do <color=#748421>Exilado</color> no início do seu turno.
-lct.enemy.lost.souls=Cartas inimigas também vão para a pilha de <color=#748421>Almas Perdidas</color>. Cuidado, até mesmo um plano cuidadoso para controlar o naipe do <color=#748421>Exilado</color> pode ser frustrado por oponentes espertos.
-lct.t3.outcast=No início do seu turno, o naipe mais comum na pilha de <color=#748421>Almas Perdidas</color> (ignorando <sprite name="birdicon">) determina o novo <color=#748421>Exilado</color>. Em seguida, a pilha de <color=#748421>Almas Perdidas</color> é enviada para a pilha de descarte.
-lct.t3.outcast.2=Como <sprite name="rabbiticon"> foi o naipe mais comum, ele se torna o novo Exilado.
-lct.t3.crusade.battle=Há mais de uma maneira de realizar uma <color=#748421>Cruzada</color>. Em vez de mover de uma clareira do <color=#748421>Exilado</color> e combater em uma clareira vizinha, você também pode combater diretamente na clareira do <color=#748421>Exilado</color>. Faça isso agora para proteger seu <sprite name="Garden"><color=#748421>Jardim</color>.
+lct.t2.craft.2=Os <sprite name="Garden"><color=#748421>Jardins</color> que correspondem ao naipe do pária contribuem para a criação durante o Anoitecer. Use o poder de criação deles para pontuar Chá de Raízes.
+lct.lost.souls=Cartas usadas e descartadas por todos os jogadores vão para a pilha de <color=#748421>Almas Perdidas</color>, em vez de irem para a pilha de descarte. O naipe mais comum dessas <color=#748421>Almas Perdidas</color> determinará o naipe do <color=#748421>Pária</color> no início do seu turno.
+lct.enemy.lost.souls=Cartas inimigas também vão para a pilha de <color=#748421>Almas Perdidas</color>. Cuidado, até mesmo um plano cuidadoso para controlar o naipe do <color=#748421>Pária</color> pode ser frustrado por oponentes espertos.
+lct.t3.outcast=No início do seu turno, o naipe mais comum na pilha de <color=#748421>Almas Perdidas</color> (ignorando <sprite name="birdicon">) determina o novo <color=#748421>Pária</color>. Em seguida, a pilha de <color=#748421>Almas Perdidas</color> é enviada para a pilha de descarte.
+lct.t3.outcast.2=Como <sprite name="rabbiticon"> foi o naipe mais comum, ele se torna o novo Pária.
+lct.t3.crusade.battle=Há mais de uma maneira de realizar uma <color=#748421>Cruzada</color>. Em vez de mover de uma clareira do <color=#748421>Pária</color> e combater em uma clareira vizinha, você também pode combater diretamente na clareira do <color=#748421>Pária</color>. Faça isso agora para proteger seu <sprite name="Garden"><color=#748421>Jardim</color>.
 lct.t3.crusade.battle.2=Sucesso. No entanto, você perdeu um guerreiro na batalha. Lembre-se de que apenas <color=#748421>guerreiros</color> perdidos em batalhas em que você era o DEFENSOR buscam vingança ao se tornarem <color=#748421>acólitos</color>.
-lct.t3.sacrifice=Use a ação <color=#748421>Sacrifício</color> três vezes para ganhar mais <color=#748421>acólitos</color>.
+lct.t3.sacrifice=Use a ação <color=#748421>Sacrificar</color> três vezes para ganhar mais <color=#748421>acólitos</color>.
 lct.t3.recruit=Use a ação <color=#748421>Recrutar</color> para colocar outro <color=#748421>guerreiro</color> perto dos seus <sprite name="Garden"><color=#748421>Jardins</color>.
 lct.t3.recruit.2=Finalmente, vamos <color=#748421>Recrutar</color> novamente para estabelecer governo na clareira <sprite name="rabbiticon"> próxima aos seus <sprite name="Garden"><color=#748421>Jardins</color>.
-lct.t3.discard=Você tem muitas cartas na mão. Descartar duas cartas de coelho ajudará a garantir que o <color=#748421>Exilado</color> se torne o <color=#748421>Exilado Odiado</color>.
+lct.t3.discard=Você tem muitas cartas na mão. Descartar duas cartas de coelho ajudará a garantir que o <color=#748421>Pária</color> se torne <color=#748421>Odiado</color>.
 lct.t3.discard.2=Ser odiado parece ruim, você diz? Não, não... os justos são frequentemente incompreendidos. Paciência, amigo, você verá.
-lct.t4.hated.outcast=Conforme previsto, o naipe mais comum na pilha de Almas Perdidas é o mesmo que o naipe do atual <color=#748421>Exilado</color>. Quando isso acontece, o <color=#748421>Exilado</color> se torna o <color=#748421>Exilado Odiado</color>, reduzindo o custo das suas <color=#748421>conspirações</color> em 1!
-lct.t4.convert=O <color=#748421>Culto dos Lagartos</color> recebe novos membros de braços abertos. Use a conspiração <color=#748421>Converter</color> para substituir um guerreiro inimigo em uma clareira do <color=#748421>Exilado</color> por um dos nossos.
-lct.t4.sanctify=Devemos purificar não apenas almas, mas também monumentos falsos. Use <color=#748421>Santificar</color> para substituir um edifício inimigo por um <sprite name="Garden"><color=#748421>Jardim</color>.
-lct.t4.off.rails=Seu conhecimento do nosso texto sagrado está quase completo. Marque <style="vpnumddteen">12</style> para provar sua lealdade eterna ao <color=#748421>Culto dos Lagartos</color>.
-lct.goal.12vp=Marque <style="vpnumddteen">12</style> ({0}/{1})
+lct.t4.hated.outcast=Conforme previsto, o naipe mais comum na pilha de Almas Perdidas é o mesmo que o naipe do atual <color=#748421>Pária</color>. Quando isso acontece, o <color=#748421>Pária</color> se torna o <color=#748421>Odiado</color>, reduzindo o custo das suas <color=#748421>conspirações</color> em 1!
+lct.t4.convert=Os <color=#748421>Lagartos Cultistas</color> recebem novos membros de braços abertos. Use a conspiração <color=#748421>Conversão</color> para substituir um guerreiro inimigo em uma clareira do <color=#748421>Pária</color> por um dos nossos.
+lct.t4.sanctify=Devemos purificar não apenas almas, mas também monumentos falsos. Use <color=#748421>Santificação</color> para substituir um edifício inimigo por um <sprite name="Garden"><color=#748421>Jardim</color>.
+lct.t4.off.rails=Seu conhecimento do nosso texto sagrado está quase completo. Pontue <style="vpnumddteen">12</style> para provar sua lealdade eterna aos <color=#748421>Lagartos Cultistas</color>.
+lct.goal.12vp=Pontue <style="vpnumddteen">12</style> ({0}/{1})
 lct.ftt.garden.removed=Quando um <color=#748421>jardim</color> é removido, ele retorna para sua trilha de jardins, muitas vezes reduzindo os pontos de vitória marcados por rituais. Além disso, você perde uma carta aleatória da mão. Proteja o <sprite name="Garden"><color=#748421>Jardim</color> a todo custo.
 scenario.garden.tier1description=Você não pode vencer a menos que tenha 5 jardins no mapa de um mesmo naipe.
 scenario.garden.tier2description=Você não pode vencer a menos que tenha pelo menos 3 jardins no mapa de cada naipe.
@@ -960,50 +994,50 @@ scenario.conquest.tier1description=Sua habilidade Vingança é substituída por 
 scenario.conquest.tier2description=Sua habilidade Vingança é substituída por Conquista: Ao atacar, os guerreiros inimigos que você remover em batalha se tornam Acólitos. Os oponentes começam com <style="vpnum">5</style>.
 scenario.restlesssouls.tier1description=No início do seu turno, troque sua mão com a pilha de Almas Perdidas (Máximo de 7. Pulado no primeiro turno).
 scenario.restlesssouls.tier2description=No início do seu turno, troque sua mão com a pilha de Almas Perdidas (Máximo de 7. Pulado no primeiro turno).
-scenario.fishing.tier1description=No início de cada um dos seus turnos, peixes aparecem nos rios. Ao se mover por um caminho de rio com um peixe, ele se torna uma peça de produção em seu naipe até o final do turno.
-scenario.fishing.tier2description=No início de cada um dos seus turnos, peixes aparecem nos rios. Ao se mover por um caminho de rio com um peixe, ele se torna uma peça de produção em seu naipe até o final do turno. Os inimigos começam com <style="vpnum">3</style>.
-scenario.angry.tier1description=Guerreiros inimigos derrotados são adicionados aos seus compromissos. Os inimigos não comprarão seus serviços. Você começa o jogo com Táticas Brutais em jogo.
-scenario.angry.tier2description=Guerreiros inimigos derrotados são adicionados aos seus compromissos. Os inimigos não comprarão seus serviços e começam com <style="vpnum">3</style>.
-scenario.shippingempire.tier1description=Você não pode marcar pontos de vitória. Você vence imediatamente ao ter um posto comercial em cada clareira de rio.
+scenario.fishing.tier1description=No início de cada um dos seus turnos, peixes aparecem nos rios. Ao se mover por um caminho de rio com um peixe, ele se torna uma peça de criação em seu naipe até o final do turno.
+scenario.fishing.tier2description=No início de cada um dos seus turnos, peixes aparecem nos rios. Ao se mover por um caminho de rio com um peixe, ele se torna uma peça de criação em seu naipe até o final do turno. Os inimigos começam com <style="vpnum">3</style>.
+scenario.angry.tier1description=Guerreiros inimigos derrotados são adicionados aos seus comprometidos. Os inimigos não comprarão seus serviços. Você começa o jogo com Táticas Brutais em jogo.
+scenario.angry.tier2description=Guerreiros inimigos derrotados são adicionados aos seus comprometidos. Os inimigos não comprarão seus serviços e começam com <style="vpnum">3</style>.
+scenario.shippingempire.tier1description=Você não pode marcar pontos de vitória. Você vence imediatamente ao ter um entreposto comercial em cada clareira de rio.
 tuber.canis.actions.RiverfolkCompanyActions.RiverfolkCompanySetup.ChooseStartingWarriorLocations=Escolha clareiras de rio para seus 4 guerreiros iniciais.
-tuber.canis.actions.RiverfolkCompanyActions.RiverfolkCompanySetup.ChooseStartingWarriorLocations.opponent=A Companhia do Rio está escolhendo clareiras de rio para seus guerreiros iniciais.
+tuber.canis.actions.RiverfolkCompanyActions.RiverfolkCompanySetup.ChooseStartingWarriorLocations.opponent=A Companhia Ribeirinha está escolhendo clareiras de rio para seus guerreiros iniciais.
 tuber.canis.actions.RiverfolkCompanyActions.SetRiverfolkServicePrices=Defina os preços de serviço até seu próximo turno.
-tuber.canis.actions.RiverfolkCompanyActions.SetRiverfolkServicePrices.opponent=A Companhia do Rio está definindo preços de serviço.
-tuber.canis.undo.riverfolkCompanySetupUndo=Pressione o botão continuar para completar a configuração.
-tuber.canis.undo.riverfolkCompanySetupUndo.opponent=Aguardando a Companhia do Rio confirmar a configuração.
-tuber.canis.actions.RiverfolkCompanyActions.RiverfolkTradePostDestroyed.ChooseFundsToLose=Escolha os fundos a serem perdidos pelo posto comercial removido.
-tuber.canis.actions.RiverfolkCompanyActions.RiverfolkTradePostDestroyed.ChooseFundsToLose.opponent=Aguardando a Companhia do Rio remover fundos pelo posto comercial removido.
+tuber.canis.actions.RiverfolkCompanyActions.SetRiverfolkServicePrices.opponent=A Companhia Ribeirinha está definindo preços de serviço.
+tuber.canis.undo.riverfolkCompanySetupUndo=Pressione o botão continuar para completar a preparação.
+tuber.canis.undo.riverfolkCompanySetupUndo.opponent=Aguardando a Companhia Ribeirinha confirmar a preparação.
+tuber.canis.actions.RiverfolkCompanyActions.RiverfolkTradePostDestroyed.ChooseFundsToLose=Escolha os fundos a serem perdidos pelo entreposto comercial removido.
+tuber.canis.actions.RiverfolkCompanyActions.RiverfolkTradePostDestroyed.ChooseFundsToLose.opponent=Aguardando a Companhia Ribeirinha remover fundos pelo entreposto comercial removido.
 tuber.canis.actions.RiverfolkCompanyActions.DaylightChoice=Escolha uma ação.
-tuber.canis.actions.RiverfolkCompanyActions.DaylightChoice.opponent=A Companhia do Rio está ponderando a próxima ação.
-tuber.canis.actions.RiverfolkCompanyActions.BuyRiverfolkServices=Escolha quaisquer serviços da Companhia do Rio para comprar.
-tuber.canis.actions.RiverfolkCompanyActions.BuyRiverfolkServices.opponent=[jogador] está considerando serviços da Companhia do Rio.
-tuber.canis.actions.RiverfolkCompanyActions.ChooseRiverfolkHandCard=Escolha uma carta da mão da Companhia do Rio para pegar.
-tuber.canis.actions.RiverfolkCompanyActions.ChooseRiverfolkHandCard.opponent=[jogador] está considerando uma carta da mão da Companhia do Rio para pegar.
+tuber.canis.actions.RiverfolkCompanyActions.DaylightChoice.opponent=A Companhia Ribeirinha está ponderando a próxima ação.
+tuber.canis.actions.RiverfolkCompanyActions.BuyRiverfolkServices=Escolha quaisquer serviços da Companhia Ribeirinha para comprar.
+tuber.canis.actions.RiverfolkCompanyActions.BuyRiverfolkServices.opponent=[jogador] está considerando serviços da Companhia Ribeirinha.
+tuber.canis.actions.RiverfolkCompanyActions.ChooseRiverfolkHandCard=Escolha uma carta da mão da Companhia Ribeirinha para pegar.
+tuber.canis.actions.RiverfolkCompanyActions.ChooseRiverfolkHandCard.opponent=[jogador] está considerando uma carta da mão da Companhia Ribeirinha para pegar.
 tuber.canis.actions.RiverfolkCompanyActions.CommitFund=Comprometa Fundos.
-tuber.canis.actions.RiverfolkCompanyActions.CommitFund.opponent=A Companhia do Rio está comprometendo fundos.
+tuber.canis.actions.RiverfolkCompanyActions.CommitFund.opponent=A Companhia Ribeirinha está comprometendo fundos.
 tuber.canis.actions.RiverfolkCompanyActions.SpendFund=Gaste Fundos.
-tuber.canis.actions.RiverfolkCompanyActions.SpendFund.opponent=A Companhia do Rio está gastando fundos.
-tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkEstablishTradePostAbility=Escolha um local para este posto comercial.
-tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkEstablishTradePostAbility.opponent=A Companhia Ribeirinha está posicionando um posto de comércio.
+tuber.canis.actions.RiverfolkCompanyActions.SpendFund.opponent=A Companhia Ribeirinha está gastando fundos.
+tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkEstablishTradePostAbility=Escolha um local para este entreposto comercial.
+tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkEstablishTradePostAbility.opponent=A Companhia Ribeirinha está posicionando um entreposto comercial.
 tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkRecruitAbility=Escolha uma clareira de rio para posicionar um guerreiro.
 tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkRecruitAbility.opponent=O oponente está escolhendo uma clareira de rio para posicionar um guerreiro.
 tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseStarting=Escolha uma clareira para o seu jardim.
-tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseStarting.opponent=O Culto dos Lagartos está escolhendo onde posicionar seu jardim.
-tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseOutcast=Escolha um naipe inicial para o Proscrito.
-tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseOutcast.opponent=O Culto dos Lagartos está escolhendo um naipe inicial para o Proscrito.
+tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseStarting.opponent=Os Lagartos Cultistas estão escolhendo onde posicionar seu jardim.
+tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseOutcast=Escolha um naipe inicial para o Pária.
+tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseOutcast.opponent=Os Lagartos Cultistas estão escolhendo um naipe inicial para o Pária.
 tuber.canis.undo.lizardCultSetupUndo=Pressione o botão de continuar para finalizar a preparação.
-tuber.canis.undo.lizardCultSetupUndo.opponent=Aguardando o Culto dos Lagartos confirmar a preparação.
+tuber.canis.undo.lizardCultSetupUndo.opponent=Aguardando os Lagartos Cultistas confirmarem a preparação.
 tuber.canis.abilities.LizardCultAbilities.CultCrusadeBattleAbility=Escolha quem atacar.
 tuber.canis.abilities.LizardCultAbilities.CultCrusadeBattleAbility.opponent=[player] está escolhendo quem atacar.
 tuber.canis.actions.LizardCultActions.RevealCardCost=Escolha uma carta para revelar.
-tuber.canis.actions.LizardCultActions.RevealCardCost.opponent=O Culto dos Lagartos está escolhendo uma carta para revelar.
+tuber.canis.actions.LizardCultActions.RevealCardCost.opponent=Os Lagartos Cultistas estão escolhendo uma carta para revelar.
 tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction=Escolha uma Conspiração.
 tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.persistant=Escolha uma Conspiração ou carta criada para usar.
-tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.persistant.opponent=O Culto dos Lagartos está escolhendo uma Conspiração ou carta criada para usar.
+tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.persistant.opponent=Os Lagartos Cultistas estão escolhendo uma Conspiração ou carta criada para usar.
 tuber.canis.actions.LizardCultActions.LizardCultDaylightAction=Escolha um Ritual.
 tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.NoActions=Nenhum Ritual disponível. Pressione o botão de continuar.
-tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.opponent=O Culto dos Lagartos está escolhendo um Ritual.
-tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.NoActions.opponent=O Culto dos Lagartos está escolhendo um Ritual.
+tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.opponent=Os Lagartos Cultistas estão escolhendo um Ritual.
+tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.NoActions.opponent=Os Lagartos Cultistas estão escolhendo um Ritual.
 tuber.canis.actions.CraftActivations=Escolha uma carta para criar.
 tuber.canis.actions.CraftActivations.opponent=[player] está considerando opções de criação.
 tuber.canis.actions.CraftActivations.NoActions=Nenhuma carta disponível para criar. Pressione o botão de continuar.
@@ -1017,26 +1051,26 @@ tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectAttacker.opponent
 tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectDefender=Escolha um defensor para Instigar em combate.
 tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectDefender.opponent=O Malandro está escolhendo um defensor para Instigar em combate.
 tooltip.ui.lizardcult.acolytes=<size=125%><b>Acolitos</b></size>\nUsados para realizar conspirações.
-<size=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas à noite. Compre mais cartas ao construir Jardins.=Draw Rate
+<size=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas ao Anoitecer. Compre mais cartas ao construir Jardins.=Draw Rate
 tooltip.ability.lizardcult.build=<size=125%><b>Construir</b></size>\nRevele uma carta não corvo para colocar um jardim em uma clareira correspondente que você governe.
-tooltip.ability.lizardcult.convert=<size=125%><b>Converter</b></size>\nRemova um guerreiro inimigo em uma clareira Proscrita e posicione um guerreiro seu no lugar.
+tooltip.ability.lizardcult.convert=<size=125%><b>Conversão</b></size>\nRemova um guerreiro inimigo em uma clareira Pária e posicione um guerreiro seu no lugar.
 tooltip.ability.lizardcult.crusade=<size=125%><b>Cruzada (combate)</b></size>\nInicie um combate em qualquer clareira Proscrita.
 tooltip.ability.lizardcult.moveandbattle=<size=125%><b>Cruzada (mover e combater)</b></size>\nMova-se de qualquer clareira Proscrita e inicie um combate na clareira de destino.
 tooltip.ability.lizardcult.recruit=<size=125%><b>Recrutar</b></size>\nRevele uma carta não corvo para colocar um guerreiro em uma clareira correspondente.
-tooltip.ability.lizardcult.sacrifice=<size=125%><b>Sacrificar</b></size>\nRevele uma carta de corvo para converter um guerreiro de sua reserva em um Acolito.
-tooltip.ability.lizardcult.sanctify=<size=125%><b>Sanctificar</b></size>\nRemova uma construção inimiga em uma clareira Proscrita e posicione um jardim no lugar.
+tooltip.ability.lizardcult.sacrifice=<size=125%><b>Sacrificar</b></size>\nRevele uma carta de corvo para converter um guerreiro de sua reserva em um Acólito.
+tooltip.ability.lizardcult.sanctify=<size=125%><b>Santificação</b></size>\nRemova uma construção inimiga em uma clareira Pária e posicione um jardim no lugar.
 tooltip.ability.lizardcult.score=<size=125%><b>Pontuar</b></size>\nRevele e descarte uma carta para pontuar pontos de vitória com base na sua trilha de jardim.
-tooltip.playmat.lizardstack=<size=125%><b>Guerreiros do Culto dos Lagartos</b></size>
+tooltip.playmat.lizardstack=<size=125%><b>Guerreiros dos Lagartos Cultistas</b></size>
 tooltip.playmat.garden=<size=125%><b>Jardim</b></size>\nSempre que um jardim for removido, descarte uma carta aleatória de sua mão.
 aiplayername.riverfolkCompany=Companhia Ribeirinha
-aiplayername.lizardCult=Culto dos Lagartos
+aiplayername.lizardCult=Lagartos Cultistas
 riverfolkWithColor=<color=#397F7F>Companhia Ribeirinha</color>
-cultWithColor=<color=#748421>Culto dos Lagartos</color>
+cultWithColor=<color=#748421>Lagartos Cultistas</color>
 vagabondWithColorAndCharacter=<color=#436979>[character name] Malandro</color>
 vagabondWithColorAndCharacter2=<color=#436979>[character name 2] Malandro</color>
-tooltip.ui.lizardcult.hatedoutcast=<size=125%><b>Proscrito Odiado</b></size>\nDetermina os jardins usados para criar itens e as clareiras com que as conspirações podem interagir. As conspirações custam um acolito a menos enquanto o proscrito for odiado.
-tooltip.ui.lizardcult.outcast=<size=125%><b>Proscrito</b></size>\nDetermina os jardins usados para criar itens e as clareiras com que as conspirações podem interagir.
-log.riverfolk.protectionism=<color=#397F7F>Companhia Ribeirinha</color> adiciona [X] guerreiros aos pagamentos, já que estava vazia no início da Alvorada.
+tooltip.ui.lizardcult.hatedoutcast=<size=125%><b>Odiado</b></size>\nDetermina os jardins usados para criar itens e as clareiras com que as conspirações podem interagir. As conspirações custam um acólito a menos enquanto o Pária for Odiado.
+tooltip.ui.lizardcult.outcast=<size=125%><b>Pária</b></size>\nDetermina os jardins usados para criar itens e as clareiras com que as conspirações podem interagir.
+log.riverfolk.protectionism=<color=#397F7F>Companhia Ribeirinha</color> adiciona [X] guerreiros aos pagamentos, já que estava vazia no início do Amanhecer.
 log.riverfolk.dividends=<color=#397F7F>Companhia Ribeirinha</color> ganha [X] pontos de vitória a partir de dividendos.
 log.riverfolk.gather=<color=#397F7F>Companhia Ribeirinha</color> move [X] guerreiros para seus fundos.
 log.riverfolk.move=<color=#397F7F>Companhia Ribeirinha</color> compromete um fundo para mover [X] guerreiros para uma clareira de [suit icon].
@@ -1047,52 +1081,52 @@ Log.riverfolk.Craft.Item=<color=#397F7F>Companhia Ribeirinha</color> compromete 
 Log.Riverfolk.Craft.for.Warriors=<color=#397F7F>Companhia Ribeirinha</color> compromete [X] fundos para criar [name] em troca de pagamento em vez do efeito da carta.
 log.riverfolk.draw=<color=#397F7F>Companhia Ribeirinha</color> compromete [X] fundos para comprar uma carta.
 log.riverfolk.recruit=<color=#397F7F>Companhia Ribeirinha</color> gasta um fundo para recrutar um guerreiro em uma clareira de [suit icon].
-log.riverfolk.trade.post=<color=#397F7F>Companhia Ribeirinha</color> gasta [X] fundos para estabelecer um posto de comércio em uma clareira de [suit icon], ganhando <style=vpnum">2</style>.
+log.riverfolk.trade.post=<color=#397F7F>Companhia Ribeirinha</color> gasta [X] fundos para estabelecer um entreposto comercial em uma clareira de [suit icon], ganhando <style=vpnum">2</style>.
 log.riverfolk.set.price=<color=#397F7F>Companhia Ribeirinha</color> define o preço do serviço [service name] para [X].
 log.riverfolk.setup=<color=#397F7F>Companhia Ribeirinha</color> adiciona [X] guerreiros a uma clareira de [suit icon] durante a preparação.
-log.riverfolk.trade.discard=<color=#397F7F>Companhia Ribeirinha</color> perde [X] fundos porque um posto de comércio foi removido.
-log.buy.service.hand=[faction name] compra o serviço Carta da Mão da Companhia Ribeirinha por [X], recebendo [suit icon][name].
+log.riverfolk.trade.discard=<color=#397F7F>Companhia Ribeirinha</color> perde [X] fundos porque um entreposto comercial foi removido.
+log.buy.service.hand=[faction name] compra o serviço Cartas da Mão da Companhia Ribeirinha por [X], recebendo [suit icon][name].
 log.buy.service.riverboats=[faction name] compra o serviço Barcos da Companhia Ribeirinha por [X].
 log.buy.service.mercenaries=[faction name] compra o serviço Mercenários da Companhia Ribeirinha por [X].
-log.cult.setup.garden=<color=#748421>Culto dos Lagartos</color> posiciona seu jardim inicial e 4 guerreiros em uma clareira de [suit icon]. 1 guerreiro é posicionado em cada clareira adjacente.
-log.cult.outcast=O Proscrito torna-se [suit icon].
-log.cult.outcast.hated=O Proscrito de [suit icon] agora é odiado.
-log.cult.outcast.no.change=O Proscrito Odiado continua sendo [suit icon].
-log.cult.crusade=<color=#748421>Culto dos Lagartos</color> gasta [X] acolitos para realizar uma Cruzada.
-log.cult.convert=<color=#748421>Culto dos Lagartos</color> gasta [X] acolitos para Converter um guerreiro de [faction name] em uma clareira de [suit icon] para um guerreiro do Culto dos Lagartos.
-log.cult.sanctify=<color=#748421>Culto dos Lagartos</color> gasta [X] acolitos para Sanctificar uma construção de [faction name] em uma clareira de [suit icon], substituindo-a por um jardim.
-log.cult.build=<color=#748421>Culto dos Lagartos</color> revela [name] para construir um jardim em uma clareira de [suit icon].
-log.cult.recruit=<color=#748421>Culto dos Lagartos</color> revela [name] para recrutar um guerreiro em uma clareira de [suit icon].
-log.cult.score=<color=#748421>Culto dos Lagartos</color> descarta [name] para pontuar jardins de [suit icon] e ganhar [X] pontos de vitória.
-log.cult.sacrifice=<color=#748421>Culto dos Lagartos</color> revela [name] para ganhar um acolito.
-log.cult.lost.garden=<color=#748421>Culto dos Lagartos</color> descarta a carta aleatória [name] porque um jardim foi removido.
+log.cult.setup.garden=<color=#748421>Lagartos Cultistas</color> posicionam seu jardim inicial e 4 guerreiros em uma clareira de [suit icon]. 1 guerreiro é posicionado em cada clareira adjacente.
+log.cult.outcast=O Pária torna-se [suit icon].
+log.cult.outcast.hated=O Pária de [suit icon] agora é Odiado.
+log.cult.outcast.no.change=O Pária Odiado continua sendo [suit icon].
+log.cult.crusade=<color=#748421>Lagartos Cultistas</color> gastam [X] acólitos para realizar uma Cruzada.
+log.cult.convert=<color=#748421>Lagartos Cultistas</color> gastam [X] acólitos para Converter um guerreiro de [faction name] em uma clareira de [suit icon] para um guerreiro dos Lagartos Cultistas.
+log.cult.sanctify=<color=#748421>Lagartos Cultistas</color> gastam [X] acólitos para Santificar uma construção de [faction name] em uma clareira de [suit icon], substituindo-a por um jardim.
+log.cult.build=<color=#748421>Lagartos Cultistas</color> revelam [name] para construir um jardim em uma clareira de [suit icon].
+log.cult.recruit=<color=#748421>Lagartos Cultistas</color> revelam [name] para recrutar um guerreiro em uma clareira de [suit icon].
+log.cult.score=<color=#748421>Lagartos Cultistas</color> descartam [name] para pontuar jardins de [suit icon] e ganhar [X] pontos de vitória.
+log.cult.sacrifice=<color=#748421>Lagartos Cultistas</color> revelam [name] para ganhar um acólito.
+log.cult.lost.garden=<color=#748421>Lagartos Cultistas</color> descartam a carta aleatória [name] porque um jardim foi removido.
 log.vagabond.explore.failure=[faction name] não encontra um item legal para pegar ao explorar em uma clareira de [suit icon].
 log.vagabond.scorched.earth=[faction name] remove <sprite name="torch"> para usar sua habilidade Terra Queimada em uma clareira de [suit icon]. As seguintes peças são removidas: [piece list]
 log.vagabond.vagrant.ability=<color=#4E6F89>Malandro</color> exaure <sprite name="torch"> para instigar um combate entre [faction name] e [faction name 2] em uma clareira de [suit icon].
 log.vagabond.arbiter.ability=[faction name] recruta a ajuda do Malandro Arbítrio <color=#4E6F89>Malandro</color> no combate, adicionando [X] espadas ao seu máximo de golpes. O Arbítrio ganha [X2] <style="vptext">PV</style> em troca.
-tooltip.lizardcult.gardens.description=Jardins do naipe do proscrito contribuem para criar itens durante a noite. Sempre que um jardim for removido, descarte uma carta aleatória de sua mão.
-tooltip.ui.hand.reveal.liz=<size=125%><b>Mão do Culto dos Lagartos</b></size> Veja as cartas do Culto dos Lagartos que foram reveladas.
+tooltip.lizardcult.gardens.description=Jardins do naipe do pária contribuem para criar itens durante o Anoitecer. Sempre que um jardim for removido, descarte uma carta aleatória de sua mão.
+tooltip.ui.hand.reveal.liz=<size=125%><b>Mão dos Lagartos Cultistas</b></size> Veja as cartas dos Lagartos Cultistas que foram reveladas.
 tooltip.ui.lostsouls.liz=Almas Perdidas
-playmat.sacrifice=Sacrifício!
+playmat.sacrifice=Sacrificar!
 ftt.twovagabond.create=Agora você pode criar jogos com dois <color=#4E6F89>Malandros</color>. Recomendamos fazer isso em jogos com mais jogadores.
-ftt.twovagabond.quest=<color=#4E6F89>Malandros</color> compartilham uma única mão de missões. Se você estiver de olho em uma, certifique-se de completá-la antes que seu oponente o faça.
+ftt.twovagabond.quest=<color=#4E6F89>Malandros</color> compartilham uma única mão de tarefas. Se você estiver de olho em uma, certifique-se de completá-la antes que seu oponente o faça.
 ftt.twovagabond.explore=Cada <sprite name="Ruins"><color=#4E6F89>ruína</color> guarda dois itens em um jogo com dois <color=#4E6F89>Malandros</color>. Esses itens são sorteados de um conjunto de 2 <sprite name="sword">, 2 <sprite name="bag">, 2 <sprite name="boot"> e 2 <sprite name="hammer">.
 ftt.twovagabond.explore.2=Ao explorar uma <sprite name="Ruins"><color=#4E6F89>ruína</color> com dois itens, você pode escolher os itens que estão lá. No entanto, não é permitido selecionar um item do mesmo tipo de outro item que você já possui e que também foi retirado de uma ruína.
-ftt.service.intro.1=No início da Alvorada, os jogadores podem comprar serviços da Companhia Ribeirinha. Para comprar um serviço, os jogadores movem guerreiros iguais ao custo do serviço de sua reserva para a área de pagamentos da Companhia Ribeirinha.
-ftt.service.intro.2=Carta da Mão: Roube uma carta da mão da Companhia Ribeirinha
+ftt.service.intro.1=No início do Amanhecer, os jogadores podem comprar serviços da Companhia Ribeirinha. Para comprar um serviço, os jogadores movem guerreiros iguais ao custo do serviço de sua reserva para a área de pagamentos da Companhia Ribeirinha.
+ftt.service.intro.2=Cartas da Mão: Roube uma carta da mão da Companhia Ribeirinha
 ftt.service.intro.3=Barcos: Trate rios como caminhos até o final do turno.
-ftt.service.intro.4=Mercenários: Durante o Dia e a Noite deste turno, trate os guerreiros da Companhia Ribeirinha como seus para fins de governar e combater. O Malandro não pode usar essa habilidade.
-ftt.service.intro.5=Note que o Malandro paga pelos serviços exaurindo itens no início da Alvorada antes de renovar. Para cada item que o Malandro exaurir para fazer isso, a Companhia Ribeirinha posiciona um de seus próprios guerreiros nos Pagamentos.
+ftt.service.intro.4=Mercenários: Durante o Dia e o Anoitecer deste turno, trate os guerreiros da Companhia Ribeirinha como seus para fins de governar e combater. O Malandro não pode usar essa habilidade.
+ftt.service.intro.5=Note que o Malandro paga pelos serviços exaurindo itens no início do Amanhecer antes de reanimar. Para cada item que o Malandro exaurir para fazer isso, a Companhia Ribeirinha posiciona um de seus próprios guerreiros nos Pagamentos.
 tutorial.title.tutorialR01=Escamas Sagradas
-tutorial.description.tutorialR01=Aprenda a jogar com o Culto dos Lagartos
+tutorial.description.tutorialR01=Aprenda a jogar com os Lagartos Cultistas
 tutorial.title.tutorialR02=Rolando no Rio
 tutorial.description.tutorialR02=Aprenda a jogar com a Companhia Ribeirinha
-playmat.sanctify=Sanctificar!
+playmat.sanctify=Santificação!
 playmat.lizscore=Pontuar!
 playmat.revenge=Vingança!
 stinger.title.fear=Medo dos Fiéis
-playmat.convert=Converter!
-key.handcard=Carta da Mão
+playmat.convert=Conversão!
+key.handcard=Cartas da Mão
 key.riverboats=Barcos
 key.mercenaries=Mercenários
 tuber.canis.abilities.LizardCultAbilities.CultBuildAbility=Escolha uma clareira para o seu jardim.
@@ -1102,7 +1136,7 @@ tooltip.fish.fox=Peixe de Raposa
 tooltip.fish.rabbit=Peixe de Coelho
 tooltip.fish.mouse=Peixe de Rato
 tooltip.fishmonochrome=
-tooltip.tutorial.hatedoutcast=Proscrito Odiado
+tooltip.tutorial.hatedoutcast=Odiado
 tooltip.tutorial.mostcommonsuit=Naipe Mais Comum
 Log.Explore.NoItems=[faction name] explora uma ruína em uma clareira de [suit icon], mas não encontrou itens.
 scenario.garden.name=Grande Jardim
@@ -1119,314 +1153,162 @@ achievement.rf.peddler=Mercador Próspero
 achievement.rf.connected=Tudo Conectado
 achievement.rf.scoundrel=Patife Sujo
 achievement.rf.bodyguard=Guarda-costas
-root.vagabond.vagrant=Errante
+root.vagabond.vagrant=Vagabundo
 root.vagabond.vagrant.ability.title=Instigar
 root.vagabond.vagrant.ability.text=Inicie uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada um.
 root.vagabond.arbiter=Árbitro
-root.vagabond.arbiter.ability.title=Protetor
+root.vagabond.arbiter.ability.title=Proteção
 root.vagabond.arbiter.ability.text=Antes de rolar os dados na batalha, o defensor pode alistar o Árbitro se ele estiver na clareira da batalha. O Árbitro ganha <sprite name="1VP"> e adiciona espadas intactas ao máximo de golpes rolados pelo defensor.
 root.vagabond.scoundrel=Patife
 root.vagabond.scoundrel.ability.title=Terra Queimada
 root.vagabond.scoundrel.ability.text=Descarte sua tocha para remover todas as peças inimigas de sua clareira. Peças não podem mais ser posicionadas nem movidas para dentro da clareira incendiada.
-tuber.canis.abilities.LizardCultAbilities.CultSanctifyAbility=Escolha uma construção para sanctificar.
+tuber.canis.abilities.LizardCultAbilities.CultSanctifyAbility=Escolha uma construção para santificar.
 playmat.boughthandcard=Carta da Mão Comprada!
 playmat.boughtriverboats=Barcos Comprados!
 playmat.boughtmercenaries=Mercenários Comprados!
-prompts.gameresults.winner.LizardCult=O Culto dos Lagartos Vence!
+prompts.gameresults.winner.LizardCult=Os Lagartos Cultistas Vencem!
 prompts.gameresults.winner.RiverfolkCompany=A Companhia Ribeirinha Vence!
 tuber.canis.abilities.LizardCultAbilities.CultConvertAbility=Escolha um guerreiro para converter
 vagabond.title.SecondVagabond_Thief=Malandro Ladrão
-vagabond.title.SecondVagabond_Tinker=Malandro Artesão
-vagabond.title.SecondVagabond_Ranger=Malandro Guardião
-vagabond.title.SecondVagabond_Vagrant=Malandro Errante
+vagabond.title.SecondVagabond_Tinker=Malandro Funileiro
+vagabond.title.SecondVagabond_Ranger=Malandro Andarilho
+vagabond.title.SecondVagabond_Vagrant=Malandro Vagabundo
 vagabond.title.SecondVagabond_Arbiter=Malandro Árbitro
 vagabond.title.SecondVagabond_Scoundrel=Malandro Patife
-vagabond.title.vagabond_Vagrant=Malandro Errante
+vagabond.title.vagabond_Vagrant=Malandro Vagabundo
 vagabond.title.vagabond_Arbiter=Malandro Árbitro
 vagabond.title.vagabond_Scoundrel=Malandro Patife
 ftt.servicecost=Custo de Serviço
 tooltip.ui.liz.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros na reserva, ele não poderá recrutar guerreiros.
-tooltip.ui.liz.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nO Culto dos Lagartos compra cartas adicionais ao erguer Jardins.
+tooltip.ui.liz.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nOs Lagartos Cultistas compram cartas adicionais ao contruir Jardins.
 tuber.canis.actions.VagabondActions.Explore.ChooseItemToTake=Escolha um item para pegar.
 tuber.canis.actions.VagabondActions.Explore.ChooseItemToTake.opponent=O Malandro está escolhendo um item para pegar das Ruínas.
-tooltip.ui.vagabond.vagabond_vagrant=<size=125%><b>Errante</b></size>\n<b>Instigar</b> — Exaure <sprite name="torch"> para iniciar uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada um.
-tooltip.ui.vagabond.vagabond_arbiter=<size=125%><b>Árbitro</b></size>\n<b>Protetor</b> — Antes de rolar os dados na batalha, o defensor pode alistar o Árbitro se ele estiver na clareira da batalha. O Árbitro ganha <sprite name="1VP"> e adiciona espadas intactas ao máximo de golpes rolados pelo defensor.
+tooltip.ui.vagabond.vagabond_vagrant=<size=125%><b>Vagabundo</b></size>\n<b>Instigar</b> — Exaura <sprite name="torch"> para iniciar uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada um.
+tooltip.ui.vagabond.vagabond_arbiter=<size=125%><b>Árbitro</b></size>\n<b>Proteção</b> — Antes de rolar os dados na batalha, o defensor pode alistar o Árbitro se ele estiver na clareira da batalha. O Árbitro ganha <sprite name="1VP"> e adiciona espadas intactas ao máximo de golpes rolados pelo defensor.
 tooltip.ui.vagabond.vagabond_scoundrel=<size=125%><b>Patife</b></size>\n<b>Terra Queimada</b> — Descarte sua <sprite name="torch"> para remover todas as peças inimigas de sua clareira. Peças não podem mais ser posicionadas nem movidas para dentro da clareira incendiada.
-tooltip.ui.vagabond.secondvagabond_ranger=<size=125%><b>Guardião</b></size>\n<b>Esconderijo</b> — Exaure <sprite name="torch"> para reparar três itens. Em seguida, encerre imediatamente o Dia.
-tooltip.ui.vagabond.secondvagabond_thief=<size=125%><b>Ladrão</b></size>\n<b>Roubar</b> — Exaure <sprite name="torch"> para pegar uma carta aleatória de um jogador em sua clareira.
-tooltip.ui.vagabond.secondvagabond_tinker=<size=125%><b>Artesão</b></size>\n<b>Trabalho Diário</b> — Exaure <sprite name="torch"> para pegar uma carta do descarte que corresponda ao naipe de sua clareira.
-tooltip.ui.vagabond.secondvagabond_vagrant=<size=125%><b>Errante</b></size>\n<b>Instigar</b> — Exaure <sprite name="torch"> para iniciar uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada um.
-tooltip.ui.vagabond.secondvagabond_arbiter=<size=125%><b>Árbitro</b></size>\n<b>Protetor</b> — Antes de rolar os dados na batalha, o defensor pode alistar o Árbitro se ele estiver na clareira da batalha. O Árbitro ganha <sprite name="1VP"> e adiciona espadas intactas ao máximo de golpes rolados pelo defensor.
+tooltip.ui.vagabond.secondvagabond_ranger=<size=125%><b>Andarilho</b></size>\n<b>Esconderijo</b> — Exaura <sprite name="torch"> para reparar três itens. Em seguida, encerre imediatamente o Dia.
+tooltip.ui.vagabond.secondvagabond_thief=<size=125%><b>Ladrão</b></size>\n<b>Roubar</b> — Exaura <sprite name="torch"> para pegar uma carta aleatória de um jogador em sua clareira.
+tooltip.ui.vagabond.secondvagabond_tinker=<size=125%><b>Funileiro</b></size>\n<b>Dia de Trabalho</b> — Exaura <sprite name="torch"> para pegar uma carta do descarte que corresponda ao naipe de sua clareira.
+tooltip.ui.vagabond.secondvagabond_vagrant=<size=125%><b>Vagabundo</b></size>\n<b>Instigar</b> — Exaura <sprite name="torch"> para iniciar uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada um.
+tooltip.ui.vagabond.secondvagabond_arbiter=<size=125%><b>Árbitro</b></size>\n<b>Proteção</b> — Antes de rolar os dados na batalha, o defensor pode alistar o Árbitro se ele estiver na clareira da batalha. O Árbitro ganha <sprite name="1VP"> e adiciona espadas intactas ao máximo de golpes rolados pelo defensor.
 tooltip.ui.vagabond.secondvagabond_scoundrel=<size=125%><b>Patife</b></size>\n<b>Terra Queimada</b> — Descarte sua <sprite name="torch"> para remover todas as peças inimigas de sua clareira. Peças não podem mais ser posicionadas nem movidas para dentro da clareira incendiada.
 prompt.tutorial.riverfolk.upsell.title=Tutoriais da Companhia Ribeirinha
-prompt.tutorial.riverfolk.upsell.description=A Companhia Ribeirinha e o Culto dos Lagartos fazem parte da Expansão Riverfolk. Visite a loja para saber mais?
-tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.opponent=O Culto dos Lagartos está escolhendo uma Conspiração
+prompt.tutorial.riverfolk.upsell.description=A Companhia Ribeirinha e os Lagartos Cultistas fazem parte da Expansão Ribeirinhos. Visitar a loja para saber mais?
+tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.opponent=Os Lagartos Cultistas estão escolhendo uma Conspiração
 Firsttime.ally=Agora você está <sprite name="Allied"><color=#4E6F89>aliado</color> com a [faction name]. Cada vez que você oferecer <sprite name="heart"> <color=#4E6F89>ajuda</color> a eles, você ganhará <style="vptext">PV</style>. Você também poderá comandar seus guerreiros em sua clareira para mover e lutar ao seu lado.
 factionnames.RiverfolkCompany=Companhia Ribeirinha
 aiplayername.secondvagabond=Malandro
 playmat.enlisted=Alistado!
 prompts.vagabonditems.novalidchoices=Você não pode pegar dois itens do mesmo tipo nas ruínas.
-playmat.establishtradepost=Estabelecer Posto de Comércio!
+playmat.establishtradepost=Estabelecer Entreposto Comercial!
 playmat.export=Exportar!
 prompts.gameresults.winner.SecondVagabond=Malandro Vence
 prompt.selectaplayer=Selecione um Jogador!
 Log.riverfolk.Favor.Craft=<color=#397F7F>Companhia Ribeirinha</color> compromete [X2] fundos para criar [name], removendo todas as peças inimigas nas clareiras de [suit icon].
 tooltip.ui.riverfolk.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nA Companhia Ribeirinha cria cartas usando Postos de Comércio.
-tooltip.ui.lizards.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas por esses itens. O Culto dos Lagartos cria itens usando Jardins.
-tooltip.ui.lizards.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nO Culto dos Lagartos cria cartas usando Jardins que correspondam ao naipe do proscrito.
-tuber.canis.abilities.CraftAbility.lizardcult=Escolha uma carta para criar usando os jardins do naipe do proscrito.
-tuber.canis.abilities.CraftAbility.lizardcult.opponent=O Culto dos Lagartos está escolhendo uma carta para criar
+tooltip.ui.lizards.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas por esses itens. Os Lagartos Cultistas criam itens usando Jardins.
+tooltip.ui.lizards.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nOs Lagartos Cultistas criam cartas usando Jardins que correspondam ao naipe do Pária.
+tuber.canis.abilities.CraftAbility.lizardcult=Escolha uma carta para criar usando os jardins do naipe do pária.
+tuber.canis.abilities.CraftAbility.lizardcult.opponent=Os Lagartos Cultistas estão escolhendo uma carta para criar
 tuber.canis.actions.LizardCultActions.ConfirmScoreForNoPoints=Escolher esta carta renderá 0 pontos. Tem certeza de que deseja continuar?
 prompt.vagabond.enlistarbiter.title=Alistar Árbitro
 prompt.export=Escolha uma carta para Exportar.
-factionnames.keepersiniron=Guardiões de Ferro
-factionnames.lordofthehundreds=Senhor das Centenas
-playerinfo.keepersiniron.devoutknights.title=Cavaleiros Devotos
-playerinfo.keepersiniron.devoutknights.description=Em batalha, ignore o primeiro golpe que você sofrer se tiver uma relíquia e um guerreiro Guardião. Ao mover, você pode mover uma relíquia com cada guerreiro Guardião.
-playerinfo.keepersiniron.prizedtrophies.title=Troféus Valiosos
-playerinfo.keepersiniron.prizedtrophies.description=Quando um inimigo remove uma relíquia, ele a coloca, com o valor virado para cima, em qualquer floresta e pontua um ponto extra.
-playerinfo.keepersiniron.relics.title=Relíquias
-playerinfo.keepersiniron.relics.desc=<sprite name="2VP"> se você preencher uma coluna
-playerinfo.keepersiniron.waystations.title=Estações de Campo
-playerinfo.keepersiniron.birdsong=1º: Acampar<size=80%> uma vez por clareira. Você pode substituir um guerreiro Guardião por uma Estação de Campo. Se nenhum estiver no mapa, coloque ambos em uma clareira na borda do mapa.<br><br></size=80%>2º: Desmontar<size=80%> uma vez por clareira. Você pode substituir uma Estação de Campo por um guerreiro Guardião. <br><br></size=80%>3º: Recrutar <size=80%>Quantas vezes quiser. Gaste uma carta para posicionar um guerreiro em uma Estação de Campo correspondente.
-playerinfo.keepersiniron.daylight=1º: Criar<size=80%> usando Estações de Campo.<br><br></size=80%>2º: Atuar com o Séquito<size=80%> da esquerda para a direita. Para cada carta, você pode realizar a ação listada. <i>(Mas se você quiser escavar em uma clareira que tenha um inimigo, deve batalhar lá primeiro.)</i>
-playerinfo.keepersiniron.evening=1º: Viver da Terra<size=80%> você deve remover um guerreiro Guardião de cada clareira com quatro ou mais.<br><br></size=80%>2º: Reunir o Séquito<size=80%> de até dez cartas. Você pode adicionar qualquer número de cartas da mão ao Séquito ou pode mover uma carta dentro dele. <br><br></size=80%>3º: Comprar <size=80%>1 carta por <sprite index=31> exibido.<br></size=80%><br>Descarte <size=80%>até ficar com 5 cartas.
-playerinfo.lordofthehundreds.thewarlord.title=O Senhor da Guerra
-playerinfo.lordofthehundreds.thewarlord.description=O Senhor da Guerra é um guerreiro que não pode ser removido fora da batalha, movido fora do seu turno ou posicionado, exceto com Ungir.
-playerinfo.lordofthehundreds.contemptfortrade.title=Desprezo pelo Comércio
-playerinfo.lordofthehundreds.contemptfortrade.description=Quando você cria um item, ganha-o, mas não pontua os pontos listados, ou o remove para pontuá-los.
-playerinfo.lordofthehundreds.looters.title=Saqueadores
-playerinfo.lordofthehundreds.looters.description=No início da batalha como atacante, você pode declarar que está saqueando o defensor. Você não causa golpes rolados, mas ele sim. No final, se você governar a clareira da batalha, pegue um item dos Itens Criados dele.
-playerinfo.lordofthehundreds.moods.title=Humores
-playerinfo.lordofthehundreds.thehoard.title=O Tesouro
-playerinfo.lordofthehundreds.oppressedspaces.title=Espaços Oprimidos:
-playerinfo.lordofthehundreds.birdsong=1º: Arrasar<size=80%> - Em cada horda, remova todas as construções e marcadores inimigos, pegue um item da ruína se houver. Após resolver as hordas, role o dado da horda e posicione uma horda em uma clareira correspondente sem horda, mas adjacente a uma horda.<br><br></size=80%>2º: Recrutar <size=80%>guerreiros iguais ao seu Bravura na clareira do seu Senhor da Guerra, e então um guerreiro em cada fortaleza.<br><br></size=80%>3º: Ungir <size=80%>um guerreiro das Centenas como seu novo Senhor da Guerra se ele estiver fora do mapa. Se não puder, posicione seu Senhor da Guerra em qualquer clareira.<br><br></size=80%>4º: Escolha um Humor diferente <size=80%>que não mostre um item no seu Tesouro.<br>
-playerinfo.lordofthehundreds.daylight=1º: Criar<size=80%> usando fortalezas.<br><br></size=80%>2º: Comandar as Centenas<size=80%> um número de vezes até Comandar.<br><br><sprite name="hundredswarrior"> Mover<br><br><sprite name="hundredswarrior"> Batalhar<br><br><sprite name="hundredswarrior"> Erguer<br><br></size=80%>3º: Avançar com o Senhor da Guerra<size=80%> um número de vezes até Bravura.<br><br>Você pode mover seu Senhor da Guerra com quaisquer guerreiros das Centenas, e então pode batalhar na clareira do seu Senhor da Guerra.
-playerinfo.lordofthehundreds.evening=1º: Incitar<size=80%> - quantas vezes quiser. Gaste uma carta para posicionar uma horda em uma clareira correspondente com um guerreiro ou Senhor da Guerra das Centenas, mas sem horda.<br><br></size=80%>2º: Oprimir <size=80%>clareiras que você governa e que têm uma peça das Centenas e nenhuma peça inimiga. <br><br>1-2: <sprite name="1VP">   3-4: <sprite name="2VP"><br><br>5: <sprite name="3VP">   6+: <sprite name="4VP"><br></size=80%><br>Comprar <size=80%>- 1 carta.</size=90%> Descarte<size=80%> até ficar com 5 cartas.
-playerinfo.lordofthehundreds.protectthewarlord=Proteger o Senhor da Guerra
-hundreds.moods.selection.title=Escolher Humor
-hundreds.moods.selection.no.moods=Sem Humores Disponíveis
-hundreds.moods.selection.newmood=Novo Humor
-hundreds.moods.grandiose=Grandioso
-hundreds.moods.stubborn=Teimoso
-hundreds.moods.bitter=Amargo
-hundreds.moods.lavish=Luxuoso
-hundreds.moods.relentless=Implacável
-hundreds.moods.wrathful=Irado
-hundreds.moods.jubilant=Exultante
-hundreds.moods.rowdy=Barulhento
-hundreds.moods.desc.grandiose=Troque a etapa Avançar com o Senhor da Guerra pela etapa Comandar as Centenas.
-hundreds.moods.desc.stubborn=Em batalha com seu Senhor da Guerra, você ignora o primeiro golpe que sofrer.
-hundreds.moods.desc.bitter=Em batalha com o Senhor da Guerra, antes da rolagem, posicione um guerreiro na clareira da batalha por horda que você escolher remover da clareira da batalha e das adjacentes.
-hundreds.moods.desc.lavish=No final da Alvorada, você pode remover quaisquer itens do seu Tesouro para posicionar dois guerreiros por item removido na clareira do seu Senhor da Guerra.
-hundreds.moods.desc.relentless=Sempre que você avançar com seu Senhor da Guerra e tanto mover quanto batalhar, você pode mover ou batalhar com ele <i>(como metade de um avanço)</i>.
-hundreds.moods.desc.wrathful=Como atacante em batalha com seu Senhor da Guerra, você causa um golpe extra. <i>(Ao saquear, você causa este golpe.)</i>
-hundreds.moods.desc.jubilant=Após incitar na clareira do seu Senhor da Guerra, você pode rolar o dado da horda para posicionar uma horda <i>(como descrito na sua etapa Arrasar)</i> até quatro vezes.
-hundreds.moods.desc.rowdy=Durante o Anoitecer, compre uma carta a mais. Se a clareira do seu Senhor da Guerra tiver três ou mais peças inimigas, compre duas cartas a mais.
-keepers.faithfulretainers=Fiel Retentor
-keepers.faithfulretainers.desc=Quando você descartar esta carta, remova-a permanentemente.
-hundreds.command=Comandar
-hundreds.prowess=Bravura
-hundreds.lavish.desc=Você pode escolher remover itens do seu Tesouro para posicionar dois guerreiros na clareira do seu Senhor da Guerra por item removido.
-hundreds.lavish.title=Remover Itens para Luxuoso?
-hundreds.hoardfull.desc=Escolha um item para remover do Tesouro (ou o item que acabou de ganhar) e pontue (<sprite name="1VP">).
-hundreds.hoardfull.title=Seu Tesouro Está Cheio
-hundreds.hoardfull.newitem=Novo Item
-playerinfo.keepersiniron.retinue.desc=Você pode adicionar qualquer número de cartas da sua mão ao Séquito ou mover uma carta dentro dele.
-playerinfo.keepersiniron.retinue.move.title=Mover
-playerinfo.keepersiniron.retinue.battleanddelve.title=Batalhar e Escavar
-playerinfo.keepersiniron.retinue.battleanddelve.desc=...na mesma clareira correspondente
-playerinfo.keepersiniron.retinue.moveorrecover.title=Mover ou Recuperar
-playerinfo.keepersiniron.retinue.moveorrecover.desc=...de uma clareira correspondente
-playerinfo.keepersiniron.buildwaystations.title=Escolha qual tipo de Estação de Campo posicionar.
-playerinfo.keepersiniron.buildwaystations.desc=Você pode pressionar o ícone <sprite name="Flip"> para alternar para o outro lado de uma Estação de Campo.
-playerinfo.keepersiniron.buildwaystations.tablet=Tabuleta
-playerinfo.keepersiniron.buildwaystations.jewelry=Joia
-playerinfo.keepersiniron.buildwaystations.figure=Estátua
-playerinfo.keepersiniron.buildwaystations.prompt.title=Escolher Estação de Campo
-playerinfo.keepersiniron.moverelic.prompt.title=Mover Relíquia?
-playerinfo.keepersiniron.recoverrelic.prompt.title=Relíquias
-playerinfo.keepersiniron.recoverrelic.prompt.button=Recuperar
-playerinfo.keepersiniron.delverelic.prompt.button=Escavar
-hirelings.uprising.title=Escolher Habilidade de Revolta
-hirelings.selection.title=Escolha um mercenário para contratar
-hirelings.card.forestpatrol.title=Patrulha Florestal
-hirelings.card.forestpatrol.ability.1=Sempre que quaisquer guerreiros da Patrulha forem removidos, posicione um deles nesta carta, e não na reserva.
-hirelings.card.forestpatrol.ability.2=Você pode mover, e então pode batalhar.<br><br><b>-OU-</b><br><br>Posicione todos os guerreiros da Patrulha desta carta em uma clareira com quaisquer guerreiros da Patrulha.
-hirelings.card.theexile.title=O Exilado
-hirelings.card.theexile.ability.1=A qualquer momento durante o turno, um jogador com peças de facção adjacentes ao Exilado pode posicionar um item de sua caixa de Itens Criados nesta carta para comprar uma carta e pontuar um ponto.
-hirelings.card.theexile.ability.2=Quantas vezes quiser, você pode exaurir um item aqui para se mover para uma floresta adjacente, e pode exaurir dois itens aqui para batalhar em uma clareira adjacente.<br><br>Ao terminar, renove todos os itens aqui.<br><br>Em batalha, você pode causar golpes até o número de itens aqui. Para cada golpe sofrido, exaure um item ou remova um se não puder exaurir nenhum.
-hirelings.card.springuprising.title=Revolta da Primavera
-hirelings.card.springuprising.ability.1=Se não houver guerreiros de Revolta no mapa, role o dado da revolta e posicione um guerreiro de Revolta em uma clareira correspondente.<br><br>Para batalhar contra a Revolta, o atacante deve descartar uma carta correspondente à clareira da batalha.
-hirelings.card.springuprising.ability.2=<size=125%><b>1º</b></size> Você deve rolar o dado da revolta.<br><br><size=125%><b>2º</b></size> Você deve remover um guerreiro de Revolta e todas as peças inimigas de uma clareira correspondente.<br><br><b>-OU-</b><br><br>Você deve posicionar um guerreiro de Revolta em uma clareira correspondente.
-hirelings.card.felinephysicians.title=Médicos Felinos
-hirelings.card.felinephysicians.ability.1=<b>Controlador:</b> Sempre que qualquer um de seus guerreiros de facção for removido, você pode gastar uma carta correspondente à clareira deles para posicionar esses guerreiros em uma clareira com suas peças de facção, em vez de na reserva <i>(como Hospitais de Campo)</i>.
-hirelings.card.bluebirdnobles.title=Nobres do Pássaro Azul
-hirelings.card.bluebirdnobles.ability.1=<b>Controlador:</b> Você governa clareiras em caso de empate na presença <i>(como Senhores da Floresta)</i>.<br><br><b>Controlador:</b> Pontue um ponto para cada três clareiras que você governar.
-hirelings.card.rabbitscouts.title=Exploradores de Coelho
-hirelings.card.rabbitscouts.ability.1=<b>Controlador:</b> Como defensor em batalha, antes da rolagem, você pode gastar uma carta correspondente à clareira da batalha para usar o maior valor da rolagem e fazer o atacante usar o menor valor <i>(como Guerrilha)</i>.
-hirelings.card.thebrigand.title=O Salteador
-hirelings.card.thebrigand.ability.1=<b>Controlador:</b> Você pode pegar um item de uma ruína em uma clareira com suas peças de facção. <i>(Como Senhor das Centenas, coloque-o no seu Tesouro.)</i> Se você pegou o último item da ruína, remova a ruína.<br><br><b>Controlador:</b> Você pode exaurir um item na sua caixa de Itens Criados <i>(não no Tesouro)</i> para pegar uma carta aleatória de um jogador com peças de facção em uma clareira com suas peças de facção.
-hirelings.card.lastdynasty.title=Última Dinastia
-hirelings.card.lastdynasty.ability.2=Se não houver guerreiros da Dinastia no mapa, posicione todos os 5 guerreiros da Dinastia em qualquer clareira na borda e batalhe lá.<br><br><b>-OU-</b><br><br>Se eles governarem a clareira, mova todos os seus guerreiros e depois batalhe com eles, se possível.<br><br><b>-OU-</b><br><br>Se eles não governarem a clareira, batalhe lá duas vezes.
-hirelings.card.popularband.title=Bando Popular
-hirelings.card.popularband.ability.1=Se não houver guerreiros do Bando no mapa, posicione um guerreiro do Bando em uma clareira com suas peças de facção.<br><br>Os inimigos não podem se mover de uma clareira com um guerreiro do Bando no mesmo turno em que se moveram para ela.
-hirelings.card.popularband.ability.2=<b>1º</b> Escolha uma clareira com um guerreiro do Bando. Você pode forçar qualquer guerreiro de facção em cada clareira adjacente a se mover para a clareira escolhida.<br><br><b>2º</b> Você pode posicionar um guerreiro do Bando em qualquer clareira.
-hirelings.card.vaultkeepers.title=Guardas do Cofre
-hirelings.card.vaultkeepers.ability.1=Se não houver peças dos Guardas no mapa, posicione 2 guerreiros dos Guardas e um marcador de cofre em qualquer clareira.
-hirelings.card.vaultkeepers.ability.2=<b>1º</b> Você pode posicionar um cofre em uma clareira com um cofre ou adjacente a ele. Se não puder, posicione um guerreiro e um cofre em qualquer clareira.<br><br><b>2º</b> Você pode batalhar em cada clareira com um cofre.<br><br><b>-OU-</b><br><br>Você pode posicionar um guerreiro dos Guardas em cada cofre.
-hirelings.card.flamebearers.title=Portadores da Chama
-hirelings.card.flamebearers.ability.1=Se não houver guerreiros dos Portadores no mapa, posicione 2 guerreiros dos Portadores em quaisquer clareiras.
-hirelings.card.flamebearers.ability.2=<b>1º</b> Em cada clareira com quaisquer guerreiros dos Portadores, você deve remover uma peça inimiga por guerreiro dos Portadores lá, guerreiros primeiro.<br><br><b>2º</b> Você deve posicionar um guerreiro dos Portadores em um guerreiro dos Portadores ou adjacente a ele. Se não puder, posicione 2 guerreiros dos Portadores em quaisquer clareiras.
-hirelings.card.streetband.title=Bando de Rua
-hirelings.card.streetband.ability.1=Posicione um guerreiro do Bando em qualquer clareira.
-hirelings.card.badgerbodyguards.title=Guarda-costas Texugos
-hirelings.card.badgerbodyguards.ability.1=<b>Controlador:</b> Em batalha, você ignora o primeiro golpe que sofrer. <i>(Isso não se combina com outros efeitos que permitem ignorar o primeiro golpe que você sofrer.)</i>
-hirelings.card.ratsmugglers.title=Contrabandistas de Rato
-hirelings.card.ratsmugglers.ability.1=<b>Controlador:</b> Quantas vezes quiser durante o Dia, você pode descartar uma carta com um item para se mover ou batalhar. <i>(Você não precisa ser capaz de criar o item.)</i>
-hirelings.prompt.bluebirdvpgain.title=Bônus de Regra de Clareira
-hirelings.prompt.flamebearersremovewarrior.title=Portadores da Chama
-hirelings.prompt.flamebearersremovewarrior.desc=Removendo peças inimigas em clareiras com portadores
-hirelings.prompt.uprisingremovingpieces.title=Revolta
-hirelings.prompt.uprisingremovingpieces.body=Removendo Guerreiro de Revolta e todas as peças inimigas
-hirelings.prompt.hundredsoppressscoring.title=Oprimir
-keepers.prompt.liveoftheland.title=Viver da Terra
-keepers.prompt.liveoftheland.desc=Guardas removidos das clareiras com 4 ou mais
-keepers.prompt.recovered.title=Recuperado
-keepers.prompt.recovered.desc=Bônus Completo:
-keepers.prompt.delve.title=Escavar
-keepers.prompt.retinuelost.title=Séquito Perdido
-keepers.prompt.retinuelost.delve.desc=Guardas governam menos clareiras adjacentes à floresta de onde a relíquia veio do que o valor dela.
-keepers.prompt.retinuelost.recover.desc=Guardas governam menos clareiras correspondentes do que o valor da relíquia recuperada.
-hundreds.prompt.item.tohoard=<b>Desprezo pelo Comércio</b><br>Item Adicionado ao Tesouro e Não Pontuado
-hundreds.prompt.item.tononhoard=<b>Desprezo pelo Comércio</b><br>Item Removido e Pontuado
-hundreds.prompt.warlordanointed.title=Senhor da Guerra Ungido
-hundreds.prompt.incite.title=Incitar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseNewEncamp=Escolha uma clareira para posicionar um guerreiro e uma Estação de Campo
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseEncamp=Escolha uma clareira para substituir um guerreiro por uma Estação de Campo
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseWaystation=Escolha uma Estação de Campo para posicionar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoEncamp=Nenhum outro Acampamento possível
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseDecamp=Escolha uma Estação de Campo para substituir por um guerreiro
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoDecamp=Impossível Desmontar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseCardRecruit=Gaste uma carta correspondente a uma clareira com uma Estação de Campo para recrutar 2 guerreiros lá
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseRecruitClearing=Escolha uma clareira correspondente com uma Estação de Campo para recrutar 2 guerreiros lá
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoRecruit=Não é possível recrutar mais
-creategame.enablehirelings=Habilitar Mercenários
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoves=Nenhum movimento possível
-tuber.canis.abilities.KeepersInIronAbilities.KeepersMoveAbility.ChooseMoveRelics=Escolha guerreiros e relíquias para mover
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve=Escolha uma clareira para Batalhar, depois Escavar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.BattleOrDelve=Escolha guerreiros inimigos para batalhar ou escolha uma relíquia para escavar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.Delve=Escolha uma relíquia para Escavar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoBattleDelve=Nenhuma Batalha, depois Escavar possível
-tuber.canis.abilities.KeepersInIronAbilities.KeepersBattleDelveAbility.ChooseBattleEnemy=Escolha um inimigo para batalhar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseMoveRecover=Escolha guerreiros para Mover ou uma relíquia para Recuperar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseRecover=Escolha uma relíquia para recuperar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoveRecover=Nenhum movimento ou recuperação possível
-tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseStarting=Escolha uma clareira para posicionar quatro guerreiros
-tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseSecond=Escolha uma clareira vizinha para posicionar quatro guerreiros
-tuber.canis.undo.KeepersSetupUndo=Pressione o botão continuar para concluir a preparação.
-tuber.canis.actions.KeepersInIronActions.KeepersRelicDestroyed=Escolha uma floresta para posicionar esta relíquia
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.AddOrShift=Adicione cartas ao seu Séquito (máximo 10) ou mova 1 carta dentro dele
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Add=Adicione cartas ao seu Séquito (máximo 10)
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Shift=Mova uma carta no seu Séquito
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.None=Nenhuma modificação de Séquito possível
-tuber.canis.undo.HundredsSetupUndo=Pressione o botão continuar para concluir a preparação.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsSetup.ChooseStarting=Escolha uma clareira para posicionar seu Senhor da Guerra, quatro guerreiros e uma fortaleza
-tooltip.playmat.relicstack=<size=125%><b>Relíquias</b></size>
+shortfactionnames.RiverfolkCompany=Ribeirinhos
+shortfactionnames.lizardcult=Lagartos Cultistas
 root.vagabond.adventurer=Aventureiro
 root.vagabond.adventurer.ability.title=Improvisar
 root.vagabond.adventurer.ability.title.required=Improvisar Necessário
-root.vagabond.adventurer.ability.text=Uma vez por turno, você pode danificar qualquer item para tratá-lo como outro item para uma missão.
-root.vagabond.harrier=Batedor
-root.vagabond.harrier.ability.title=Planar
+root.vagabond.adventurer.ability.text=Uma vez por turno, você pode danificar qualquer item para tratá-lo como outro item para uma tarefa.
+root.vagabond.harrier=Saqueador
+root.vagabond.harrier.ability.title=Esgueirar
 root.vagabond.harrier.ability.text=Mova-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
 root.vagabond.ronin=Ronin
 root.vagabond.ronin.ability.title=Golpe Rápido
 root.vagabond.ronin.ability.text=Em batalha, você pode exaurir uma espada para causar um golpe extra.
-tuber.canis.abilities.VagabondAbilities.GlideAbility.Destination=Escolha uma clareira para planar.
+tuber.canis.abilities.VagabondAbilities.GlideAbility.Destination=Escolha uma clareira para se esgueirar.
 vagabond.swiftstrike.activate=Gostaria de exaurir uma espada para causar um golpe extra?
-vagabond.improvise.activate=Gostaria de Improvisar esta missão?
+vagabond.improvise.activate=Gostaria de Improvisar esta tarefa?
 vagabond.improvise.item=Escolha um item para danificar para Improvisar.
 vagabond.improvise.item.opponent=[player] está escolhendo um item para danificar para Improvisar.
-vagabond.improvise.item.quest=Escolha qual item de missão exaurir.
-Log.Quest.Improvise=[faction name] Improvisou, exaurindo um [item icon] e danificando um [item icon 2] para completar a missão [name].
+vagabond.improvise.item.quest=Escolha qual item de tarefa para exaurir.
+Log.Quest.Improvise=[faction name] Improvisou, exaurindo um [item icon] e danificando um [item icon 2] para completar a tarefa [name].
 log.vagabond.ronin.ability=[faction name] usou Golpe Rápido, exaurindo [item icon] para adicionar um golpe adicional.
-log.vagabond.harrier.ability=[faction name] usou Planar para mover-se, planando pelo céu.
-tooltip.ability.vagabond.glide=<size=125%><b>Planar</b></size> - Exaure <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
-tooltip.ui.vagabond.Vagabond_Adventurer=<size=125%><b>Aventureiro</b></size>\n<b>Improvisar</b> — Uma vez por turno, você pode danificar qualquer item para tratá-lo como outro item para uma missão.
-tooltip.ui.vagabond.Vagabond_Harrier=<size=125%><b>Batedor</b></size>\n<b>Planar</b> — Exaure <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
-tooltip.ui.vagabond.Vagabond_Ronin=<size=125%><b>Ronin</b></size>\n<b>Golpe Rápido</b> — Em batalha, você pode exaurir uma espada para causar um golpe extra.
-tooltip.ui.vagabond.SecondVagabond_Harrier=<size=125%><b>Batedor</b></size>\n<b>Planar</b> — Exaure <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
-tooltip.ui.vagabond.SecondVagabond_Ronin=<size=125%><b>Ronin</b></size>\n<b>Golpe Rápido</b> — Em batalha, você pode exaurir uma espada para causar um golpe extra.
-tooltip.ui.vagabond.SecondVagabond_Adventurer=<size=125%><b>Aventureiro</b></size>\n<b>Improvisar</b> — Uma vez por turno, você pode danificar qualquer item para tratá-lo como outro item para uma missão.
+log.vagabond.harrier.ability=[faction name] usou Esgueirar para mover-se, planando pelo céu.
+tooltip.ability.vagabond.glide=<size=125%><b>Esgueirar</b></size> - Exaura <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
+tooltip.ui.vagabond.Vagabond_Adventurer=<size=125%><b>Aventureiro</b></size>\n<b>Improvisar</b> — Uma vez por turno, você pode danificar qualquer item para tratá-lo como outro item para uma tarefa.
+tooltip.ui.vagabond.Vagabond_Harrier=<size=125%><b>Saqueador</b></size>\n<b>Esgueirar</b> — Exaura <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
+tooltip.ui.vagabond.Vagabond_Ronin=<size=125%><b>Ronin</b></size>\n<b>Ataque Rápido</b> — Em batalha, você pode exaurir uma espada para causar um golpe extra.
+tooltip.ui.vagabond.SecondVagabond_Harrier=<size=125%><b>Saqueador</b></size>\n<b>Esgueirar</b> — Exaura <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
+tooltip.ui.vagabond.SecondVagabond_Ronin=<size=125%><b>Ronin</b></size>\n<b>Ataque Rápido</b> — Em batalha, você pode exaurir uma espada para causar um golpe extra.
+tooltip.ui.vagabond.SecondVagabond_Adventurer=<size=125%><b>Aventureiro</b></size>\n<b>Improvisar</b> — Uma vez por turno, você pode danificar qualquer item para tratá-lo como outro item para uma tarefa.
 vagabond.title.Vagabond_Adventurer=Aventureiro
 vagabond.title.Vagabond_Ronin=Ronin
-vagabond.title.Vagabond_Harrier=Batedor
-vagabond.title.SecondVagabond_Harrier=Batedor
+vagabond.title.Vagabond_Harrier=Saqueador
+vagabond.title.SecondVagabond_Harrier=Saqueador
 vagabond.title.SecondVagabond_Ronin=Ronin
 vagabond.title.SecondVagabond_Adventurer=Aventureiro
-vagabond.swiftstrike.activate.opponent=Ronin Malandro está considerando Golpe Rápido.
+vagabond.swiftstrike.activate.opponent=Malandro Ronin está considerando Ataque Rápido.
 vagabond.improvise.item.quest.opponent=[player] está escolhendo um item para exaurir para Improvisar.
-vagabond.improvise.activate.opponent=Malandro está escolhendo uma missão para completar.
-tooltip.swiftstrike.battle=<size=125%><b>Golpe Rápido:</b></size><br>Exaure uma espada para causar um golpe extra.
-root.cardname.exilesandpartisans.boatbuilders=Construtores de Barcos
+vagabond.improvise.activate.opponent=Malandro está escolhendo uma tarefa para completar.
+tooltip.swiftstrike.battle=<size=125%><b>Golpe Rápido:</b></size><br>Exaura uma espada para causar um golpe extra.
+root.cardname.exilesandpartisans.boatbuilders=Construtores Navais
 root.cardtext.exilesandpartisans.boatbuilders.any=Você trata rios como caminhos.
-root.cardname.exilesandpartisans.charmoffensive=Ofensiva Encantadora
+root.cardname.exilesandpartisans.charmoffensive=Charme Ofensivo
 root.cardtext.exilesandpartisans.charmoffensive.any=No início do Anoitecer, pode comprar uma carta e escolher outro jogador para pontuar um ponto.
-root.cardname.exilesandpartisans.coffinmakers=Fabricantes de Caixões
-root.cardtext.exilesandpartisans.coffinmakers.any=Sempre que guerreiros voltarem para a reserva, posicione-os nesta carta. No início da Alvorada, você pontua um ponto a cada cinco guerreiros aqui, depois retorna todos os guerreiros aqui para suas reservas.
+root.cardname.exilesandpartisans.coffinmakers=Coveiros
+root.cardtext.exilesandpartisans.coffinmakers.any=Sempre que guerreiros voltarem para a reserva, posicione-os nesta carta. No início do Amanhecer, você pontua um ponto a cada cinco guerreiros aqui, depois retorna todos os guerreiros aqui para suas reservas.
 root.cardname.exilesandpartisans.corvidplanners=Planejadores Corvídeos
 root.cardtext.exilesandpartisans.corvidplanners.any=Ao mover-se, você ignora governar.
-root.cardname.exilesandpartisans.eyrieemigre=Emigrante das Rapinas
-root.cardtext.exilesandpartisans.eyrieemigre.any=No final da Alvorada, faça um movimento e depois inicie uma batalha na clareira para onde se moveu. Se não realizar ambas as ações, descarte esta carta.
-root.cardname.exilesandpartisans.falseorders=Ordens Falsas
-root.cardtext.exilesandpartisans.falseorders.any=Na Alvorada, pode descartar esta carta para mover metade dos guerreiros de um inimigo (arredondado para cima) de qualquer clareira, tratando-se como aquele jogador e ignorando governar.
-root.cardname.exilesandpartisans.foxpartisans=Partidários da Raposa
+root.cardname.exilesandpartisans.eyrieemigre=Imigrante Rapina
+root.cardtext.exilesandpartisans.eyrieemigre.any=No final do Amanhecer, faça um movimento e depois inicie uma batalha na clareira para onde se moveu. Se não realizar ambas as ações, descarte esta carta.
+root.cardname.exilesandpartisans.falseorders=Ordens Falsificadas
+root.cardtext.exilesandpartisans.falseorders.any=No Amanhecer, pode descartar esta carta para mover metade dos guerreiros de um inimigo (arredondado para cima) de qualquer clareira, tratando-se como aquele jogador e ignorando governar.
+root.cardname.exilesandpartisans.foxpartisans=Partisans Raposas
 root.cardtext.exilesandpartisans.foxpartisans.any=Em batalha em clareiras de raposa, pode causar um golpe extra e depois descartar todas as suas cartas, exceto as de raposa.
 root.cardname.exilesandpartisans.informants=Informantes
 root.cardtext.exilesandpartisans.informants.any=No Anoitecer, se você fosse comprar cartas, pode em vez disso pegar uma carta de emboscada do monte de descarte.
-root.cardname.exilesandpartisans.leagueofadventurousmice=Liga dos Camundongos Aventureiros
+root.cardname.exilesandpartisans.leagueofadventurousmice=Liga dos Ratos Aventureiros
 root.cardtext.exilesandpartisans.leagueofadventurousmice.any=Uma vez durante o Dia, pode exaurir um item na sua caixa de Itens Criados para se mover ou iniciar uma batalha.
-root.cardname.exilesandpartisans.masterengravers=Gravadores Mestres
+root.cardname.exilesandpartisans.masterengravers=Mestre Escultor
 root.cardtext.exilesandpartisans.masterengravers.any=Sempre que você criar um item, pontue um ponto extra.
-root.cardname.exilesandpartisans.mousepartisans=Partidários de Rato
+root.cardname.exilesandpartisans.mousepartisans=Partisans Ratos
 root.cardtext.exilesandpartisans.mousepartisans.any=Em batalha em clareiras de rato, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de rato.
-root.cardname.exilesandpartisans.murinebroker=Corretor Murino
+root.cardname.exilesandpartisans.murinebroker=Camundongo Receptador
 root.cardtext.exilesandpartisans.murinebroker.any=Sempre que outro jogador criar um item, compre uma carta.
 root.cardname.exilesandpartisans.propagandabureau=Escritório de Propaganda
 root.cardtext.exilesandpartisans.propagandabureau.any=Uma vez durante o Dia, pode gastar uma carta para remover um guerreiro inimigo de uma clareira correspondente e posicionar um guerreiro lá.
-root.cardname.exilesandpartisans.rabbitpartisans=Partidários de Coelho
+root.cardname.exilesandpartisans.rabbitpartisans=Partisans Coelhos
 root.cardtext.exilesandpartisans.rabbitpartisans.any=Em batalha em clareiras de coelho, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de coelho.
 root.cardname.exilesandpartisans.saboteurs=Sabotadores
-root.cardtext.exilesandpartisans.saboteurs.any=No início da Alvorada, pode descartar esta carta para descartar uma carta criada de um inimigo.
+root.cardtext.exilesandpartisans.saboteurs.any=No início do Amanhecer, pode descartar esta carta para descartar uma carta criada de um inimigo.
 root.cardname.exilesandpartisans.soupkitchens=Cozinhas Comunitárias
 root.cardtext.exilesandpartisans.soupkitchens.any=Seus marcadores agora contam para governar, e cada um de seus marcadores conta duas vezes.
-root.cardname.exilesandpartisans.swapmeet=Encontro Aleatório
-root.cardtext.exilesandpartisans.swapmeet.any=Uma vez durante a Alvorada, pode pegar uma carta aleatória de outro jogador e então dar uma carta a ele.
+root.cardname.exilesandpartisans.swapmeet=Escambo
+root.cardtext.exilesandpartisans.swapmeet.any=Uma vez durante o Amanhecer, pode pegar uma carta aleatória de outro jogador e então dar uma carta a ele.
 root.cardname.exilesandpartisans.tunnels=Túneis
 root.cardtext.exilesandpartisans.tunnels.any=Você trata clareiras com qualquer uma de suas peças de criação como adjacentes.
 tuber.canis.abilities.ExilesAndPartisansAbilities.CharmOffensiveAbility=Escolha um jogador para ganhar <sprite name="1VP">.
-tuber.canis.abilities.ExilesAndPartisansAbilities.CharmOffensiveAbility.opponent=[player] está escolhendo um oponente para ganhar <sprite name="1VP"> com Ofensiva Encantadora.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigreAbility.move=Selecione uma clareira de onde mover usando Emigrante das Rapinas.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigreAbility.move.opponent=[player] está escolhendo uma clareira de onde mover usando Emigrante das Rapinas.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.battle=Escolha um inimigo para batalhar usando Emigrante das Rapinas.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.battle.opponent=[player] está escolhendo um inimigo para batalhar usando Emigrante das Rapinas.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.confirmdiscard=Você não conseguiu se mover e/ou batalhar com Emigrante das Rapinas. Pressione continuar para descartá-lo.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.confirmdiscard.opponent=[player] deve descartar Emigrante das Rapinas, pois não conseguiu nem se mover nem batalhar com ele.
+tuber.canis.abilities.ExilesAndPartisansAbilities.CharmOffensiveAbility.opponent=[player] está escolhendo um oponente para ganhar <sprite name="1VP"> com Charme Ofensivo.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigreAbility.move=Selecione uma clareira de onde mover usando Imigrante Rapina.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigreAbility.move.opponent=[player] está escolhendo uma clareira de onde mover usando Imigrante Rapina.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.battle=Escolha um inimigo para batalhar usando Imigrante Rapina.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.battle.opponent=[player] está escolhendo um inimigo para batalhar usando Imigrante Rapina.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.confirmdiscard=Você não conseguiu se mover e/ou batalhar com Imigrante Rapina. Pressione continuar para descartá-lo.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.confirmdiscard.opponent=[player] deve descartar Imigrante Rapina, pois não conseguiu nem se mover nem batalhar com ele.
 tuber.canis.abilities.FalseOrdersAbility.destination=Selecione uma clareira para mover a metade.
-tuber.canis.abilities.FalseOrdersAbility.destination.opponent=[player] está escolhendo uma clareira para mover guerreiros inimigos com Ordens Falsas.
-tuber.canis.abilities.FalseOrdersAbility.origin=Selecione guerreiros para mover usando Ordens Falsas.
-tuber.canis.abilities.FalseOrdersAbility.origin.opponent=[player] está escolhendo guerreiros inimigos para mover com Ordens Falsas.
+tuber.canis.abilities.FalseOrdersAbility.destination.opponent=[player] está escolhendo uma clareira para mover guerreiros inimigos com Ordens Falsificadas.
+tuber.canis.abilities.FalseOrdersAbility.origin=Selecione guerreiros para mover usando Ordens Falsificadas.
+tuber.canis.abilities.FalseOrdersAbility.origin.opponent=[player] está escolhendo guerreiros inimigos para mover com Ordens Falsificadas.
 tuber.canis.abilities.ExilesAndPartisansAbilities.InformantsAbility=Escolha uma Emboscada para comprar.
 tuber.canis.abilities.ExilesAndPartisansAbilities.InformantsAbility.opponent=[player] está escolhendo uma emboscada para comprar do monte de descarte usando Informantes.
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.cost=Escolha um item para exaurir.
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.cost.opponent=[player] está escolhendo um item para exaurir com a Liga dos Camundongos Aventureiros.
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.cost.opponent=[player] está escolhendo um item para exaurir com a Liga dos Ratos Aventureiros.
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.move=Mover
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.move.opponent=[player] está escolhendo uma clareira para mover-se com a Liga dos Camundongos Aventureiros.
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.move.opponent=[player] está escolhendo uma clareira para mover-se com a Liga dos Ratos Aventureiros.
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.battle=Batalhar
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.battle.opponent=[player] está escolhendo uma clareira para batalhar com a Liga dos Camundongos Aventureiros.
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.battle.opponent=[player] está escolhendo uma clareira para batalhar com a Liga dos Ratos Aventureiros .
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.outcome=Escolha uma opção
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.outcome.opponent=[player] está escolhendo se move ou batalha com a Liga dos Camundongos Aventureiros.
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.outcome.opponent=[player] está escolhendo se move ou batalha com a Liga dos Ratos Aventureiros.
 button.move=Mover
 button.battle=Batalhar
 tuber.canis.abilities.PropagandaBureauAbility.warrior=Escolha um guerreiro para substituir por um seu.
@@ -1440,89 +1322,89 @@ tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.discard.oppon
 tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.player=Escolha um jogador para Sabotadores.
 tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.player.opponent=[player] está escolhendo um jogador para alvejar com Sabotadores.
 tuber.canis.abilities.SwapMeetAbility.give=Escolha uma carta para dar a [USERNAME].
-tuber.canis.abilities.SwapMeetAbility.give.opponent=[player] está escolhendo uma carta para dar com Encontro Aleatório.
+tuber.canis.abilities.SwapMeetAbility.give.opponent=[player] está escolhendo uma carta para dar com Escambo.
 tuber.canis.abilities.SwapMeetAbility.player=Escolha um jogador para trocar uma carta.
 tuber.canis.abilities.SwapMeetAbility.player.opponent=[player] está escolhendo um jogador para trocar uma carta.
 Log.BoatBuilders=
-Log.CharmOffensive=[faction name] usa Ofensiva Encantadora para comprar uma carta e dar [faction name 2] 1 <style="vptext">PV</style>.
-Log.CoffinMakers.Warriors=[X] guerreiros removidos foram posicionados em Fabricantes de Caixões em vez da reserva.
-Log.CoffinMakers.Warriors.One=Um guerreiro removido foi posicionado em Fabricantes de Caixões em vez da reserva.
-Log.CoffinMakers.Points=[faction name] pontua [X] <style="vptext">PV</style> com Fabricantes de Caixões. [X2] guerreiros em Fabricantes de Caixões foram devolvidos à reserva.
-Log.CoffinMakers.Points.One=[faction name] pontua [X] <style="vptext">PV</style> com Fabricantes de Caixões. Um guerreiro em Fabricantes de Caixões foi devolvido à reserva.
-Log.EyrieEmigre.Move=[faction name] usa Emigrante das Rapinas para mover [X] guerreiros para uma clareira de [suit icon], mas não batalha.
-Log.EyrieEmigre.Move.One=[faction name] usa Emigrante das Rapinas para mover 1 guerreiro para uma clareira de [suit icon], mas não batalha.
-Log.EyrieEmigre.Battle=[faction name] usa Emigrante das Rapinas para mover [X] guerreiros para uma clareira de [suit icon] e batalhar contra [faction name 2].
-Log.EyrieEmigre.Battle.One=[faction name] usa Emigrante das Rapinas para mover 1 guerreiro para uma clareira de [suit icon] e batalhar contra [faction name 2].
-Log.EyrieEmigre.Discard=[faction name] descarta seu Emigrante das Rapinas, pois não se moveu nem batalhou com ele.
-Log.FalseOrdersAbility=[faction name] descarta Ordens Falsas para mover [X] guerreiros de [faction name 2] para uma clareira de [suit icon].
+Log.CharmOffensive=[faction name] usa Charme Ofensivo para comprar uma carta e dar [faction name 2] 1 <style="vptext">PV</style>.
+Log.CoffinMakers.Warriors=[X] guerreiros removidos foram posicionados em Coveiros em vez da reserva.
+Log.CoffinMakers.Warriors.One=Um guerreiro removido foi posicionado em Coveiros em vez da reserva.
+Log.CoffinMakers.Points=[faction name] pontua [X] <style="vptext">PV</style> com Coveiros. [X2] guerreiros em Coveiros foram devolvidos à reserva.
+Log.CoffinMakers.Points.One=[faction name] pontua [X] <style="vptext">PV</style> com Coveiros. Um guerreiro em Coveiros foi devolvido à reserva.
+Log.EyrieEmigre.Move=[faction name] usa Imigrante Rapina para mover [X] guerreiros para uma clareira de [suit icon], mas não batalha.
+Log.EyrieEmigre.Move.One=[faction name] usa Imigrante Rapina para mover 1 guerreiro para uma clareira de [suit icon], mas não batalha.
+Log.EyrieEmigre.Battle=[faction name] usa Imigrante Rapina para mover [X] guerreiros para uma clareira de [suit icon] e batalhar contra [faction name 2].
+Log.EyrieEmigre.Battle.One=[faction name] usa Imigrante Rapina para mover 1 guerreiro para uma clareira de [suit icon] e batalhar contra [faction name 2].
+Log.EyrieEmigre.Discard=[faction name] descarta seu Imigrante Rapina, pois não se moveu nem batalhou com ela.
+Log.FalseOrdersAbility=[faction name] descarta Ordens Falsificadas para mover [X] guerreiros de [faction name 2] para uma clareira de [suit icon].
 Log.Informants=[faction name] compra uma emboscada de [suit icon] do monte de descarte usando Informantes.
-Log.LeagueOfAdventurousMice=[faction name] exaure [item icon] para usar a Liga dos Camundongos Aventureiros.
-Log.MasterEngravers=[faction name] ganha 1 <style="vptext">PV</style> por criar um item com Gravadores Mestres.
-Log.MurineBroker=[faction name] compra uma carta com Corretor Murino a partir de um item criado.
+Log.LeagueOfAdventurousMice=[faction name] exaure [item icon] para usar a Liga dos Ratos Aventureiros.
+Log.MasterEngravers=[faction name] ganha 1 <style="vptext">PV</style> por criar um item com Mestre Escultor.
+Log.MurineBroker=[faction name] compra uma carta com Camundongo Receptador a partir de um item criado.
 Log.Partisans=[faction name] descarta [cardnames] para causar um golpe extra com [name].
 Log.PropagandaBureauAbility=[faction name] usa Escritório de Propaganda para descartar [name], substituindo um guerreiro de [faction name 2] por um dos seus em uma clareira de [suit icon].
 Log.PropagandaBureauAbility.NoReplacement=[faction name] usa Escritório de Propaganda para descartar [name], apenas removendo um guerreiro de [faction name 2].
 Log.SaboteursAbility=[faction name] descarta Sabotadores para descartar [name] de [faction name 2].
-Log.SwapMeetAbility=[faction name] usa Encontro Aleatório para trocar uma carta com [faction name 2].
-Log.Tunnels=
+Log.SwapMeetAbility=[faction name] usa Escambo para trocar uma carta com [faction name 2].
+Log.Tunnels=[faction name] se moveu usando Túneis.
 warning.unusable=Sua facção não pode usar a habilidade desta carta. Tem certeza de que deseja criá-la?
 warning.unusable.opponent=O oponente está considerando criar
 warning.unusable.boat=Sua facção já possui esta habilidade. Tem certeza de que deseja criá-la?
 warning.unusable.boat.opponent=O oponente está considerando criar
 playmat.saboteursdiscard=Descartado por Sabotadores!
 tooltip.ui.enp=Baralho Utilizado
-tooltip.partisanbunny.battle=<size=125%><b>Partidários de Coelho:</b></size><br>Em batalha em clareiras de coelho, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de coelho.
-tooltip.partisanmouse.battle=<size=125%><b>Partidários de Rato:</b></size><br>Em batalha em clareiras de rato, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de rato.
-tooltip.partisanfox.battle=<size=125%><b>Partidários de Raposa:</b></size><br>Em batalha em clareiras de raposa, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de raposa.
+tooltip.partisanbunny.battle=<size=125%><b>Partisans Coelho:</b></size><br>Em batalha em clareiras de coelho, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de coelho.
+tooltip.partisanmouse.battle=<size=125%><b>Partisans Ratos:</b></size><br>Em batalha em clareiras de rato, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de rato.
+tooltip.partisanfox.battle=<size=125%><b>Partisans Raposas:</b></size><br>Em batalha em clareiras de raposa, pode causar um golpe extra e depois descartar todas as suas cartas, exceto de raposa.
 aiplayername.corvidconspiracy=Conspiração Corvídea
 aiplayername.undergroundduchy=Ducado Subterrâneo
-battledamage.fx.embeddedagents=Agentes Infiltrados!
+battledamage.fx.embeddedagents=Agentes Escondidos!
 battledamage.fx.offensiveagents=Agentes Ofensivos!
-cct.Birdsong.t1.recruit=Agora o jogo realmente começou. Durante a Alvorada, você pode gastar uma carta da sua mão para posicionar um <sprite name="corvid"><color=#6B5182>guerreiro</color> em cada clareira correspondente ao seu naipe.
-cct.Birdsong.t2.craft=Seus <color=#6B5182>complôs</color> no mapa (revelados ou não) contribuem com o naipe de sua clareira para criar durante a Alvorada.
-cct.Birdsong.t2.flip.1=A seguir, você pode revelar <color=#6B5182>complôs</color> em clareiras onde tiver ao menos um <sprite name="corvid"><color=#6B5182>guerreiro</color>. Comece revelando seu <sprite name="plot_extortion"> <color=#6B5182>Complô de Extorsão</color> para roubar uma carta.<br>Cada <sprite name="plot_extortion"> revelado também comprará uma carta extra no Anoitecer.
-cct.Birdsong.t2.flip.2=Ao revelar um <sprite name="Plot"> <color=#6B5182>complô</color>, você pontua <sprite name="1VP"> por cada <sprite name="Plot"> <color=#6B5182>marcador de complô</color> revelado no mapa.
+cct.Birdsong.t1.recruit=Agora o jogo realmente começou. Durante o Amanhecer, você pode gastar uma carta da sua mão para posicionar um <sprite name="corvid"><color=#6B5182>guerreiro</color> em cada clareira correspondente ao seu naipe.
+cct.Birdsong.t2.craft=Suas <color=#6B5182>tramas</color> no mapa (reveladas ou não) contribuem com o naipe de sua clareira para criar durante o Amanhecer.
+cct.Birdsong.t2.flip.1=A seguir, você pode revelar <color=#6B5182>tramas</color> em clareiras onde tiver ao menos um <sprite name="corvid"><color=#6B5182>guerreiro</color>. Comece revelando sua <sprite name="plot_extortion"> <color=#6B5182>Trama de Extorsão</color> para roubar uma carta.<br>Cada <sprite name="plot_extortion"> revelada também comprará uma carta extra no Anoitecer.
+cct.Birdsong.t2.flip.2=Ao revelar uma <sprite name="Plot"> <color=#6B5182>trama</color>, você pontua <sprite name="1VP"> por cada <sprite name="Plot"> <color=#6B5182>marcador de trama</color> revelado no mapa.
 cct.Birdsong.t2.recruit=Por fim, vamos descartar uma carta para recrutar novamente. Faça isso agora em clareiras de <sprite name="ClearingMouse"> rato.
-cct.Birdsong.t3.flip.1=Não temos nada a criar neste turno, então pulamos para revelar <color=#6B5182>complôs</color>. <color=#6B5182>Revele</color> seu <sprite name="plot_snare"> <color=#6B5182>Complô de Armadilha</color> para ativar seu efeito de aprisionamento de <sprite name="corvid"><color=#6B5182>guerreiro</color> e ganhar <sprite name="2VP">.
-cct.Birdsong.t3.flip.2=Lembre-se, quando você revelar um <color=#6B5182>complot</color>, você pontua <sprite name="1VP"> para cada marcador de <color=#6B5182>complot</color> revelado no mapa. Quanto mais marcadores de <color=#6B5182>complot</color> você mantiver defendidos, maior será seu potencial de pontuação.
-cct.Birdsong.t3.flip.3=Agora, revele seu <sprite name="plot_raid"> <color=#6B5182>Complot de Saque</color> para pontuar <sprite name="3VP">. Seu efeito ocorre apenas quando removido do mapa, mas revelá-lo ainda é útil para pontuar.
+cct.Birdsong.t3.flip.1=Não temos nada a criar neste turno, então pulamos para revelar <color=#6B5182>tramas</color>. <color=#6B5182>Revele</color> sua <sprite name="plot_snare"> <color=#6B5182>Trama de Armadilha</color> para ativar seu efeito de aprisionamento de <sprite name="corvid"><color=#6B5182>guerreiro</color> e ganhar <sprite name="2VP">.
+cct.Birdsong.t3.flip.2=Lembre-se, quando você revelar uma <color=#6B5182>trama</color>, você pontua <sprite name="1VP"> para cada marcador de <color=#6B5182>trama</color> revelado no mapa. Quanto mais marcadores de <color=#6B5182>trama</color> você mantiver defendidos, maior será seu potencial de pontuação.
+cct.Birdsong.t3.flip.3=Agora, revele sua <sprite name="plot_raid"> <color=#6B5182>Trama de Ataque</color> para pontuar <sprite name="3VP">. Seu efeito ocorre apenas quando removido do mapa, mas revelá-lo ainda é útil para pontuar.
 cct.Birdsong.t3.recruit=Recrute em clareiras <sprite name="ClearingMouse">.
-cct.Birdsong.t4.flip=Não podemos revelar nosso <sprite name="plot_bomb"> <color=#6B5182>Complot de Bomba</color> porque não temos um <sprite name="corvid"><color=#6B5182>guerreiro</color> lá. Mas não se preocupe! É melhor esperar para revelar um <sprite name="plot_bomb"> em clareiras com peças inimigas para destruí-las.
+cct.Birdsong.t4.flip=Não podemos revelar nossa <sprite name="plot_bomb"> <color=#6B5182>Trama de Bomba</color> porque não temos um <sprite name="corvid"><color=#6B5182>guerreiro</color> lá. Mas não se preocupe! É melhor esperar para revelar uma <sprite name="plot_bomb"> em clareiras com peças inimigas para destruí-las.
 cct.Birdsong.t4.recruit=Envie seus <sprite name="corvid"><color=#6B5182>guerreiros</color> para as clareiras <sprite name="ClearingFox">.
-cct.Daylight.t1.actions=Durante o Dia, podemos realizar até 3 das seguintes ações.<br><sprite name="UIMoveToken">Mover<br><sprite name="UIBattleToken">Batalha<br><sprite name="CorvidPlotToken">Complot<br><sprite name="CorvidTrickToken">Truque<br>
+cct.Daylight.t1.actions=Durante o Dia, podemos realizar até 3 das seguintes ações:<br><sprite name="UIMoveToken">Mover<br><sprite name="UIBattleToken">Batalhar<br><sprite name="CorvidPlotToken">Tramar<br><sprite name="CorvidTrickToken">Despistar<br>
 cct.Daylight.t1.move.1=Use a ação Mover para consolidar seus <sprite name="corvid"><color=#6B5182>guerreiros</color> em uma clareira mais próxima do seu inimigo.
 cct.Daylight.t1.move.2=Mova-se novamente para continuar sua marcha em direção às forças da <color=#336699>Dinastia das Rapinas</color>.
-cct.Daylight.t1.plot=Vamos começar com o que nós <color=#6B5182>Corvídeos</color> fazemos de melhor, conspirar!
-cct.Daylight.t1.plot.extortion=Temos uma variedade de <color=#6B5182>complots</color> à nossa disposição. <sprite name="plot_extortion"> <color=#6B5182>Extorquir</color> a <color=#336699>Dinastia</color> para melhorar nosso fluxo de cartas.
-cct.Daylight.t1.plot.hidden=A <color=#336699>Dinastia</color> pode ver que um <color=#6B5182>complot</color> foi tramado, mas não saberá o tipo de <color=#6B5182>complot</color> até que você escolha revelá-lo.
-cct.Daylight.t1.plot.sacrifice=Conspirar requer sacrifício. Seu primeiro <color=#6B5182>complot</color> do turno custa um <sprite name="corvid"><color=#6B5182>guerreiro</color> na clareira onde ele é posicionado. Cada <color=#6B5182>complot</color> sucessivo custará um <sprite name="corvid"><color=#6B5182>guerreiro</color> a mais que o anterior.
-cct.Daylight.t2.bird.expose=Que <color=#6B5182>complot</color> é este que você tramou perto do nosso <sprite name="Roost"><color=#336699>ninho</color>? Isso não pode continuar! Deve ser exposto!
+cct.Daylight.t1.plot=Vamos começar com o que nós <color=#6B5182>Corvídeos</color> fazemos de melhor, tramar!
+cct.Daylight.t1.plot.extortion=Temos uma variedade de <color=#6B5182>tramas</color> à nossa disposição. Use <sprite name="plot_extortion"> <color=#6B5182>Extorsão</color> contra a <color=#336699>Dinastia</color> para melhorar nosso fluxo de cartas.
+cct.Daylight.t1.plot.hidden=A <color=#336699>Dinastia</color> pode ver que uma <color=#6B5182>trama</color> foi armada, mas não saberá o tipo de <color=#6B5182>trama</color> até que você escolha revelá-la.
+cct.Daylight.t1.plot.sacrifice=Conspirar requer sacrifício. Sua primeira <color=#6B5182>trama</color> do turno custa um <sprite name="corvid"><color=#6B5182>guerreiro</color> na clareira onde ela é posicionada. Cada <color=#6B5182>trama</color> sucessiva custará um <sprite name="corvid"><color=#6B5182>guerreiro</color> a mais que a anterior.
+cct.Daylight.t2.bird.expose=Que <color=#6B5182>trama</color> é esta que você tramou perto do nosso <sprite name="Roost"><color=#336699>ninho</color>? Isso não pode continuar! Deve ser exposta!
 cct.Daylight.t2.bird.guess=Aposto que vocês, astutos <sprite name="corvid"><color=#6B5182>Corvídeos</color>, colocaram uma <sprite name="plot_snare"> <color=#6B5182>Armadilha</color> no nosso <sprite name="Roost"><color=#336699>ninho</color>!
-cct.Daylight.t2.embedded=Uma defesa inabalável! Sua habilidade <sprite name="EmbeddedAgents"> <color=#6B5182>Agentes Infiltrados</color> adiciona um acerto às batalhas defensivas em que você tenha um marcador de <color=#6B5182>complot</color> oculto.
-cct.Daylight.t2.exposure.1=Antes de comprar cartas durante o Anoitecer, um inimigo pode tentar <color=#6B5182>Expor</color> seu <color=#6B5182>complot</color> ao adivinhar corretamente qual é o tipo de <color=#6B5182>complot</color>. Como custo, ele deve revelar uma carta que corresponda ao naipe da clareira.
-cct.Daylight.t2.exposure.2=Se ele estiver correto, você deve descartar seu <color=#6B5182>complot</color>, ignorando seu efeito. Se ele errar, você ganha a carta revelada.
+cct.Daylight.t2.embedded=Uma defesa inabalável! Sua habilidade <sprite name="EmbeddedAgents"> <color=#6B5182>Agentes Escondidos</color> adiciona um acerto às batalhas defensivas em que você tenha um marcador de <color=#6B5182>trama</color> oculto.
+cct.Daylight.t2.exposure.1=Antes de comprar cartas durante o Anoitecer, um inimigo pode tentar <color=#6B5182>Expôr</color> sua <color=#6B5182>trama</color> ao adivinhar corretamente qual é o tipo de <color=#6B5182>trama</color>. Como custo, ele deve revelar uma carta que corresponda ao naipe da clareira.
+cct.Daylight.t2.exposure.2=Se ele estiver correto, você deve descartar sua <color=#6B5182>trama</color>, ignorando seu efeito. Se ele errar, você ganha a carta revelada.
 cct.Daylight.t2.exposure.result=A brigada <color=#336699>Dinastia</color> caiu no nosso blefe. Eles erraram, e nós ficamos com a carta deles.
-cct.Daylight.t2.move.1=Para sua primeira ação do Dia, mova seus <sprite name="corvid"><color=#6B5182>guerreiros</color> para o <sprite name="Roost"><color=#336699>ninho</color> inicial da <color=#336699>Dinastia</color> para preparar novos <color=#6B5182>complots</color>.
-cct.Daylight.t2.plot.raid=Coloque um <sprite name="plot_raid"> <color=#6B5182>Complot de Saque</color> onde você moveu seus <sprite name="corvid"><color=#6B5182>guerreiros</color>. Se ele for removido em um ataque, você posiciona um <color=#6B5182>guerreiro</color> em cada clareira adjacente.
+cct.Daylight.t2.move.1=Para sua primeira ação do Dia, mova seus <sprite name="corvid"><color=#6B5182>guerreiros</color> para o <sprite name="Roost"><color=#336699>ninho</color> inicial da <color=#336699>Dinastia</color> para preparar novas <color=#6B5182>tramas</color>.
+cct.Daylight.t2.plot.raid=Coloque uma <sprite name="plot_raid"> <color=#6B5182>Trama de Ataque</color> onde você moveu seus <sprite name="corvid"><color=#6B5182>guerreiros</color>. Se ela for removida em um ataque, você posiciona um <color=#6B5182>guerreiro</color> em cada clareira adjacente.
 cct.Daylight.t2.plot.snare=Em seguida, removeremos 2 <sprite name="corvid"><color=#6B5182>guerreiros</color> para montar uma <sprite name="plot_snare"> <color=#6B5182>Armadilha</color> para a <color=#336699>Dinastia</color>. Quando revelada, ela impedirá que inimigos movam guerreiros para fora da clareira ou coloquem novas peças lá.
 cct.Daylight.t3.bird.turmoil=O <color=#336699>Déspota</color> falhou conosco. É hora de trazer um verdadeiro líder, o <color=#336699>Comandante</color>.
 cct.Daylight.t3.move=Use sua próxima ação para consolidar seus <sprite name="corvid"><color=#6B5182>guerreiros</color>.
-cct.Daylight.t3.plot=Ao posicionar um <color=#6B5182>complot</color>, você deve escolher uma clareira que não tenha um já existente.
-cct.Daylight.t3.plot.bomb=Coloque o <sprite name="plot_bomb"> <color=#6B5182>Complot de Bomba</color> para ver se podemos causar uma grande explosão!
-cct.Daylight.t3.trick.1=Finalmente, enganaremos a <color=#336699>Dinastia</color> e a levaremos ao <color=#336699>Caos</color>. Use <color=#6B5182>Truque</color> para trocar a localização do seu <sprite name="plot_raid"> <color=#6B5182>Complot de Saque</color> revelado com o <sprite name="plot_snare"> <color=#6B5182>Complot de Armadilha</color>.
-cct.Daylight.t3.trick.2=O <sprite name="plot_snare"> <color=#6B5182>Armadilha</color> os impedirá de se mover daquela clareira ou recrutar <sprite name="corvid"><color=#6B5182>guerreiros</color> nela. Isso deve causar problemas e levá-los ao <color=#336699>Caos</color>.
+cct.Daylight.t3.plot=Ao posicionar uma <color=#6B5182>trama</color>, você deve escolher uma clareira que não tenha uma já existente.
+cct.Daylight.t3.plot.bomb=Coloque a <sprite name="plot_bomb"> <color=#6B5182>Trama de Bomba</color> para ver se podemos causar uma grande explosão!
+cct.Daylight.t3.trick.1=Finalmente, enganaremos a <color=#336699>Dinastia</color> e a levaremos ao <color=#336699>Tumulto</color>. Use <color=#6B5182>Despistar</color> para trocar a localização da sua <sprite name="plot_raid"> <color=#6B5182>Trama de Ataque</color> revelada com a <sprite name="plot_snare"> <color=#6B5182>Trama de Armadilha</color>.
+cct.Daylight.t3.trick.2=O <sprite name="plot_snare"> <color=#6B5182>Armadilha</color> os impedirá de se mover daquela clareira ou recrutar <sprite name="corvid"><color=#6B5182>guerreiros</color> nela. Isso deve causar problemas e levá-los ao <color=#336699>Tumulto</color>.
 cct.Daylight.t4.battle.1=Agora que estamos em posição, é hora de lutar!
 cct.Daylight.t4.battle.2=O <sprite name="Roost"><color=#336699>ninho</color> deles está indefeso! Ataque novamente para finalizar.
 cct.Daylight.t4.move=Com a liderança do seu inimigo em desordem, é o momento perfeito para uma demonstração de força. Mova seus <sprite name="corvid"><color=#6B5182>guerreiros</color> para levar a batalha até a <color=#336699>Dinastia das Rapinas</color>.
-cct.Daylight.t4.nimble=Que movimento ágil o seu! Assim como o <color=#4E6F89>Malandro</color>, os <color=#6B5182>guerreiros Corvídeos <sprite name="corvid"> </color> movem-se sem restrições de controle de clareiras.
+cct.Daylight.t4.nimble=Que movimento Ágil o seu! Assim como o <color=#4E6F89>Malandro</color>, os <color=#6B5182>guerreiros Corvídeos <sprite name="corvid"> </color> movem-se sem restrições de controle de clareiras.
 cct.Daylight.t4.offrails=Você deve estar em uma posição forte para assumir o controle daqui. Pontue <style="vpnumddteen">15</style> ou destrua peças inimigas com uma <sprite name="plot_bomb"> <color=#6B5182>Bomba</color> para concluir este cenário.
 cct.Evening.t1.draw=Anoitecer se aproxima. Com suas ações de Dia concluídas, você comprará uma carta e passará a vez para a <color=#336699>Dinastia das Rapinas</color>.
-cct.Evening.t2.end=Parece que todas as peças estão no lugar. Mas antes que nossos <color=#6B5182>complôs</color> entrem em ação, precisamos passar a vez para a <color=#336699>Dinastia das Rapinas</color> realizar seu turno.
-cct.Evening.t2.exert=No Anoitecer, você pode pular a compra de cartas para <sprite name="CorvidExertToken"> <color=#6B5182>Exercer</color> uma ação extra. Temos mais a fazer, então vamos em frente.
+cct.Evening.t2.end=Parece que todas as peças estão no lugar. Mas antes que nossas <color=#6B5182>tramas</color> entrem em ação, precisamos passar a vez para a <color=#336699>Dinastia das Rapinas</color> realizar seu turno.
+cct.Evening.t2.exert=No Anoitecer, você pode pular a compra de cartas para <sprite name="CorvidExertToken"> <color=#6B5182>Exceder</color> uma ação extra. Temos mais a fazer, então vamos em frente.
 cct.Evening.t2.move=Mova um <sprite name="corvid"><color=#6B5182>guerreiro</color> até nossa <sprite name="plot_snare"> <color=#6B5182>Armadilha</color> para garantir que teremos o <sprite name="corvid"><color=#6B5182>guerreiro</color> necessário para revelá-la no próximo turno.
 cct.goal.15vp=Pontue <style="vpnumddteen">15</style> ({0}/{1})<br><br>-OU-<br><br>
 cct.goal.bomb=Destrua 1 ou mais peças inimigas com uma <sprite name="plot_bomb"> <color=#6B5182>Bomba</color>.
-cct.intro=Bem-vindo, iniciado! Hoje marca sua iniciação na grande <color=#6B5182>Conspiração Corvídea</color>, o verdadeiro poder que controla as cordas desta guerra na floresta.<br><br>Para ter sucesso como membro da <color=#6B5182>Conspiração Corvídea</color>, é necessário um planejamento cuidadoso e o máximo de sigilo. Nossos inimigos nunca nos verão chegando enquanto espalhamos nossos complôs por toda a floresta.
+cct.intro=Bem-vindo, iniciado! Hoje marca sua iniciação na grande <color=#6B5182>Conspiração Corvídea</color>, o verdadeiro poder que controla as cordas desta guerra na floresta.<br><br>Para ter sucesso como membro da <color=#6B5182>Conspiração Corvídea</color>, é necessário um planejamento cuidadoso e o máximo de sigilo. Nossos inimigos nunca nos verão chegando enquanto espalhamos nossas tramas por toda a floresta.
 cct.setup.warriors=Durante a preparação, nossa posição inicial na floresta é estabelecida posicionando um <sprite name="corvid"><color=#6B5182>guerreiro</color> em cada clareira de um naipe diferente.
 conspiracyWithColor=<color=#9673B4>Conspiração Corvídea</color>
 corvid.plot.bomb.description=Quando revelado, remova todas as peças inimigas de sua clareira e, em seguida, remova este marcador.
@@ -1530,7 +1412,7 @@ corvid.plot.bomb.title=Bomba
 corvid.plot.extortion.description=Quando revelada, pegue uma carta aleatória de cada jogador que tenha peças em sua clareira. Enquanto revelada, você compra uma carta extra no Anoitecer.
 corvid.plot.extortion.title=Extorsão
 corvid.plot.raid.description=Quando removida, posicione um guerreiro em cada clareira adjacente.
-corvid.plot.raid.title=Incursão
+corvid.plot.raid.title=Ataque
 corvid.plot.snare.description=Enquanto revelada, peças inimigas não podem ser posicionadas ou movidas de sua clareira.
 corvid.plot.snare.title=Armadilha
 creategame.advancedsetup=Preparação Avançada
@@ -1538,18 +1420,18 @@ creategame.extras=Extras
 creategame.ownedfactions=Facções Possuídas
 duchy.ministertype.lord=Lorde
 duchy.ministertype.noble=Nobre
-duchy.ministertype.squire=Escudeiro
+duchy.ministertype.squire=Comum
 duchyWithColor=<color=#BD5752>Ducado Subterrâneo</color>
 factionnames.corvidconspiracy=Conspiração Corvídea
 factionnames.undergroundduchy=Ducado Subterrâneo
-ftt.exposure.intro.1=A qualquer momento antes de comprar cartas no Anoitecer, você pode usar Exposição para tentar remover um complô Corvídeo oculto que esteja em uma clareira com uma de suas peças.
-ftt.exposure.intro.2=Para fazer isso, selecione o botão Exposição e revele uma carta que corresponda ao naipe da clareira onde o complô está escondido. Em seguida, faça sua aposta sobre qual é o complô. Se estiver correto, remova o complô. Se errar, você deverá dar a carta revelada para a Conspiração Corvídea.
+ftt.exposure.intro.1=A qualquer momento antes de comprar cartas no Anoitecer, você pode usar Exposição para tentar remover ums trama Corvídea oculta que esteja em uma clareira com uma de suas peças.
+ftt.exposure.intro.2=Para fazer isso, selecione o botão Exposição e revele uma carta que corresponda ao naipe da clareira onde a trama está escondida. Em seguida, faça sua aposta sobre qual é a trama. Se estiver correto, remova a trama. Se errar, você deverá dar a carta revelada para a Conspiração Corvídea.
 lake.Ferry=Uma vez por turno, um jogador que se mova de uma clareira com a Balsa pode mover qualquer número de guerreiros e a Balsa daquela clareira para outra clareira costeira. Após isso, ele compra uma carta.
 lake.intro=Bem-vindo ao Lago! As coisas aqui são simples, desde que você saiba como usar a Balsa.
 lake.move.Ferry=Gostaria de usar a Balsa para realizar este movimento?
 log.banker=[faction name] descarta [cardnames] por [X] <style="vptext">PV</style>.
-log.brigadier.2battle=[faction name] ativa o Brigadier para realizar duas batalhas.
-log.brigadier.2move=[faction name] ativa o Brigadier para realizar dois movimentos.
+log.brigadier.2battle=[faction name] ativa o Brigadeiro para realizar duas batalhas.
+log.brigadier.2move=[faction name] ativa o Brigadeiro para realizar dois movimentos.
 log.captain=[faction name] ativa o Capitão para realizar uma batalha.
 log.clear.path=[faction name] descarta [name] para abrir um caminho e pontuar 1 <style="vptext">PV</style>.
 log.corvid.move=<color=#9673B4>Conspiração Corvídea</color> move [X] guerreiros para uma clareira de [suit icon].
@@ -1562,7 +1444,7 @@ log.duchy.dig.nomove=[faction name] descarta [name] para colocar um túnel em um
 log.duchy.dig.tunnel.removed=[faction name] remove um túnel de uma clareira de [suit icon].
 log.duchy.Evening.step1.bird=[faction name] devolve suas cartas reveladas para a mão e descarta as seguintes cartas de pássaro reveladas: [cardnames].
 log.duchy.Evening.step1.nobird=[faction name] devolve suas cartas reveladas para a mão.
-log.duchy.failure=[faction name] devolve [name] e descarta [cardname] devido ao Preço do Fracasso.
+log.duchy.failure=[faction name] devolve [name] e descarta [cardname] devido ao Preço da Derrota.
 log.duchy.lord.score=[faction name] ativa [name] para pontuar [X] <style="vptext">PV</style>.
 log.duchy.move=<color=#BD5752>Ducado Subterrâneo</color> move [X] guerreiros para uma clareira de [suit icon].
 log.duchy.move.burrow=<color=#BD5752>Ducado Subterrâneo</color> move [X] guerreiros da Toca para uma clareira de [suit icon].
@@ -1571,91 +1453,91 @@ log.duchy.move.one.burrow=<color=#BD5752>Ducado Subterrâneo</color> move 1 guer
 log.duchy.recruit=[faction name] coloca um guerreiro na Toca.
 log.duchy.setup=[faction name] coloca seu túnel inicial e 2 guerreiros em uma clareira de canto de [suit icon]. Mais 2 guerreiros são colocados em cada clareira adjacente.
 log.duchy.sway=[faction name] revela [cardnames] para aliciar [name], ganhando [X] <style="vptext">PV</style>.
-log.embedded.agents=[faction name] ganha um golpe extra por seu marcador de complô oculto na clareira da batalha.
-log.exert=[faction name] usa Esforçar-se para ganhar uma ação extra de Dia no Anoitecer. Como pagamento, ele deixará de comprar cartas no Anoitecer.
-log.exposure.failure=[faction name] tenta expor um marcador de complô em uma clareira de [suit icon] e revela [name] para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega [name].
-log.exposure.failure.opponent=[faction name] tenta expor um marcador de complô em uma clareira de [suit icon] e revela uma carta para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega a carta revelada.
-log.exposure.success=[faction name] tenta expor um marcador de complô em uma clareira de [suit icon] e revela [name] para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
-log.exposure.success.opponent=[faction name] tenta expor um marcador de complô em uma clareira de [suit icon] e revela uma carta para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
+log.embedded.agents=[faction name] ganha um golpe extra por seu marcador de trama oculto na clareira da batalha.
+log.exert=[faction name] usa Exceder para ganhar uma ação extra de Dia no Anoitecer. Como pagamento, ele deixará de comprar cartas no Anoitecer.
+log.exposure.failure=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela [name] para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega [name].
+log.exposure.failure.opponent=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela uma carta para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega a carta revelada.
+log.exposure.success=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela [name] para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
+log.exposure.success.opponent=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela uma carta para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
 log.flip=[faction name] revela [plot token name] em uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
 log.flip.resolution.bomb=Bomba remove [pieces] de [faction name].
 log.flip.resolution.extortion=[faction name] pega uma carta de [faction name 2].
-log.foremole=[faction name] ativa o Toupeirão, revelando [name] para colocar [building name] em uma clareira de [suit icon].
+log.foremole=[faction name] ativa o Capataz, revelando [name] para colocar [building name] em uma clareira de [suit icon].
 log.lake.Ferry=[faction name] usou a Balsa ao se mover e comprou uma carta.
 log.marshal=[faction name] ativa o Marechal para um movimento.
 log.mayor=[faction name] copia a ação de [name] com o Prefeito.
 log.navalwarfare.hit=[faction name] pontua um golpe de Guerra Naval.
 log.playerwon=[faction name] Vence!
-log.plot=[faction name] remove [X] guerreiros de uma clareira de [suit icon] para posicionar um complô oculto lá.
-log.plot.one=[faction name] remove um de seus guerreiros de uma clareira de [suit icon] para posicionar um complô oculto lá.
-log.spawn.burrow=[X] Guerreiro(s) adicionados ao Covil.
+log.plot=[faction name] remove [X] guerreiros de uma clareira de [suit icon] para posicionar uma trama oculta lá.
+log.plot.one=[faction name] remove um de seus guerreiros de uma clareira de [suit icon] para posicionar uma trama oculta lá.
+log.spawn.burrow=[X] Guerreiro(s) adicionados à Toca
 log.Tower.score=[faction name] ganha 1 <style="vptext">PV</style> por governar a clareira com a <sprite name="TowerToken"> <color=#6E5656>Torre</color>.
-log.trick=[faction name] trocou a localização de dois marcadores de complô.
+log.trick=[faction name] trocou a localização de dois marcadores de trama.
 ministertype.lords=Lordes
 ministertype.nobles=Nobres
-ministertype.squires=Escudeiros
+ministertype.squires=Comuns
 mountain.intro=Bem-vindo à Montanha! Há algumas coisas que você deve saber se quiser ser o governante por aqui.
 mountain.pass=A clareira com a <sprite name="TowerToken"> <color=#6E5656>Torre</color> é chamada de Passagem. No final do Anoitecer de um jogador, ele pontua <sprite name="1VP"> se governar a Passagem.
 mountain.path=Há alguns caminhos fechados aqui que precisarão ser abertos se você quiser atravessá-los. Uma vez por turno durante o Dia, um jogador pode gastar uma carta para transformar um caminho fechado adjacente em um caminho aberto e pontuar <sprite name="1VP">.
-playerinfo.corvid.Birdsong=1º: Criar – usando complôs, revelados ou ocultos.<br><br>2º: Revelar – marcadores de complô à sua escolha em clareiras com guerreiros Corvídeos. Para cada revelação, pontue 1 PV por complô revelado no mapa e, em seguida, resolva seu efeito de revelação, se houver.<br><br>3º: Recrutar – uma vez por turno, gaste qualquer carta para posicionar um guerreiro em cada clareira correspondente.
-playerinfo.corvid.Daylight=Realize até 3 ações.<br><br><sprite index=96>Complô<br>Remova um guerreiro Corvídeo, mais um por marcador de complô que você tenha posicionado neste turno, de uma clareira sem marcador de complô para posicionar um marcador de complô oculto lá.<br><br><sprite index=96>Armadilha<br>Troque dois marcadores de complô, revelados ou ocultos, no mapa.<br><br><sprite index=96>Mover<br><br><sprite index=96>Batalhar
-playerinfo.corvid.embeddedagents.description=Em batalha como defensor com um marcador de complô oculto, você causa um golpe extra.
-playerinfo.corvid.embeddedagents.title=Agentes Infiltrados
-playerinfo.corvid.Evening=1º: Exaurir<size=80%> – Você pode realizar uma ação extra durante o Dia. Se fizer isso, você não compra cartas durante a próxima etapa de compra.<br><br></size=80%>2º: Comprar<size=80%> – 1 carta, mais 1 carta por <sprite index=97> no mapa.<br></size=80%><br>Descarte<size=80%> até 5 cartas.
-playerinfo.corvid.exposure.description=Um jogador inimigo em uma clareira com um marcador de complô oculto pode lhe mostrar uma carta correspondente ao naipe da clareira para adivinhar o tipo do complô. Se acertar, o complô é removido. Caso contrário, você recebe a carta revelada.
+playerinfo.corvid.Birdsong=1º: Criar – usando tramas, reveladas ou ocultas.<br><br>2º: Revelar Tramas – Revele marcadores de trama à sua escolha em clareiras com guerreiros Corvídeos. Para cada revelação, pontue 1 PV por trama revelada no mapa e, em seguida, resolva seu efeito de revelação, se houver.<br><br>3º: Recrutar – uma vez por turno, gaste qualquer carta para posicionar um guerreiro em cada clareira correspondente.
+playerinfo.corvid.Daylight=Realize até 3 ações.<br><br><sprite index=96>Tramar<br>Remova um guerreiro Corvídeo, mais um por marcador de trama que você tenha posicionado neste turno, de uma clareira sem marcador de trama para posicionar um marcador de trama oculta lá.<br><br><sprite index=96>Despistar<br>Troque dois marcadores de trama, reveladas ou ocultas, no mapa.<br><br><sprite index=96>Mover<br><br><sprite index=96>Batalhar
+playerinfo.corvid.embeddedagents.description=Em batalha como defensor com um marcador de trama oculta, você causa um golpe extra.
+playerinfo.corvid.embeddedagents.title=Agentes Escondidos
+playerinfo.corvid.Evening=1º: Exceder<size=80%> – Você pode realizar uma ação extra durante o Dia. Se fizer isso, você não compra cartas durante a próxima etapa de compra.<br><br></size=80%>2º: Compre<size=80%> – 1 carta, mais 1 carta por <sprite index=97> no mapa.<br></size=80%><br>Descarte<size=80%> até 5 cartas.
+playerinfo.corvid.exposure.description=Um jogador inimigo em uma clareira com um marcador de trama oculta pode lhe mostrar uma carta correspondente ao naipe da clareira para adivinhar o tipo da trama. Se acertar, a trama é removida. Caso contrário, você recebe a carta revelada.
 playerinfo.corvid.exposure.title=Exposição
 playerinfo.corvid.nimble.description=Você pode se mover independentemente de quem governa sua clareira.
 playerinfo.corvid.nimble.title=Ágil
-playerinfo.corvid.offensiveagents.description=Ao atacar em uma clareira com um marcador de complô oculto, você causa um golpe extra.
+playerinfo.corvid.offensiveagents.description=Ao atacar em uma clareira com um marcador de trama oculta, você causa um golpe extra.
 playerinfo.corvid.offensiveagents.title=Agentes Ofensivos
 playerinfo.corvid.plot.bomb.description=Bomba: Ao ser revelada, remova todas as peças inimigas de sua clareira e, em seguida, remova este marcador.
 playerinfo.corvid.plot.extortion.description=Extorsão: Ao ser revelada, roube uma carta aleatória de cada jogador que tenha qualquer peça em sua clareira. Enquanto estiver revelada, você compra uma carta extra no Anoitecer.
 playerinfo.corvid.plot.raid.description=Saque: Ao ser removido, posicione um guerreiro em cada clareira adjacente.
 playerinfo.corvid.plot.snare.description=Armadilha: Enquanto estiver revelada, peças inimigas não podem ser posicionadas nem movidas de sua clareira.
-playerinfo.corvid.plots.title=Complôs
-playerinfo.duchy.Birdsong=Posicione um guerreiro, mais um guerreiro por <sprite index=101> exibido, no Covil.
+playerinfo.corvid.plots.title=Tramas
+playerinfo.duchy.Birdsong=Posicione um guerreiro, mais um guerreiro por <sprite index=101> exibido, na Toca.
 playerinfo.duchy.buildings.citadels=Cidadelas
 playerinfo.duchy.buildings.markets=Mercados
 playerinfo.duchy.buildings.title=Construções
-playerinfo.duchy.burrow.title=O Covil
+playerinfo.duchy.burrow.title=A Toca
 playerinfo.duchy.crowntrack.lords=Lordes <sprite name="crown"> x {0}<br><i>Custo: Quatro Cartas</i>
 playerinfo.duchy.crowntrack.nobles=Nobres <sprite name="crown"> x {0}<br><i>Custo: Três Cartas</i>
-playerinfo.duchy.crowntrack.squires=Escudeiros <sprite name="crown"> x {0}<br><i>Custo: Duas Cartas</i>
+playerinfo.duchy.crowntrack.squires=Comuns <sprite name="crown"> x {0}<br><i>Custo: Duas Cartas</i>
 playerinfo.duchy.crowntrack.title=Trilha da Coroa
-playerinfo.duchy.Daylight=1º: Realize até 2 ações.<br><br><sprite index=101>Construir<br>Revele uma carta para posicionar uma construção em uma clareira correspondente que você governe.<br><br><sprite index=101>Recrutar<br>Posicione um guerreiro no Covil.<br><br><sprite index=101>Cavar<br>Gaste uma carta para posicionar um túnel em uma clareira correspondente sem túnel, depois mova até quatro guerreiros do Covil para essa clareira. (Mova um túnel se todos estiverem no mapa.)<br><br><sprite index=101>Mover<br><br><sprite index=101>Batalhar<br><br>2º: Você pode realizar a ação de cada ministro influenciado uma vez.<br><br>3º: Uma vez por turno, você pode revelar cartas correspondentes a clareiras com qualquer peça do Ducado (uma carta por clareira) para influenciar um Ministro. Um escudeiro precisa de duas cartas, um nobre precisa de três e um lorde precisa de quatro.
+playerinfo.duchy.Daylight=1º: Realize até 2 ações.<br><br><sprite index=101>Construir<br>Revele uma carta para posicionar uma construção em uma clareira correspondente que você governe.<br><br><sprite index=101>Recrutar<br>Posicione um guerreiro na Toca.<br><br><sprite index=101>Escavar<br>Gaste uma carta para posicionar um túnel em uma clareira correspondente sem túnel, depois mova até quatro guerreiros da Toca para essa clareira. (Mova um túnel se todos estiverem no mapa.)<br><br><sprite index=101>Mover<br><br><sprite index=101>Batalhar<br><br>2º: Você pode realizar a ação de cada ministro influenciado uma vez.<br><br>3º: Uma vez por turno, você pode revelar cartas correspondentes a clareiras com qualquer peça do Ducado (uma carta por clareira) para influenciar um Ministro. Um comum precisa de duas cartas, um nobre precisa de três e um lorde precisa de quatro.
 playerinfo.duchy.Evening=1º: Descarte<size=80%> – qualquer carta revelada de <sprite name="birdicon">. Retorne todas as outras cartas reveladas para a mão.<br><br></size=80%>2º: Criar<size=80%> – usando cidadelas e mercados.<br></size=80%><br>Comprar<size=80%> – 1 carta, mais 1 carta por <sprite name="DrawCard"> exibido.</size=90%> Descarte<size=80%> até 5 cartas.
 playerinfo.duchy.priceoffailure.description=Ao remover construções do Ducado, devolva seu ministro influenciado de maior posto e descarte uma carta aleatória.
-playerinfo.duchy.priceoffailure.title=Custo do Fracasso
+playerinfo.duchy.priceoffailure.title=Preço da Derrota
 playmat.bomb=Bomba!
-playmat.exert=Exaurir!
+playmat.exert=Exceder!
 playmat.extortion=Extorsão!
 playmat.ministeractived=Ministro Ativado
-playmat.priceoffailure=Custo do Fracasso!
-playmat.raid=Saque!
+playmat.priceoffailure=Preço da Derrota!
+playmat.raid=Ataque!
 playmat.rightguess=Acertou!
 playmat.snare=Armadilha!
 playmat.trailblaze=Abrir Caminho
-playmat.trick=Armadilha!
+playmat.trick=Despistar!
 playmat.wrongguess=Errou!
 prompt.adset.factiondraft=Escolha uma Facção.
 prompt.challenges.nolordsbeforeme.minister.Lord=Escolha um Lorde para influenciar gratuitamente.
-prompt.challenges.nolordsbeforeme.minister.Squire=Escolha um Escudeiro para influenciar gratuitamente.
+prompt.challenges.nolordsbeforeme.minister.Squire=Escolha um Comum para influenciar gratuitamente.
 prompt.corvid.exposure.title=Exposição
-prompt.corvid.plot.place=Escolha um complô para posicionar.
-prompt.corvid.plot.place.opponent=[player] está escolhendo um complô para posicionar.
-prompt.corvid.plot.title=Complô
+prompt.corvid.plot.place=Escolha uma trama para posicionar.
+prompt.corvid.plot.place.opponent=[player] está escolhendo uma trama para posicionar.
+prompt.corvid.plot.title=Trama
 prompt.corvid.raid.warrior=Escolha clareiras para posicionar [X] guerreiros.
 prompt.corvid.raid.warrior.opponent=[player] está escolhendo clareiras para posicionar guerreiros.
-prompt.corvid.trick.swap=Escolha um segundo marcador de complô para trocar.
-prompt.corvid.trick.swap.opponent=[player] está escolhendo marcadores de complô para trocar.
+prompt.corvid.trick.swap=Escolha um segundo marcador de trama para trocar.
+prompt.corvid.trick.swap.opponent=[player] está escolhendo marcadores de trama para trocar.
 prompt.duchy.chooseminister.title=Escolha um Ministro
 prompt.duchy.dig.discard=Escolha uma carta para gastar.
-prompt.duchy.dig.discard.opponent=[player] está escolhendo uma carta para descartar para cavar um túnel.
+prompt.duchy.dig.discard.opponent=[player] está escolhendo uma carta para descartar para escavar um túnel.
 prompt.duchy.dig.tunnel.place=Posicione um túnel.
 prompt.duchy.dig.tunnel.place.opponent=[player] está posicionando um túnel.
 prompt.duchy.dig.tunnel.remove=Escolha um túnel para remover do tabuleiro.
 prompt.duchy.dig.tunnel.remove.opponent=[player] está escolhendo um túnel para remover do jogo.
-prompt.duchy.dig.warriors.move=Mova até 4 guerreiros do covil.
+prompt.duchy.dig.warriors.move=Mova até 4 guerreiros da toca.
 prompt.duchy.minister.banker.discard=Descarte qualquer número de cartas que compartilhem o mesmo naipe.
 prompt.duchy.minister.banker.discard.opponent=[player] está escolhendo cartas para descartar com o Banqueiro.
 prompt.duchy.minister.brigadier=Escolha Uma
@@ -1664,11 +1546,11 @@ prompt.duchy.minister.brigadier.button.move=Mover x2
 prompt.duchy.minister.brigadier.opponent=[player] está considerando opções...
 prompt.duchy.minister.foremole.building=Escolha uma construção para construir.
 prompt.duchy.minister.foremole.clearing=Escolha uma clareira para construir.
-prompt.duchy.minister.mayor=Escolha um Nobre ou Escudeiro influenciado.
+prompt.duchy.minister.mayor=Escolha um Nobre ou Comum influenciado.
 prompt.duchy.minister.mayor.opponent=[player] está considerando opções...
-prompt.duchy.priceoffailure.description=Escolha um Ministro para devolver como Custo do Fracasso.
-prompt.duchy.priceoffailure.description.opponent=[player] está escolhendo um Ministro para devolver como Custo do Fracasso.
-prompt.duchy.priceoffailure.title=Custo do Fracasso
+prompt.duchy.priceoffailure.description=Escolha um Ministro para devolver como o Preço da Derrota.
+prompt.duchy.priceoffailure.description.opponent=[player] está escolhendo um Ministro para devolver como o Preço da Derrota.
+prompt.duchy.priceoffailure.title=Preço da Derrota
 prompt.duchy.sway.minister=Escolha um ministro para influenciar.
 prompt.duchy.sway.minister.noneavailable=Nenhum ministro disponível para influenciar. Pressione o botão continuar.
 prompt.duchy.sway.minister.noneavailable.opponent=[player] está escolhendo um ministro para influenciar.
@@ -1679,8 +1561,8 @@ prompt.duchy.swayminister.crowns=<sprite name="crown"> x {0}
 prompt.duchy.swayministers.title=Influenciar Ministros
 prompt.exposure.card=Escolha uma carta para revelar.
 prompt.exposure.card.opponent=[player] está escolhendo cartas para revelar.
-prompt.exposure.plot.type=Escolha um tipo de complô para proclamar.
-prompt.exposure.plot.type.opponent=[player] está escolhendo um tipo de complô para proclamar.
+prompt.exposure.plot.type=Escolha um tipo de trama para proclamar.
+prompt.exposure.plot.type.opponent=[player] está escolhendo um tipo de trama para proclamar.
 prompt.factiondraft.insurgent=Insurgente
 prompt.factiondraft.militant=Militante
 prompt.locked.factiondraft=Não pode ser escolhido a menos que ao menos uma facção militante tenha sido escolhida.
@@ -1698,20 +1580,20 @@ root.duchy.brigadier=Brigadeiro
 root.duchy.brigadier.text=Realize até dois movimentos ou inicie até duas batalhas.
 root.duchy.captain=Capitão
 root.duchy.captain.text=Inicie uma batalha.
-root.duchy.duchessofmud=Duquesa do Barro
+root.duchy.duchessofmud=Duquesa da Lama
 root.duchy.duchessofmud.text=Pontue <sprite name="2VP"> se todos os túneis estiverem no mapa.
 root.duchy.earlofstone=Conde da Pedra
 root.duchy.earlofstone.text=Pontue <sprite name="1VP"> por cidadela no mapa.
-root.duchy.foremole=Toupeira-Mor
+root.duchy.foremole=Capataz
 root.duchy.foremole.text=Revele qualquer carta para colocar uma cidadela ou mercado em qualquer clareira (correspondente ou não) que você governa.
 root.duchy.marshal=Marechal
 root.duchy.marshal.text=Realize um movimento.
 root.duchy.mayor=Prefeito
-root.duchy.mayor.text=Realize a ação de qualquer nobre ou escudeiro convencido.
+root.duchy.mayor.text=Realize a ação de qualquer nobre ou comum convencido.
 scenario.burrowwarfare.name=Guerra Subterrânea
-scenario.burrowwarfare.tier1description=Adicione um guerreiro a menos ao seu Túnel durante a Alvorada. Quando seus guerreiros forem removidos em batalha, eles vão para o Túnel.
-scenario.burrowwarfare.tier2description=Você não adiciona guerreiros ao seu Túnel durante a Alvorada e não pode construir Cidadelas. Quando seus guerreiros forem removidos em batalha, eles vão para o Túnel.
-scenario.burrowwarfare.tier2description.balanceupdate=Você não adiciona guerreiros ao seu Túnel durante a Alvorada e não pode construir Cidadelas. Quando um ou mais de seus guerreiros forem removidos em batalha, devolva um ao seu Túnel.
+scenario.burrowwarfare.tier1description=Adicione um guerreiro a menos ao seu Túnel durante o Amanhecer. Quando seus guerreiros forem removidos em batalha, eles vão para o Túnel.
+scenario.burrowwarfare.tier2description=Você não adiciona guerreiros ao seu Túnel durante o Amanhecer e não pode construir Cidadelas. Quando seus guerreiros forem removidos em batalha, eles vão para o Túnel.
+scenario.burrowwarfare.tier2description.balanceupdate=Você não adiciona guerreiros ao seu Túnel durante o Amanhecer e não pode construir Cidadelas. Quando um ou mais de seus guerreiros forem removidos em batalha, devolva um ao seu Túnel.
 scenario.canyoudigit.name=Pode Cavar?
 scenario.canyoudigit.tier1description=Você tem um número ilimitado de túneis em seu suprimento. Você não pode vencer a menos que tenha um túnel em cada clareira de canto.
 scenario.canyoudigit.tier2description=Você tem um número ilimitado de túneis em seu suprimento. Você não pode vencer a menos que tenha um túnel em cada clareira de canto e na clareira da Torre. Seus inimigos tentarão destruir seus túneis.
@@ -1728,30 +1610,30 @@ scenario.navalwarfare.name=Guerra Naval
 scenario.navalwarfare.tier1description=Você ganha um golpe extra em batalhas adjacentes ao lago. Seus oponentes ganham um golpe extra em batalhas contra você em clareiras não adjacentes ao lago.
 scenario.navalwarfare.tier2description=Você ganha um golpe extra em batalhas na clareira da Balsa. Seus oponentes ganham um golpe extra em batalhas contra você em todas as outras clareiras.
 scenario.nolordsbeforeme.name=Sem Senhores Além de Mim
-scenario.nolordsbeforeme.tier1description=No início do jogo, escolha um senhor para convencer de graça. Você não pode ter outros senhores.
-scenario.nolordsbeforeme.tier2description=No início do jogo, escolha um escudeiro para convencer de graça. Você não pode ter outros escudeiros.
-scenario.nolordsbeforeme.tier2description.balance.update=No início do jogo, escolha um escudeiro para convencer de graça. Você não pode ter outros escudeiros nem senhores.
+scenario.nolordsbeforeme.tier1description=No início do jogo, escolha um lorde para convencer de graça. Você não pode ter outros lordes.
+scenario.nolordsbeforeme.tier2description=No início do jogo, escolha um comum para convencer de graça. Você não pode ter outros comuns.
+scenario.nolordsbeforeme.tier2description.balance.update=No início do jogo, escolha um comum para convencer de graça. Você não pode ter outros comuns nem lordes.
 scenario.offensiveagents.name=Agentes Ofensivos
-scenario.offensiveagents.tier1description=Sua habilidade Agentes Infiltrados é substituída por "Agentes Ofensivos: Ao atacar em uma clareira com um marcador de trama oculto, você causa um golpe extra."
-scenario.offensiveagents.tier2description=Sua habilidade Agentes Infiltrados é substituída por "Agentes Ofensivos: Ao atacar em uma clareira com um marcador de trama oculto, você causa um golpe extra." Você está sem a trama de Extorsão.
+scenario.offensiveagents.tier1description=Sua habilidade Agentes Escondidos é substituída por "Agentes Ofensivos: Ao atacar em uma clareira com um marcador de trama oculta, você causa um golpe extra."
+scenario.offensiveagents.tier2description=Sua habilidade Agentes Escondidos é substituída por "Agentes Ofensivos: Ao atacar em uma clareira com um marcador de trama oculta, você causa um golpe extra." Você está sem a trama de Extorsão.
 scenario.theTower.name=A Torre
 scenario.theTower.tier1description=Você só pode pontuar <style="vptext">PV</style> enquanto controlar a Torre.
 scenario.theTower.tier2description=Você só pode pontuar <style="vptext">PV</style> enquanto controlar a Torre. Seus inimigos irão buscar a Torre agressivamente.
 scenario.trailblazer.name=Desbravador
 scenario.trailblazer.tier1description=Você pode mover apenas 1 guerreiro por vez através dos caminhos padrão das clareiras (rios, caminhos de montanha e túneis funcionam normalmente).
 scenario.trailblazer.tier2description=Você não pode se mover através dos caminhos padrão das clareiras (rios, caminhos de montanha e túneis funcionam normalmente). Os oponentes não irão desbloquear caminhos de montanha.
-tooltip.ability.corvid.exert=<size=125%><b>Esforçar-se</b></size>\nVocê pode realizar uma ação extra durante o Dia. Se fizer isso, não poderá comprar cartas durante a próxima etapa. Utilizável uma vez por turno.
+tooltip.ability.corvid.exert=<size=125%><b>Exceder</b></size>\nVocê pode realizar uma ação extra durante o Dia. Se fizer isso, não poderá comprar cartas durante a próxima etapa. Utilizável uma vez por turno.
 tooltip.ability.corvid.exposure=<size=125%><b>Exposição</b></size>\nSe você tiver peças em uma clareira com um marcador de trama oculto, pode mostrar uma carta correspondente para tentar adivinhar o tipo da trama. Se acertar, remova a trama e ignore seu efeito. Se errar, você deve dar a carta revelada à Conspiração Corvídea. Não pode ser usado após comprar cartas no Anoitecer.
 tooltip.ability.corvid.plot=<size=125%><b>Trama</b></size>\nRemova um guerreiro Corvídeo, mais um guerreiro Corvídeo por cada trama que você já colocou neste turno, de uma clareira para colocar um marcador de trama oculto naquela clareira. Cada clareira pode conter apenas um marcador de trama por vez, e todos os guerreiros removidos para colocar a trama devem vir da clareira onde a trama será colocada.
-tooltip.ability.corvid.trick=<size=125%><b>Truque</b></size>\nTroque dois marcadores de trama no mapa. Ambos os marcadores devem estar revelados ou ocultos.
+tooltip.ability.corvid.trick=<size=125%><b>Despistar</b></size>\nTroque dois marcadores de trama no mapa. Ambos os marcadores devem estar revelados ou ocultos.
 tooltip.ability.duchy.battle=<size=125%><b>Batalha</b></size>\nTente remover peças inimigas de uma clareira onde você tenha guerreiros.
-tooltip.ability.duchy.build=<size=125%><b>Erguer</b></size>\nRevele uma carta para colocar uma cidadela ou mercado em uma clareira correspondente que você governe. Cartas de pássaro reveladas serão descartadas.
-tooltip.ability.duchy.dig=<size=125%><b>Cavar</b></size>\nGaste uma carta para colocar um marcador de túnel em uma clareira correspondente sem um marcador de túnel. Em seguida, mova até 4 guerreiros do Túnel para aquela clareira. Se todos os seus túneis já estiverem no mapa, você pode remover um túnel no início desta ação.
+tooltip.ability.duchy.build=<size=125%><b>Contruir</b></size>\nRevele uma carta para colocar uma cidadela ou mercado em uma clareira correspondente que você governe. Cartas de pássaro reveladas serão descartadas.
+tooltip.ability.duchy.dig=<size=125%><b>Escavar</b></size>\nGaste uma carta para colocar um marcador de túnel em uma clareira correspondente sem um marcador de túnel. Em seguida, mova até 4 guerreiros do Túnel para aquela clareira. Se todos os seus túneis já estiverem no mapa, você pode remover um túnel no início desta ação.
 tooltip.ability.duchy.move=<size=125%><b>Mover</b></size>\nMovimente guerreiros entre clareiras.
 tooltip.ability.duchy.recruit=<size=125%><b>Recrutar</b></size>\nColoque um guerreiro no Túnel.
-tooltip.advancedsetup=<size=125%><b>Configuração Avançada</b></size><br>A Configuração Avançada é uma forma alternativa de selecionar e preparar facções, que altera o equilíbrio entre elas e oferece maior variedade de posicionamentos iniciais. Ao usar essa configuração, os jogadores também compram 5 cartas iniciais e descartam 2.
-tooltip.advancedsetup.locked=<size=125%><b>Configuração Avançada</b></size><br>A Configuração Avançada é uma forma alternativa de selecionar e preparar facções, que altera o equilíbrio entre elas e oferece maior variedade de posicionamentos iniciais. Ao usar essa configuração, os jogadores também compram 5 cartas iniciais e descartam 2. Para desbloquear este modo, você deve possuir 6 ou mais facções em sua coleção.
-tooltip.advancedsetup.ownedfactions=As facções incluídas no draft da configuração avançada não podem ser modificadas manualmente. Em vez disso, elas representam a coleção do jogador que criou o jogo.
+tooltip.advancedsetup=<size=125%><b>Preparação Avançada</b></size><br>A Preparação Avançada é uma forma alternativa de selecionar e preparar facções, que altera o equilíbrio entre elas e oferece maior variedade de posicionamentos iniciais. Ao usar essa preparação, os jogadores também compram 5 cartas iniciais e descartam 2.
+tooltip.advancedsetup.locked=<size=125%><b>Preparação Avançada</b></size><br>A Preparação Avançada é uma forma alternativa de selecionar e preparar facções, que altera o equilíbrio entre elas e oferece maior variedade de posicionamentos iniciais. Ao usar essa preparação, os jogadores também compram 5 cartas iniciais e descartam 2. Para desbloquear este modo, você deve possuir 6 ou mais facções em sua coleção.
+tooltip.advancedsetup.ownedfactions=As facções incluídas no draft da preparação avançada não podem ser modificadas manualmente. Em vez disso, elas representam a coleção do jogador que criou o jogo.
 tooltip.banned.alliance=Aliança Banida
 tooltip.banned.corvid=Corvídeos Banidos
 tooltip.banned.duchy=Ducado Banido
@@ -1762,20 +1644,20 @@ tooltip.banned.riverfolk=Ribeirinhos Banidos
 tooltip.banned.secondvagabond=Segundo Malandro Banidos
 tooltip.banned.vagabond=Malandro Banido
 tooltip.corvid.plots.description=Cada clareira pode conter apenas um marcador de trama.
-tooltip.crowns=Cada nível de Ministro (Escudeiro, Nobre, Senhor) pode ser convencido no máximo 3 vezes por jogo. A quantidade de vezes restantes é representada por coroas.
+tooltip.crowns=Cada nível de Ministro (Comum, Nobre, Lorde) pode ser convencido no máximo 3 vezes por jogo. A quantidade de vezes restantes é representada por coroas.
 tooltip.duchy.burrow.description=O Túnel é adjacente a cada clareira com um túnel. Você sempre o governa, e apenas você pode entrar nele.
 tooltip.duchy.playmat.burrow=<size=125%><b>O Túnel</b></size>\nO Túnel é adjacente a cada clareira com um túnel. O Ducado Subterrâneo sempre o governa, e apenas eles podem entrar nele.
 tooltip.embeddedagents.battle=<size=125%><b>Agentes Ofensivos:</b></size><br>Ao defender em uma clareira com um marcador de trama oculto, cause um golpe extra.
 tooltip.lakemap=<size=125%><b>Mapa do Lago</b></size><br>Use a Balsa para atravessar o grande lago e encher sua mão com cartas extras.
 tooltip.minister.locked=Você não tem mais coroas para jogar um ministro deste nível.
-tooltip.minister.moreinfo=Para Convencer um ministro, você deve revelar um número de cartas baseado no nível do ministro (escudeiro 2, nobre 3, senhor 4). Você só pode revelar cartas correspondentes a clareiras onde tenha peças, e cada uma dessas clareiras permite revelar apenas uma carta. Ao convencer um ministro, você também perde uma coroa de seu nível. Se não tiver mais coroas de um nível, não poderá recrutar um ministro desse tipo.
+tooltip.minister.moreinfo=Para Convencer um ministro, você deve revelar um número de cartas baseado no nível do ministro (Comum 2, nobre 3, lorde 4). Você só pode revelar cartas correspondentes a clareiras onde tenha peças, e cada uma dessas clareiras permite revelar apenas uma carta. Ao convencer um ministro, você também perde uma coroa de seu nível. Se não tiver mais coroas de um nível, não poderá recrutar um ministro desse tipo.
 tooltip.mountainmap=<size=125%><b>Mapa da Montanha</b></size><br>Limpe caminhos bloqueados e controle a Torre para ganhar pontos de vitória adicionais.
 tooltip.mountainmap.tower=<size=125%><b>Torre</b></size>\nA clareira com a <sprite name="TowerToken"> <color=#6E5656>Torre</color> é chamada de Passagem. No final do Anoitecer de um jogador, ele pontua <sprite name="1VP"> se governar a Passagem.
 tooltip.offensiveagents.battle=<size=125%><b>Agentes Ofensivos:</b></size><br>Ao atacar em uma clareira com um marcador de trama oculto, cause um golpe extra.
 tooltip.opponent.corvid=<size=125%><b>Oponente da Conspiração Corvídea</b></size>
 tooltip.opponent.duchy=<size=125%><b>Oponente do Ducado Subterrâneo</b></size>
 tooltip.opponent.invalid=<size=125%><b>Oponente sem Facção</b></size>
-tooltip.playmat.citadel=<size=125%><b>Cidadela</b></size>\nContribui com o naipe da clareira onde está para pagar custos de criação. Cidadelas também aumentam o número de Guerreiros adicionados ao Túnel na Alvorada.
+tooltip.playmat.citadel=<size=125%><b>Cidadela</b></size>\nContribui com o naipe da clareira onde está para pagar custos de criação. Cidadelas também aumentam o número de Guerreiros adicionados ao Túnel no Amanhecer.
 tooltip.playmat.corvidplots=<size=125%><b>Tramas da Conspiração Corvídea</b></size>
 tooltip.playmat.corvidstack=<size=125%><b>Guerreiros da Conspiração Corvídea</b></size>
 tooltip.playmat.duchystack=<size=125%><b>Guerreiros do Ducado Subterrâneo</b></size>
@@ -1786,9 +1668,9 @@ tooltip.playmat.plot.Down.opponent=<size=125%><b>Trama Oculta</b></size>\nHá um
 tooltip.playmat.plot.Extortion.Down=<size=125%><b>Extorsão Oculta</b></size>\nQuando revelado, pegue uma carta aleatória de cada jogador que tenha peças na sua clareira. Enquanto revelado, você compra uma carta adicional no Anoitecer.
 tooltip.playmat.plot.Extortion.Up=<size=125%><b>Extorsão Revelada</b></size>\nQuando revelado, pegue uma carta aleatória de cada jogador que tenha peças na sua clareira. Enquanto revelado, você compra uma carta adicional no Anoitecer.
 tooltip.playmat.plot.Extortion.Up.opponent=<size=125%><b>Extorsão Revelada</b></size>\nQuando revelado, o jogador Corvídeo pega uma carta aleatória de cada jogador que tenha peças nesta clareira. Enquanto revelado, o jogador Corvídeo compra uma carta adicional no Anoitecer.
-tooltip.playmat.plot.Raid.Down=<size=125%><b>Incursão Oculta</b></size>\nQuando removido, coloque um guerreiro em cada clareira adjacente. Exposição não aciona isso.
-tooltip.playmat.plot.Raid.Up=<size=125%><b>Incursão Revelada</b></size>\nQuando removido, coloque um guerreiro em cada clareira adjacente. Exposição não aciona isso.
-tooltip.playmat.plot.Raid.Up.opponent=<size=125%><b>Incursão Revelada</b></size>\nQuando removido, o jogador Corvídeo coloca um guerreiro em cada clareira adjacente. Exposição não aciona isso.
+tooltip.playmat.plot.Raid.Down=<size=125%><b>Ataque Oculto</b></size>\nQuando removido, coloque um guerreiro em cada clareira adjacente. Exposição não aciona isso.
+tooltip.playmat.plot.Raid.Up=<size=125%><b>Ataque Revelado</b></size>\nQuando removido, coloque um guerreiro em cada clareira adjacente. Exposição não aciona isso.
+tooltip.playmat.plot.Raid.Up.opponent=<size=125%><b>Ataque Revelado</b></size>\nQuando removido, o jogador Corvídeo coloca um guerreiro em cada clareira adjacente. Exposição não aciona isso.
 tooltip.playmat.plot.Snare.Down=<size=125%><b>Armadilha Oculta</b></size>\nEnquanto revelado, peças inimigas não podem ser colocadas ou movidas desta clareira.
 tooltip.playmat.plot.Snare.Up=<size=125%><b>Armadilha Revelada</b></size>\nEnquanto revelado, peças inimigas não podem ser colocadas ou movidas desta clareira.
 tooltip.playmat.plot.Snare.Up.opponent=<size=125%><b>Armadilha Revelada</b></size>\nEnquanto revelado, peças que não sejam da Conspiração Corvídea não podem ser colocadas nesta clareira. Peças que não sejam da Conspiração Corvídea também não podem sair desta clareira (mas podem entrar).
@@ -1796,26 +1678,26 @@ tooltip.playmat.tunnel=<size=125%><b>Túnel</b></size>\nUma clareira com um Tún
 tooltip.quickbattle.disabled=Batalhas 3D estão desativadas no seu dispositivo por motivos de desempenho.
 tooltip.revealed.cards.duchy=<size=125%><b>Cartas Reveladas</b></size><br>Veja as cartas que o Ducado Subterrâneo revelou desde o início de seu turno mais recente.
 tooltip.trailblaze=<size=125%><b>Abrir Caminho</b></size>\nUma vez por turno no Dia, um jogador pode descartar uma carta da mão para abrir um caminho de montanha e pontuar <sprite name="1VP">. O jogador deve ter pelo menos uma peça em uma clareira ligada ao caminho fechado para fazer isso.
-tooltip.ui.buildmodal.extrawarrior=Construir isso aumenta o número de guerreiros colocados no Túnel durante a Alvorada.
+tooltip.ui.buildmodal.extrawarrior=Construir isso aumenta o número de guerreiros colocados no Túnel durante o Amanhecer.
 tooltip.ui.corvid.bombplots=<size=125%><b>Tramas de Bomba Disponíveis</b></size>\nQuando revelado, remova todas as peças inimigas na sua clareira e, em seguida, remova este marcador.
 tooltip.ui.corvid.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nA Conspiração Corvídea compra uma carta adicional para cada trama de Extorsão revelada.
 tooltip.ui.corvid.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nA Conspiração Corvídea cria cartas usando tramas.
 tooltip.ui.corvid.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas para pegar esses itens. A Conspiração Corvídea cria itens usando tramas.
 tooltip.ui.corvid.extortionplots=<size=125%><b>Tramas de Extorsão Disponíveis</b></size>\nQuando revelado, pegue uma carta aleatória de cada jogador que tenha peças na sua clareira. Enquanto revelado, você compra uma carta adicional no Anoitecer.
-tooltip.ui.corvid.raidplots=<size=125%><b>Tramas de Incursão Disponíveis</b></size>\nQuando removido, coloque um guerreiro em cada clareira adjacente. (Exposição não aciona isso.)
+tooltip.ui.corvid.raidplots=<size=125%><b>Tramas de Ataque Disponíveis</b></size>\nQuando removido, coloque um guerreiro em cada clareira adjacente. (Exposição não aciona isso.)
 tooltip.ui.corvid.snareplots=<size=125%><b>Tramas de Armadilha Disponíveis</b></size>\nEnquanto revelado, peças inimigas não podem ser colocadas ou movidas desta clareira.
-tooltip.ui.corvid.warriorcount=<size=125%><b>Guerreiros em Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
+tooltip.ui.corvid.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros na reserva, ele não poderá recrutar guerreiros.
 tooltip.ui.duchy.burrowwarriorcount=<size=125%><b>Guerreiros no Túnel</b></size>\nGuerreiros podem ser movidos do Túnel para clareiras com Túnel.
 tooltip.ui.duchy.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nO Ducado Subterrâneo compra cartas adicionais ao construir Mercados.
-tooltip.ui.duchy.citadelcount=<size=125%><b>Taxa de Recrutamento no Túnel</b></size>\nO número de guerreiros recrutados para o Túnel durante a Alvorada. Isso pode ser aumentado ao construir Cidadelas.
+tooltip.ui.duchy.citadelcount=<size=125%><b>Taxa de Recrutamento no Túnel</b></size>\nO número de guerreiros recrutados para o Túnel durante o Amanhecer. Isso pode ser aumentado ao construir Cidadelas.
 tooltip.ui.duchy.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nO Ducado Subterrâneo cria cartas usando Cidadelas e Mercados.
 tooltip.ui.duchy.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas para pegar esses itens. O Ducado cria itens usando Cidadelas e Mercados.
 tooltip.ui.duchy.tunnelcount=<size=125%><b>Túnel Não Utilizado</b></size>
-tooltip.ui.duchy.warriorcount=<size=125%><b>Guerreiros em Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
+tooltip.ui.duchy.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros na reserva, ele não poderá recrutar guerreiros.
 tooltip.ui.hand.reveal.corvid=<size=125%><b>Mão da Conspiração Corvídea</b></size><br>Veja as cartas da Conspiração Corvídea que foram reveladas.
 tooltip.ui.hand.reveal.duchy=<size=125%><b>Mão do Ducado Subterrâneo</b></size><br>Veja as cartas do Ducado Subterrâneo que foram reveladas.
 tooltip.ui.randomclearingsuits=<size=125%><b>Naipe das Clareiras Aleatórias</b></size><br>Os Naipes das Clareiras serão atribuídos aleatoriamente.
-tooltip.ui.reset.disabled=Facções não podem ser redefinidas enquanto a Configuração Avançada estiver habilitada.
+tooltip.ui.reset.disabled=Facções não podem ser redefinidas enquanto a Preparação Avançada estiver habilitada.
 tooltip.ui.swayedministers=<size=125%><b>Ministros Influenciados</b></size>\nVeja os Ministros que o jogador do Ducado Subterrâneo influenciou.
 tooltip.ui.unswayedministers=<size=125%><b>Ministros Não Influenciados</b></size>\nVeja os Ministros que você não influenciou.
 tuber.canis.abilities.CorvidConspiracyAbilities.BattleAbility=Escolha um oponente para batalhar.
@@ -1836,7 +1718,7 @@ tuber.canis.abilities.UndergroundDuchyAbilities.DuchyChooseBuilding=Escolha uma 
 tuber.canis.abilities.UndergroundDuchyAbilities.DuchyChooseBuilding.opponent=[player] está escolhendo uma construção para erguer.
 tuber.canis.actions.BirdsongActivations.Expose=Expor uma trama?
 tuber.canis.actions.BirdsongActivations.Expose.opponent=[player] está escolhendo expor uma trama.
-tuber.canis.actions.BirdsongActivations.ExposeOrCard=Expor uma trama ou escolher uma carta com ativação de Alvorada para ativar.
+tuber.canis.actions.BirdsongActivations.ExposeOrCard=Expor uma trama ou escolher uma carta com ativação de Amanhecer para ativar.
 tuber.canis.actions.BirdsongActivations.ExposeOrCard.opponent=[player] está considerando opções...
 tuber.canis.actions.challenges.DredgingTheLakeDraw.discardchoice=Escolha uma carta descartada para comprar.
 tuber.canis.actions.challenges.DredgingTheLakeDraw.drawfromdeckordiscard=Comprar do monte de descarte em vez do baralho?
@@ -1868,12 +1750,12 @@ tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchyParliamentPhase.Duch
 tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchyParliamentPhase.DuchyDaylightParliament.opponent=O Ducado está escolhendo Ministros para ativar.
 tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchySetup.ChooseStarting=Escolha uma clareira de canto para seu túnel.
 tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchySetup.ChooseStarting.opponent=O Ducado está escolhendo uma clareira de canto para seu túnel.
-tuber.canis.undo.CorvidCompanySetupUndo=Pressione o botão de continuar para concluir a configuração.
-tuber.canis.undo.CorvidCompanySetupUndo.opponent=Aguardando a Conspiração Corvídea para confirmar a configuração.
-tuber.canis.undo.EyrieDynastiesSetupUndo=Pressione o botão de continuar para concluir a configuração.
-tuber.canis.undo.EyrieDynastiesSetupUndo.opponent=Aguardando a Dinastia das Rapinas para confirmar a configuração.
-tuber.canis.undo.UndergroundDuchySetupUndo=Pressione o botão de continuar para concluir a configuração.
-tuber.canis.undo.UndergroundDuchySetupUndo.opponent=Aguardando o Ducado para confirmar a configuração.
+tuber.canis.undo.CorvidCompanySetupUndo=Pressione o botão de continuar para concluir a preparação.
+tuber.canis.undo.CorvidCompanySetupUndo.opponent=Aguardando a Conspiração Corvídea confirmar a preparação.
+tuber.canis.undo.EyrieDynastiesSetupUndo=Pressione o botão de continuar para concluir a preparação.
+tuber.canis.undo.EyrieDynastiesSetupUndo.opponent=Aguardando a Dinastia das Rapinas confirmar a preparação.
+tuber.canis.undo.UndergroundDuchySetupUndo=Pressione o botão de continuar para concluir a preparação.
+tuber.canis.undo.UndergroundDuchySetupUndo.opponent=Aguardando o Ducado confirmar a preparação.
 tutorial.crownslabel=Coroas Restantes
 tutorial.description.TutorialU01=Aprenda a jogar com o Ducado Subterrâneo
 tutorial.description.TutorialU02=Aprenda a jogar com a Conspiração Corvídea
@@ -1881,45 +1763,666 @@ tutorial.title.TutorialU01=Ameaça das Profundezas
 tutorial.title.TutorialU02=Chocando Planos
 tutorial.tunnellabel=Túnel
 udt.Birdsong.t1.burrow.adjacent=A <sprite name="Burrow"> <color=#BD5752>toca</color> é adjacente a todos os seus <sprite name="Tunnel"> <color=#BD5752>túneis</color> no mapa e pode ser usada para lançar ataques por trás das linhas inimigas.
-udt.Birdsong.t1.burrow.recruit=Durante a Alvorada, colocamos um <sprite name="duchy"><color=#BD5752>guerreiro</color> em uma clareira chamada <sprite name="Burrow"> <color=#BD5752>A Toca</color>, que não pode ser acessada pelos seus oponentes.
-udt.Birdsong.t2.recruit.citadel=Durante a Alvorada, você adiciona 1 <sprite name="duchy"><color=#BD5752>guerreiro</color> à <sprite name="Burrow"> <color=#BD5752>Toca</color>. Graças à <sprite name="Citadel"> <color=#BD5752>Cidadela</color> que você construiu no último turno, você ganha um <sprite name="duchy"><color=#BD5752>guerreiro</color> extra, totalizando 2.
+udt.Birdsong.t1.burrow.recruit=Durante o Amanhecer, colocamos um <sprite name="duchy"><color=#BD5752>guerreiro</color> em uma clareira chamada <sprite name="Burrow"> <color=#BD5752>A Toca</color>, que não pode ser acessada pelos seus oponentes.
+udt.Birdsong.t2.recruit.citadel=Durante o Amanhecer, você adiciona 1 <sprite name="duchy"><color=#BD5752>guerreiro</color> à <sprite name="Burrow"> <color=#BD5752>Toca</color>. Graças à <sprite name="Citadel"> <color=#BD5752>Cidadela</color> que você construiu no último turno, você ganha um <sprite name="duchy"><color=#BD5752>guerreiro</color> extra, totalizando 2.
 udt.Birdsong.t5=Podemos ter perdido uma batalha, mas a guerra ainda não acabou. Influencie <color=#BD5752>Ministros</color>, crie itens e ataque construções inimigas para pontuar <style="vpnumddteen">15</style> e completar este cenário.
-udt.Daylight.t1.actions=Durante o Dia, podemos realizar até 2 das seguintes ações:<br><sprite name="DuchyBuildToken">Erguer<br><sprite name="DuchyRecruitToken">Recrutar<br><sprite name="DuchyDigToken">Cavar<br><sprite name="UIMoveToken">Mover<br><sprite name="UIBattleToken">Batalha<br>
-udt.Daylight.t1.build.reveal=Como parte do custo para erguer, você deve revelar uma carta correspondente ao naipe da clareira selecionada. Cada carta pode ser revelada apenas uma vez por turno.
+udt.Daylight.t1.actions=Durante o Dia, podemos realizar até 2 das seguintes ações:<br><sprite name="DuchyBuildToken">Construir<br><sprite name="DuchyRecruitToken">Recrutar<br><sprite name="DuchyDigToken">Escavar<br><sprite name="UIMoveToken">Mover<br><sprite name="UIBattleToken">Batalhar<br>
+udt.Daylight.t1.build.reveal=Como parte do custo para construir, você deve revelar uma carta correspondente ao naipe da clareira selecionada. Cada carta pode ser revelada apenas uma vez por turno.
 udt.Daylight.t1.build.reveal2=Durante o Anoitecer, as cartas de naipe reveladas <sprite name="birdicon"> são descartadas. Revelamos uma carta de naipe <sprite name="ClearingRabbit">, então ela retorna para nossa mão para uso futuro.
 udt.Daylight.t1.build.type=Em seguida, escolhemos qual tipo de construção queremos. A <sprite name="Citadel"> <color=#BD5752>Cidadela</color> é uma boa escolha, pois aumenta os <sprite name="duchy"><color=#BD5752>guerreiros</color> que recrutamos para nossa <sprite name="Burrow"> <color=#BD5752>Toca</color> a cada turno.
-udt.Daylight.t1.building=Agora erga uma construção em uma clareira que você governa.
+udt.Daylight.t1.building=Agora construa em uma clareira que você governa.
 udt.Daylight.t1.recruit=Primeiro, vamos recrutar para obter outro <sprite name="duchy"><color=#BD5752>guerreiro</color> em nossa <sprite name="Burrow"> <color=#BD5752>Toca</color>.
 udt.Daylight.t2.attack=Com seus <sprite name="duchy"><color=#BD5752>guerreiros</color> posicionados, é hora de mostrar aos <color=#CC6633>Marqueses</color> que nenhuma clareira está a salvo do <color=#BD5752>Ducado Subterrâneo</color>!
 udt.Daylight.t2.cat.attack=Esses toupeiras surgiram do nada. Achei que ELES é que eram os cegos...
 udt.Daylight.t2.dig.clearing=<color=#BD5752>Cave</color> um <sprite name="Tunnel"> <color=#BD5752>Túnel</color> naquela clareira para enviar seus <sprite name="duchy"><color=#BD5752>guerreiros</color> para um ataque.
-udt.Daylight.t2.dig.discard=Para pagar o custo de uma <color=#BD5752>Cava</color>, você deve descartar uma carta correspondente ao naipe da clareira onde cavou o <sprite name="Tunnel"> <color=#BD5752>túnel</color>.
+udt.Daylight.t2.dig.discard=Para pagar o custo de uma <color=#BD5752>Escavação</color>, você deve descartar uma carta correspondente ao naipe da clareira onde escavou o <sprite name="Tunnel"> <color=#BD5752>túnel</color>.
 udt.Daylight.t2.dig.move=Ao posicionar um <sprite name="Tunnel"> <color=#BD5752>Túnel</color>, você pode mover até 4 <sprite name="duchy"><color=#BD5752>guerreiros</color> de sua <sprite name="Burrow"> <color=#BD5752>Toca</color> para lá. Vamos mover todos os 4 para começar nosso ataque!
 udt.Daylight.t2.exposed=Seu inimigo felino deixou uma construção exposta em uma clareira <sprite name="ClearingMouse"> ao oeste. Essa é uma oportunidade perfeita para um ataque partindo de nossa <sprite name="Burrow"> <color=#BD5752>Toca</color>!
 udt.Daylight.t2.tunnels.move=Uma vez que um <sprite name="Tunnel"> <color=#BD5752>Túnel</color> está no mapa, você pode mover guerreiros livremente entre ele e a <sprite name="Burrow"> <color=#BD5752>Toca</color> usando a ação Mover.
 udt.Daylight.t3.moveandattack=Nosso plano exige que asseguremos mais clareiras <sprite name="ClearingRabbit">. Mova 2 <sprite name="duchy"><color=#BD5752>guerreiros</color> para uma clareira <sprite name="ClearingRabbit"> controlada por inimigos e, em seguida, realize uma batalha lá.
-udt.Daylight.t3.sway.reveal=Para influenciar um <color=#BD5752>Ministro</color>, você deve revelar um número de cartas igual ao nível do <color=#BD5752>Ministro</color> (2 para Escudeiro, 3 para Nobre, 4 para Lorde). No entanto, você só pode revelar cartas correspondentes a clareiras onde tenha peças, e cada clareira permite revelar apenas uma carta.
+udt.Daylight.t3.sway.reveal=Para influenciar um <color=#BD5752>Ministro</color>, você deve revelar um número de cartas igual ao nível do <color=#BD5752>Ministro</color> (2 para Comum, 3 para Nobre, 4 para Lorde). No entanto, você só pode revelar cartas correspondentes a clareiras onde tenha peças, e cada clareira permite revelar apenas uma carta.
 udt.Daylight.t3.sway.vp=Você pontua <sprite name="2VP"> por jogar o <color=#BD5752>Brigadeiro</color>, pois ele é um <color=#BD5752>Nobre</color>, e remove uma das três coroas nobres <sprite name="crown"> de seu inventário. Quando ficar sem coroas de <color=#BD5752>Nobre</color>, não poderá mais influenciar novos <color=#BD5752>Ministros Nobres</color>.
 udt.Daylight.t3.sway1=Agora podemos influenciar poderosos <color=#BD5752>Ministros</color> para nosso lado, pontuando <style="vptext">PV</style> e aumentando as ações disponíveis.
-udt.Daylight.t3.sway2=Os <color=#BD5752>Ministros</color> possuem três níveis: <color=#BD5752>Escudeiro</color>, <color=#BD5752>Nobre</color> e <color=#BD5752>Lorde</color>. Níveis mais altos exigem mais cartas para serem influenciados, mas valem mais <style="vptext">PV</style> e têm habilidades mais poderosas.
+udt.Daylight.t3.sway2=Os <color=#BD5752>Ministros</color> possuem três níveis: <color=#BD5752>Comum</color>, <color=#BD5752>Nobre</color> e <color=#BD5752>Lorde</color>. Níveis mais altos exigem mais cartas para serem influenciados, mas valem mais <style="vptext">PV</style> e têm habilidades mais poderosas.
 udt.Daylight.t3.sway3=Vamos influenciar o <color=#BD5752>Brigadeiro</color> para melhorar nossa capacidade de movimento e combate nos próximos turnos.
 udt.Daylight.t4.brigadier1=Após completar suas ações iniciais, você pode usar os poderes dos <color=#BD5752>Ministros Influenciados</color>. Ative o <color=#BD5752>Brigadeiro</color> para batalhar na clareira onde cavou o túnel.
 udt.Daylight.t4.brigadier2=Seu oponente está indefeso. Bata novamente para acabar com o que restou do assentamento.
-udt.Daylight.t4.build=Com vontade de cartas? É hora de erguer um <sprite name="Market"> <color=#BD5752>Mercado</color>! Esta construção aumentará o número de cartas que compramos durante o Anoitecer.
+udt.Daylight.t4.build=Com vontade de cartas? É hora de construir um <sprite name="Market"> <color=#BD5752>Mercado</color>! Esta construção aumentará o número de cartas que compramos durante o Anoitecer.
 udt.Daylight.t4.cat.destroyed=Você toma uma construção, nós tomamos outra.
-udt.Daylight.t4.dig=Nossa economia está prosperando! Mas o mesmo vale para os <color=#CC6633>Marqueses</color>, e não podemos permitir isso. <color=#BD5752>Cave</color> um túnel próximo à fonte de madeira deles e interrompa-a pela força.
-udt.Daylight.t4.priceoffailure=Oh, não! Estávamos tão focados na agressão que esquecemos de proteger nosso <sprite name="Market"> <color=#BD5752>Mercado</color> e agora devemos sofrer as consequências do <color=#BD5752>Preço do Fracasso</color>. Quando uma construção do <color=#BD5752>Ducado</color> é removida, você perde seu <color=#BD5752>Ministro</color> influenciado de nível mais alto e descarta uma carta aleatória da sua mão.
+udt.Daylight.t4.dig=Nossa economia está prosperando! Mas o mesmo vale para os <color=#CC6633>Marqueses</color>, e não podemos permitir isso. <color=#BD5752>Escave</color> um túnel próximo à fonte de madeira deles e interrompa-a pela força.
+udt.Daylight.t4.priceoffailure=Oh, não! Estávamos tão focados na agressão que esquecemos de proteger nosso <sprite name="Market"> <color=#BD5752>Mercado</color> e agora devemos sofrer as consequências do <color=#BD5752>Preço da Derrota</color>. Quando uma construção do <color=#BD5752>Ducado</color> é removida, você perde seu <color=#BD5752>Ministro</color> influenciado de nível mais alto e descarta uma carta aleatória da sua mão.
 udt.Daylight.t4.skipsway=Como você só tem a carta "Vendinha de Bolos" na mão, não possui cartas suficientes para influenciar um <color=#BD5752>ministro</color> neste turno. Hora de passar para os <color=#CC6633>Marqueses</color> e comprar cartas.
 udt.Evening.t1.craft=Agora podemos criar usando os naipes das clareiras onde temos construções. Observe que os <sprite name="Tunnel"> <color=#BD5752>Túneis</color> são marcadores, não construções, então não contribuem para a criação.
 udt.Evening.t1.craft.2=Sua construção <sprite name="Citadel"> <color=#BD5752>Cidadela</color> na clareira <sprite name="ClearingRabbit"> permitirá criar o Equipamento de Viagem.
 udt.Evening.t1.draw=Por fim, compramos uma carta e passamos o turno para nossos oponentes felinos.
-udt.goal.15vp=Pontuação <style="vpnumddteen">15</style> ({0}/{1})
+udt.goal.15vp=Pontue <style="vpnumddteen">15</style> ({0}/{1})
 udt.intro=Bem-vindo ao <color=#BD5752>Ducado Subterrâneo</color>, um vasto império subterrâneo que busca a dominação total da floresta. Juntos, atacaremos de baixo usando nosso vasto sistema de túneis e influenciaremos a "baixa sociedade" a nosso favor, ganhando novas habilidades poderosas.
-udt.setup.tunnel=Para começar, colocamos um <sprite name="Tunnel"> <color=#BD5752>Túnel</color> na clareira de canto oposta ao <color=#CC6633>Forte</color> dos <color=#CC6633>Marqueses</color> <sprite name="KeepToken">. Também colocamos 2 guerreiros nesta clareira e em cada clareira adjacente.
-tooltip.disablefactiondraft=<size=125%><b>Desativar Escolha de Facção</b></size><br>Desativa a escolha de facções no modo de Configuração Avançada.
+udt.setup.tunnel=Para começar, colocamos um <sprite name="Tunnel"> <color=#BD5752>Túnel</color> na clareira de canto oposta à <color=#CC6633>Torre da Guarda</color> dos <color=#CC6633>Marqueses</color> <sprite name="KeepToken">. Também colocamos 2 guerreiros nesta clareira e em cada clareira adjacente.
+tooltip.disablefactiondraft=<size=125%><b>Desativar Escolha de Facção</b></size><br>Desativa a escolha de facções no modo de Preparação Avançada.
 creategame.disablefactiondraft=Desativar Escolha de Facção
-tooltip.bansecondvagabond=<size=125%><b>Banir Segundo Malandro</b></size><br>Proíbe múltiplos Malandros no modo de Configuração Avançada.
+tooltip.bansecondvagabond=<size=125%><b>Banir Segundo Malandro</b></size><br>Proíbe múltiplos Malandros no modo de Preparação Avançada.
 creategame.bansecondvagabond=Banir Segundo Malandro
+shortfactionnames.corvidconspiracy=Corvídea
+shortfactionnames.undergroundduchy=Ducado
+factionnames.keepersiniron=Guardiões de Ferro
+factionnames.lordofthehundreds=Senhor das Centenas
+tooltip.opponent.keepers=<size=125%><b>Oponente dos Guardiões de Ferro</b></size>
+tooltip.opponent.hundreds=<size=125%><b>Oponente do Senhor das Centenas</b></size>
+playerinfo.keepersiniron.devoutknights.title=Cavaleiros Devotos
+playerinfo.keepersiniron.devoutknights.description=Em batalha, ignore o primeiro golpe que você sofrer se tiver uma relíquia e um guerreiro Guardião. Ao mover, você pode mover uma relíquia com cada guerreiro Guardião.
+playerinfo.keepersiniron.prizedtrophies.title=Troféus Valiosos
+playerinfo.keepersiniron.prizedtrophies.description=Quando um inimigo remove uma relíquia, ele a coloca, com o valor virado para cima, em qualquer floresta e pontua um ponto extra.
+playerinfo.keepersiniron.relics.title=Relíquias
+playerinfo.keepersiniron.relics.desc=<sprite name="2VP"> se você preencher uma coluna
+playerinfo.keepersiniron.waystations.title=Estações
+playerinfo.keepersiniron.birdsong=1º: Acampe<size=80%> uma vez por clareira. Você pode substituir um guerreiro Guardião por uma Estação. Se nenhum estiver no mapa, coloque ambos em uma clareira na borda do mapa.<br><br></size=80%>2º: Levante Acampamento<size=80%> uma vez por clareira. Você pode substituir uma Estação por um guerreiro Guardião. <br><br></size=80%>3º: Recrute <size=80%>quantas vezes quiser. Gaste uma carta para posicionar um guerreiro em uma Estação correspondente.
+playerinfo.keepersiniron.daylight=1º: Criar<size=80%> usando estações.<br><br></size>2º: Ative o <b>Séquito</b>, realizando as seguintes ações:<br><br><b>Mover:</b><size=80%> Mova de uma clareira correspondente.<br><br></size><b>Batalhe e Escave:</b><size=80%> Batalhe se possível, então você pode escavar na mesma clareira correspondente. Escavar - Se você governar com um guerreiro Guardião, mova e revele uma relíquia de uma floresta adjacente. Descarte a carta usada para Escavar se você governar menos clareiras adjacentes àquela floresta do que o valor da relíquia.<br><br></size><b>Mover ou Recuperar:</b><size=80%> Mova à partir de uma clareira correspondente ou recupere relíquias - Pontue qualquer número de relíquias do mesmo tipo que as estações ali. Descarte a carta usada para Recuperar e interrompa a ação se você tiver menos clareiras correspondentes do que o valor de uma relíquia tomada.</size>
+playerinfo.keepersiniron.daylight.deliverymission=1º: Criar<size=80%> usando estações.<br><br></size>2º: Ative o <b>Séquito</b>, realizando as seguintes ações:<br><br><b>Mover:</b><size=80%> Mova de uma clareira correspondente.<br><br></size><b>Batalhe e Escave:</b><size=80%> Batalhe se possível, então você pode escavar na mesma clareira correspondente.<br><br>Escavar - Se você governar com um guerreiro Guardião, mova e revele uma relíquia de uma floresta adjacente. Descarte a carta usada para Escavar se você governar menos clareiras adjacentes àquela floresta do que o valor da relíquia.<br><br></size><b>Mover:</b><size=80%> Mova de uma clareira correspondente.</size>
+playerinfo.keepersiniron.evening=1º: Deixe a Terra<size=80%> você deve remover um guerreiro Guardião de cada clareira com quatro ou mais.<br><br></size=80%>2º: Receba o Séquito<size=80%> em até dez cartas. Você pode adicionar qualquer número de cartas da mão ao Séquito ou pode mover uma carta dentro dele. <br><br></size=80%>3º: Compre <size=80%>1 carta por <sprite index=31> exibido.<br></size=80%><br>Descarte <size=80%>até ficar com 5 cartas.
+playerinfo.keepersiniron.evening.huddle=1º: Reunir-se<size=80%> Você deve remover cada guerreiro Guardião em uma clareira sem outros guerreiros Guardiões.<br><br></size>2º: Receba o Séquito<size=80%> em até dez cartas. Você pode adicionar qualquer número de cartas da mão para seu Séquito, ou pode mover uma carta nele. <br><br></size>3º: Compre <size=80%>1 carta por <sprite index=31> mostrado.<br></size><br>Descarte <size=80%>até 5 cartas.</size>
+playerinfo.keepersiniron.evening.famine=1º: Relíquia Vinculada<size=80%> Você deve remover um guerreiro Guardião de cada clareira sem uma relíquia.<br><br></size>2º: Receba o Séquito<size=80%> em até dez cartas. Você pode adicionar qualquer número de cartas da mão para seu Séquito, ou pode mover uma carta nele. <br><br></size>3º: Compre <size=80%>1 carta por <sprite index=31> mostrado.<br></size><br>Descarte <size=80%>até 5 cartas.</size>
+playerinfo.lordofthehundreds.thewarlord.title=O Senhor da Guerra
+playerinfo.lordofthehundreds.thewarlord.description=O Senhor da Guerra é um guerreiro que não pode ser removido fora da batalha, movido fora do seu turno ou posicionado, exceto com Convocar
+playerinfo.lordofthehundreds.contemptfortrade.title=Desprezo pelo Comércio
+playerinfo.lordofthehundreds.contemptfortrade.description=Quando você cria um item, ganha-o, mas não pontua os pontos listados, ou o remove para pontuá-los.
+playerinfo.lordofthehundreds.looters.title=Saqueadores
+playerinfo.lordofthehundreds.looters.description=No início da batalha como atacante, você pode declarar que está saqueando o defensor. Você não causa golpes rolados, mas ele sim. No final, se você governar a clareira da batalha, pegue um item dos Itens Criados dele.
+playerinfo.lordofthehundreds.moods.title=Humores
+playerinfo.lordofthehundreds.thehoard.title=O Tesouro
+playerinfo.lordofthehundreds.oppressedspaces.title=Espaços Oprimidos: {0}
+playerinfo.lordofthehundreds.infiltratedspaces.title=Espaços Infiltrados: {0}
+playerinfo.lordofthehundreds.birdsong=1º: Arrase<size=80%> - Em cada clareira com um marcador de turba, remova todas as construções e marcadores inimigos, pegue um item de uma ruína presente na clareira, se houver. Após resolver as turbas, role o dado de turba e posicione uma turba em uma clareira correspondente sem turba, mas adjacente a uma turba.<br><br></size=80%>2º: Recrute <size=80%>guerreiros iguais à sua Proeza na clareira do seu Senhor da Guerra, e então um guerreiro em cada forte.<br><br></size=80%>3º: Convoque <size=80%>um guerreiro das Centenas como seu novo Senhor da Guerra se ele estiver fora do mapa. Se não puder, posicione seu Senhor da Guerra em qualquer clareira.<br><br></size=80%>4º: Escolha um Humor diferente <size=80%>que não mostre um item no seu Tesouro.<br>
+playerinfo.lordofthehundreds.daylight=1º: Criar<size=80%> usando fortes.<br><br></size=80%>2º: Comande as Centenas<size=80%> um número de vezes até Comandar.<br><br><sprite name="hundredswarrior"> Mover<br><br><sprite name="hundredswarrior"> Batalha<br><br><sprite name="hundredswarrior"> Construir<br><br></size=80%>3º: Avance com o Senhor da Guerra<size=80%> um número de vezes até sua quantidade de Proezas.<br><br>Você pode mover seu Senhor da Guerra com quaisquer guerreiros das Centenas, e então pode batalhar na clareira do seu Senhor da Guerra.
+playerinfo.lordofthehundreds.evening=1º: Incite<size=80%> - quantas vezes quiser. Gaste uma carta para posicionar uma horda em uma clareira correspondente com um guerreiro ou Senhor da Guerra das Centenas, mas sem horda.<br><br></size=80%>2º: Oprima <size=80%>clareiras que você governa e que têm uma peça das Centenas e nenhuma peça inimiga. <br><br>1-2: <sprite name="1VP">   3-4: <sprite name="2VP"><br><br>5: <sprite name="3VP">   6+: <sprite name="4VP"><br></size=80%><br>Compre <size=80%>- 1 carta.</size=90%> Descarte<size=80%> até ficar com 5 cartas.
+playerinfo.lordofthehundreds.evening.infiltrate.normal=1º: Incite<size=80%> - qualquer número de vezes. Gaste uma carta para colocar uma turba em uma clareira correspondente com um guerreiro ou Senhor da Guerra, mas nenhuma turba.<br><br></size>2º: Infiltre <size=80%>clareiras governadas por um oponente que tenham uma peça das Centenas. <br><br>1-2: <sprite name="1VP_White"> 3-4: <sprite name="2VP_White"><br><br>5: <sprite name="3VP_White"> 6+: <sprite name="4VP_White"><br></size><br>Compre <size=80%>- 1 carta. </size=90%>Descarte<size=80%> até 5 cartas.</size>
+playerinfo.lordofthehundreds.evening.infiltrate.heroic=1º: Incite<size=80%> - qualquer número de vezes. Gaste uma carta para colocar uma turba em uma clareira correspondente com um guerreiro ou Senhor da Guerra, mas nenhuma turba.<br><br></size>2nd: Infiltre <size=80%>clareiras governadas por um oponente com pelo menos 3 peças, que tenham um guerreiro das Centenas ou Senhor da Guerra. <br><br>1-2: <sprite name="1VP_White">   3-4: <sprite name="2VP_White"><br><br>5: <sprite name="3VP_White">   6+: <sprite name="4VP_White"><br></size><br>Compre <size=80%>- 1 carta. </size=90%>Descarte<size=80%> até 5 cartas.</size>
+playerinfo.lordofthehundreds.protectthewarlord=Proteger o Senhor da Guerra
+hundreds.moods.selection.title=Escolher Humor
+hundreds.moods.selection.no.moods=Sem Humores Disponíveis
+hundreds.moods.selection.newmood=Novo Humor
+hundreds.moods.selection.oldmood=Humor Antigo
+hundreds.moods.grandiose=Grandioso
+hundreds.moods.desc.grandiose=Troque a etapa Avance com o Senhor da Guerra pela etapa Comande as Centenas.
+hundreds.moods.stubborn=Teimoso
+hundreds.moods.desc.stubborn=Em batalha com seu Senhor da Guerra, você ignora o primeiro golpe que sofrer.
+hundreds.moods.bitter=Cruel
+hundreds.moods.desc.bitter=Em batalha com o Senhor da Guerra, antes da rolagem, posicione um guerreiro na clareira da batalha por horda que você escolher remover da clareira da batalha e das adjacentes.
+hundreds.moods.lavish=Esbanjador
+hundreds.moods.desc.lavish=No final do Amanhecer, você pode remover quaisquer itens do seu Tesouro para posicionar dois guerreiros por item removido na clareira do seu Senhor da Guerra.
+hundreds.moods.relentless=Implacável
+hundreds.moods.desc.relentless=Sempre que você avançar com seu Senhor da Guerra e tanto mover quanto batalhar, você pode mover ou batalhar com ele <i>(como metade de um avanço)</i>.
+hundreds.moods.wrathful=Colérico
+hundreds.moods.desc.wrathful=Como atacante em batalha com seu Senhor da Guerra, você causa um golpe extra. <i>(Ao saquear, você causa este golpe.)</i>
+hundreds.moods.jubilant=Jubilante
+hundreds.moods.desc.jubilant=Após incitar na clareira do seu Senhor da Guerra, você pode rolar o dado da horda para posicionar uma horda <i>(como descrito na sua etapa Arrasar)</i> até quatro vezes.
+hundreds.moods.rowdy=Conflitante
+hundreds.moods.desc.rowdy=Durante o Anoitecer, compre uma carta a mais. Se a clareira do seu Senhor da Guerra tiver três ou mais peças inimigas, compre duas cartas a mais.
+hundreds.movewarlord.prompt.title=Mover Senhor da Guerra?
+keepers.faithfulretainers=Fiel Retentor
+keepers.faithfulretainers.desc=Quando você descartar esta carta, remova-a permanentemente.
+hundreds.command=Comandar
+hundreds.prowess=Proeza
+hundreds.lavish.desc=Você pode escolher remover itens do seu Tesouro para posicionar dois guerreiros na clareira do seu Senhor da Guerra por item removido.
+hundreds.lavish.title=Remover Itens para Luxuoso?
+hundreds.contemptfortrade.button.victorypoints=<style="vptext">PV</style>
+hundreds.contemptfortrade.button.hoard=Tesouro
+hundreds.contemptfortrade.desc=Crie para adicionar <sprite name="[item]"> ao Tesouro ou para <sprite name="2VP">
+hundreds.hoardfull.desc=Escolha um item para remover do Tesouro (ou o item que acabou de ganhar) e pontue (<sprite name="1VP">).
+hundreds.hoardfull.title=Seu Tesouro Está Cheio
+hundreds.hoardfull.newitem=Novo Item
+playerinfo.keepersiniron.retinue.desc=Você pode adicionar qualquer número de cartas da sua mão ao Séquito ou mover uma carta dentro dele.
+playerinfo.keepersiniron.retinue.move.title=Mover
+playerinfo.keepersiniron.retinue.battleanddelve.title=Batalhar e Escavar
+playerinfo.keepersiniron.retinue.battleanddelve.desc=...na mesma clareira correspondente
+playerinfo.keepersiniron.retinue.moveorrecover.title=Mover ou Recuperar
+playerinfo.keepersiniron.retinue.moveorrecover.desc=...de uma clareira correspondente
+playerinfo.keepersiniron.retinue.recruit.title=Mover
+playerinfo.keepersiniron.retinue.recruit.desc=...de uma clareira correspondente
+playerinfo.keepersiniron.buildwaystations.title=Escolha qual tipo de estação posicionar.
+playerinfo.keepersiniron.buildwaystations.desc=Você pode pressionar o ícone <sprite name="Flip"> para alternar para o outro lado de uma estação.
+playerinfo.keepersiniron.buildwaystations.tablet=Tábua
+playerinfo.keepersiniron.buildwaystations.jewelry=Jóia
+playerinfo.keepersiniron.buildwaystations.figure=Figura
+playerinfo.keepersiniron.buildwaystations.prompt.title=Escolher Estação
+playerinfo.keepersiniron.moverelic.prompt.title=Mover Relíquia?
+playerinfo.keepersiniron.recoverrelic.prompt.title=Relíquias
+playerinfo.keepersiniron.recoverrelic.prompt.button=Recuperar
+playerinfo.keepersiniron.delverelic.prompt.button=Escavar
+hirelings.uprising.title=Escolha a Habilidade de Insurgência
+hirelings.selection.title=Escolha um mercenário para contratar
+hirelings.card.forestpatrol.title=Patrulha Florestal
+hirelings.card.forestpatrol.ability.1=Sempre que quaisquer guerreiros da Patrulha forem removidos, posicione um deles nesta carta, e não na reserva.
+hirelings.card.forestpatrol.ability.2=Você pode mover, e então pode batalhar.<br><br><b>-OU-</b><br><br>Posicione todos os guerreiros da Patrulha desta carta em uma clareira com quaisquer guerreiros da Patrulha.
+hirelings.card.lastdynasty.title=Última Dinastia
+hirelings.card.lastdynasty.ability.2=Se não houver guerreiros da Dinastia no mapa, posicione todos os 5 guerreiros da Dinastia em qualquer clareira na borda e batalhe lá.<br><br><b>-OU-</b><br><br>Se eles governarem a clareira, mova todos os seus guerreiros e depois batalhe com eles, se possível.<br><br><b>-OU-</b><br><br>Se eles não governarem a clareira, batalhe lá duas vezes.
+hirelings.card.springuprising.title=Insurgência da Primavera
+hirelings.card.springuprising.ability.1=Se não houver guerreiros de Insurgência no mapa, role o dado da insurgência e posicione um guerreiro de Insurgência em uma clareira correspondente.<br><br>Para batalhar contra a Insurgência, o atacante deve descartar uma carta correspondente à clareira da batalha.
+hirelings.card.springuprising.ability.2=<size=125%><b>1º</b></size> Você deve rolar o dado da insurgência.<br><br><size=125%><b>2º</b></size> Você deve remover um guerreiro de Insurgência e todas as peças inimigas de uma clareira correspondente.<br><br><b>-OU-</b><br><br>Você deve posicionar um guerreiro de Insurgência em uma clareira correspondente.
+hirelings.card.theexile.title=O Exilado
+hirelings.card.theexile.ability.1=A qualquer momento durante o turno, um jogador com peças de facção adjacentes ao Exilado pode posicionar um item de sua caixa de Itens Criados nesta carta para comprar uma carta e pontuar um ponto.
+hirelings.card.theexile.ability.2=Quantas vezes quiser, você pode exaurir um item aqui para se mover para uma floresta adjacente, e pode exaurir dois itens aqui para batalhar em uma clareira adjacente.<br><br>Ao terminar, reanime todos os itens aqui.<br><br>Em batalha, você pode causar golpes até o número de itens aqui. Para cada golpe sofrido, exaura um item ou remova um se não puder exaurir nenhum.
+hirelings.card.felinephysicians.title=Médicos Felinos
+hirelings.card.felinephysicians.ability.1=<b>Controlador:</b> Sempre que qualquer um de seus guerreiros de facção for removido, você pode gastar uma carta correspondente à clareira deles para posicionar esses guerreiros em uma clareira com suas peças de facção, em vez de na reserva <i>(como Hospitais de Campo)</i>.
+hirelings.card.bluebirdnobles.title=Nobres do Pássaro Azul
+hirelings.card.bluebirdnobles.ability.1=<b>Controlador:</b> Você governa clareiras em caso de empate na presença <i>(como Lordes da Floresta)</i>.<br><br><b>Controlador:</b> Pontue um ponto para cada três clareiras que você governar.
+hirelings.card.rabbitscouts.title=Exploradores de Coelho
+hirelings.card.rabbitscouts.ability.1=<b>Controlador:</b> Como defensor em batalha, antes da rolagem, você pode gastar uma carta correspondente à clareira da batalha para usar o maior valor da rolagem e fazer o atacante usar o menor valor <i>(como Guerrilha)</i>.
+hirelings.card.thebrigand.title=O Salteador
+hirelings.card.thebrigand.ability.1=<b>Controlador:</b> Você pode pegar um item de uma ruína em uma clareira com suas peças de facção. <i>(Como Senhor das Centenas, coloque-o no seu Tesouro.)</i> Se você pegou o último item da ruína, remova a ruína.<br><br><b>Controlador:</b> Você pode exaurir um item na sua caixa de Itens Criados <i>(não no Tesouro)</i> para pegar uma carta aleatória de um jogador com peças de facção em uma clareira com suas peças de facção.
+hirelings.card.popularband.title=Bando Popular
+hirelings.card.popularband.ability.1=Se não houver guerreiros do Bando no mapa, posicione um guerreiro do Bando em uma clareira com suas peças de facção.<br><br>Os inimigos não podem se mover de uma clareira com um guerreiro do Bando no mesmo turno em que se moveram para ela.
+hirelings.card.popularband.ability.2=<b>1º</b> Escolha uma clareira com um guerreiro do Bando. Você pode forçar qualquer guerreiro de facção em cada clareira adjacente a se mover para a clareira escolhida.<br><br><b>2º</b> Você pode posicionar um guerreiro do Bando em qualquer clareira.
+hirelings.card.vaultkeepers.title=Guardas do Cofre
+hirelings.card.vaultkeepers.ability.1=Se não houver peças dos Guardas no mapa, posicione 2 guerreiros dos Guardas e um marcador de cofre em qualquer clareira.
+hirelings.card.vaultkeepers.ability.2=<b>1º</b> Você pode posicionar um cofre em uma clareira com um cofre ou adjacente a ele. Se não puder, posicione um guerreiro e um cofre em qualquer clareira.<br><br><b>2º</b> Você pode batalhar em cada clareira com um cofre.<br><br><b>-OU-</b><br><br>Você pode posicionar um guerreiro dos Guardas em cada cofre.
+hirelings.card.flamebearers.title=Portadores da Chama
+hirelings.card.flamebearers.ability.1=Se não houver guerreiros dos Portadores no mapa, posicione 2 guerreiros dos Portadores em quaisquer clareiras.
+hirelings.card.flamebearers.ability.2=<b>1º</b> Em cada clareira com quaisquer guerreiros dos Portadores, você deve remover uma peça inimiga por guerreiro dos Portadores lá, guerreiros primeiro.<br><br><b>2º</b> Você deve posicionar um guerreiro dos Portadores em um guerreiro dos Portadores ou adjacente a ele. Se não puder, posicione 2 guerreiros dos Portadores em quaisquer clareiras.
+hirelings.card.streetband.title=Bando de Rua
+hirelings.card.streetband.ability.1=Posicione um guerreiro do Bando em qualquer clareira.
+hirelings.card.badgerbodyguards.title=Guarda-costas Texugos
+hirelings.card.badgerbodyguards.ability.1=<b>Controlador:</b> Em batalha, você ignora o primeiro golpe que sofrer. <i>(Isso não se combina com outros efeitos que permitem ignorar o primeiro golpe que você sofrer.)</i>
+hirelings.card.ratsmugglers.title=Contrabandistas de Rato
+hirelings.card.ratsmugglers.ability.1=<b>Controlador:</b> Quantas vezes quiser durante o Dia, você pode descartar uma carta com um item para se mover ou batalhar. <i>(Você não precisa ser capaz de criar o item.)</i>
+hirelings.prompt.bluebirdvpgain.title=Bônus de Governo de Clareira
+hirelings.prompt.flamebearersremovewarrior.title=Portadores da Chama
+hirelings.prompt.flamebearersremovewarrior.desc=Removendo peças inimigas em clareiras com portadores
+hirelings.prompt.uprisingremovingpieces.title=Insurgência
+hirelings.prompt.uprisingremovingpieces.body=Removendo Guerreiro de Insurgência e todas as peças inimigas
+keepers.prompt.liveoftheland.title=Deixe a Terra
+keepers.prompt.liveoftheland.desc=1 guerreiro dos Guardiões removido de clareiras com 4 ou mais guerreiros.
+keepers.prompt.huddleup.title=Reunir-se
+keepers.prompt.huddleup.desc=Guardiões removidos de clareiras sem outros guerreiros Guardiões.
+keepers.prompt.famine.title=Relíquia Vinculada
+keepers.prompt.famine.desc=1 guerreiro Guardião é removido de cada clareira sem nenhuma Relíquia.
+keepers.prompt.recovered.title=Recuperado
+keepers.prompt.recovered.desc=Bônus Completo:
+keepers.prompt.delve.title=Escavar
+keepers.prompt.retinuelost.title=Séquito Perdido
+keepers.prompt.retinuelost.delve.desc=Guardas governam menos clareiras adjacentes à floresta de onde a relíquia veio do que o valor dela.
+keepers.prompt.retinuelost.recover.desc=Guardas governam menos clareiras correspondentes do que o valor da relíquia recuperada.
+hundreds.prompt.item.tohoard=<b>Desprezo pelo Comércio</b><br>Item Adicionado ao Tesouro e Não Pontuado
+hundreds.prompt.item.tononhoard=<b>Desprezo pelo Comércio</b><br>Item Removido e Pontuado
+hundreds.prompt.warlordanointed.title=Senhor da Guerra Convocado
+hundreds.prompt.incite.title=Incitar
+hundreds.prompt.oppress.title=Oprimir
+hundreds.prompt.oppress.description={0} clareiras governadas sem inimigos
+hundreds.prompt.infiltrate.title=Infiltrar
+hundreds.prompt.infiltrate.normal.description={0} clareiras governadas por oponentes com um guerreiro das Centenas ou Senhor da Guerra
+hundreds.prompt.infiltrate.heroic.description={0} clareiras governadas por oponentes com 4 ou mais peças de oponentes e um guerreiro das Centenas ou Senhor da Guerra
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseNewEncamp=Escolha uma clareira para posicionar um guerreiro e uma estação.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseEncamp=Acampar: Escolha uma clareira para substituir um guerreiro por uma estação.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseWaystation=Construir Estação
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoEncamp=Nenhum outro Acampamento possível
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseDecamp=Levantar Acampamento: Escolha uma estação para substituir por um guerreiro
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoDecamp=Impossível Levantar Acampamento.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseCardRecruit=Gaste uma carta correspondente para recrutar 2 guerreiros.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseCardRecruitOne=Gaste uma carta correspondente para recrutar 1 guerreiro.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseRecruitClearing=Escolha uma clareira com uma estação para recrutar 2 guerreiros lá.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseRecruitClearingOne=Escolha uma clareira com uma estação para recrutar 1 guerreiro lá.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoRecruit=Não é possível recrutar mais
+creategame.enablehirelings=Habilitar Mercenários
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoves=Nenhum movimento possível
+tuber.canis.abilities.KeepersInIronAbilities.KeepersMoveAbility.ChooseMoveRelics=Escolha guerreiros e relíquias para mover
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve=Escolha uma clareira para Batalhar, depois Escavar
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.BattleOrDelve=Escolha guerreiros inimigos para batalhar ou escolha uma relíquia para escavar
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.Delve=Escolha uma relíquia para Escavar
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoBattleDelve=Nenhuma Batalha, depois Escavar possível
+tuber.canis.abilities.KeepersInIronAbilities.KeepersBattleDelveAbility.ChooseBattleEnemy=Escolha um inimigo para batalhar
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseMoveRecover=Escolha guerreiros para Mover ou uma relíquia para Recuperar
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseRecover=Escolha uma relíquia para recuperar
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoveRecover=Nenhum movimento ou recuperação possível
+tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseStarting=Escolha uma clareira para posicionar quatro guerreiros
+tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseSecond=Escolha uma clareira vizinha para posicionar quatro guerreiros
+tuber.canis.undo.KeepersSetupUndo=Pressione o botão continuar para concluir a preparação.
+tuber.canis.actions.KeepersInIronActions.KeepersRelicDestroyed=Escolha uma floresta para posicionar esta relíquia
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.AddOrShift=Adicione cartas ao seu Séquito (máximo 10) ou mova 1 carta dentro dele
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Add=Adicione cartas ao seu Séquito (máximo 10)
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Shift=Mova uma carta no seu Séquito
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.None=Nenhuma modificação de Séquito possível
+tuber.canis.undo.HundredsSetupUndo=Pressione o botão continuar para concluir a preparação.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsSetup.ChooseStarting=Escolha uma clareira para posicionar seu Senhor da Guerra, quatro guerreiros e um forte.
+tooltip.playmat.relicstack=<size=125%><b>Relíquias</b></size>
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRaze=Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMobClearing=Escolha uma clareira adjacente a uma turba para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.NoClearingsForMob=Nenhuma clareira correspondente para colocar uma turba. Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.NoMobsForRaze=Sem peças de turba! Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRazeTakeItem=Escolha um item para pegar da ruína.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRecruit=Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitClearing=Escolha um forte para recrutar um guerreiro.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToAnoint=Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointClearing=Escolha uma clareira para colocar seu Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointWarrior=Escolha uma clareira com um guerreiro das Centenas para substituir um deles pelo seu Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.AnointAlreadyPresent=Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMood=Escolha um Humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToLavish=Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseLavish=Remova itens de seu Tesouro para colocar dois guerreiros para cada.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToBirdsongEnd=Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCraftMode=Crie para adicionar [item] ao tesouro ou para ganhar [X]
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseNoCraft=Não há cartas para criar. Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCommand=Escolha uma ação de Comando para executar.
+hundredsWithColor=<color=#B40518>Senhor das Centenas</color>
+keepersWithColor=<color=#575757>Guardiões de Ferro</color>
+tuber.canis.actions.LordOfTheHundredsActions.HundredsHoardDiscard=Escolha um item para remover do seu Tesouro e ganhe 1 <style="vptext">PV</style>.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLoot=Você não causa nenhum acerto rolado na batalha. Em vez disso, pegue um dos seguintes itens se você governar a clareira após a batalha:
+tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLootItem=Escolha um item para pegar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsBattleBitter=Remova turbas adjacentes para adicionar esse mesmo número de guerreiros à batalha.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildClearing=Escolha uma clareira correspondente para colocar um forte.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildCard=Gaste uma carta para colocar um forte em uma clareira correspondente que você governa.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsBattleAbility=Escolha um inimigo para lutar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsDaylightRelentless=Implacável! Mover-se ou batalhar com seu Senhor da Guerra?
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteClearing=Escolha uma clareira para incitar uma turba (custa uma carta correspondente).
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteCard=Escolha uma carta correspondente para gastar.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteCard=Nenhuma carta na mão correspondendo a uma compensação válida para Incitar. Pressione continuar.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteMob=Nenhuma turba em estoque para Incitar. Pressione continuar.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.JubilantChooseRoll=Rolar para colocar uma turba? ([X] restantes)
+keepers.prompt.mobdie.title=Dado de turba
+playerinfo.lordofthehundreds.command=Comandar
+playerinfo.lordofthehundreds.prowess=Proeza
+prompts.keepersbuild.waystation=Estação
+prompts.hundredsbuild.stronghold=Forte
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseMoveWarlord=Escolha quantos guerreiros mover e se deseja mover seu Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoWarlord=Nenhum Senhor da Guerra com quem avançar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOrBattle=Escolha uma clareira para mover seu Senhor da Guerra com quaisquer guerreiros das Centenas ou escolha um inimigo para lutar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOnly=Escolha uma clareira para mover seu Senhor da Guerra com quaisquer guerreiros das Centenas.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceBattleOnly=Escolha um inimigo para lutar com seu Senhor da Guerra e guerreiros das Centenas.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoActions=Sem investidas restantes.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.CommandNoActions=Nenhuma ação de Comando restante.
+warning.keepers.encamp=Esta clareira não tem um slot de construção aberto para sua Estação. Tem certeza de que quer escolhê-la e colocar apenas um guerreiro?
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseNewEncamp.opponent=[player] está Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseEncamp.opponent=[player] está Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseWaystation.opponent=[player] está Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoEncamp.opponent=[player] está Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseDecamp.opponent=[player] está Levantando Acampamento.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoDecamp.opponent=[player] está Levantando Acampamento.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseCardRecruit.opponent=[player] está recrutando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseRecruitClearing.opponent=[player] está recrutando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoRecruit.opponent=[player] está recrutando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoves.opponent=[player] está movendo.
+tuber.canis.abilities.KeepersInIronAbilities.KeepersMoveAbility.ChooseMoveRelics.opponent=[player] está movendo.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.opponent=[players] está escolhendo Batalhar, depois Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.BattleOrDelve.opponent=[players] está escolhendo Batalhar, depois Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.Delve.opponent=[players] está escolhendo Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoBattleDelve.opponent=[players] está escolhendo Batalhar, depois Escavar.
+tuber.canis.abilities.KeepersInIronAbilities.KeepersBattleDelveAbility.ChooseBattleEnemy.opponent=[players] está escolhendo Batalhar, depois Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseMoveRecover.opponent=[players] está escolhendo Mover ou Recuperar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseRecover.opponent=[players] está escolhendo Mover ou Recuperar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoveRecover.opponent=[players] está escolhendo Mover ou Recuperar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseStarting.opponent=[player] está escolhendo uma clareira para começar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseSecond.opponent=[player] está escolhendo uma clareira para começar.
+tuber.canis.undo.KeepersSetupUndo.opponent=[player] está escolhendo uma clareira para começar.
+tuber.canis.actions.KeepersInIronActions.KeepersRelicDestroyed.opponent=[player] está colocando a relíquia removida em uma floresta.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.AddOrShift.opponent=[player] está recebendo o Séquito.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Add.opponent=[player] está recebendo o Séquito.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Shift.opponent=[player] está recebendo o Séquito.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.None.opponent=[player] está recebendo o Séquito.
+tuber.canis.undo.HundredsSetupUndo.opponent=[player] está escolhendo uma clareira para começar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsSetup.ChooseStarting.opponent=[player] está escolhendo uma clareira para começar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRaze.opponent=[player] está iniciando seu turno.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMobClearing.opponent=[player] está escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.NoClearingsForMob.opponent=[player] está escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.NoMobTokens.opponent=[player] está escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.NoMobsForRaze.opponent=[player] está escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRazeTakeItem.opponent=[player] está escolhendo um item para pegar da ruína.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRecruit.opponent=[player] está recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitClearing.opponent=[player] está recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToAnoint.opponent=[player] está recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointClearing.opponent=[player] está colocando seu Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointWarrior.opponent=[player] está convocando um guerreiro.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.AnointAlreadyPresent.opponent=[player] está escolhendo um novo humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMood.opponent=[player] está escolhendo um novo humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToLavish.opponent=[player] está escolhendo um novo humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseLavish.opponent=[player] está removendo itens de seu Tesouro para colocar guerreiros.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToBirdsongEnd.opponent=[player] está terminando o Amanhecer.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCraftMode.opponent=[player] está criando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseNoCraft.opponent=[player] está criando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCommand.opponent=[player] está escolhendo uma ação de Comando para realizar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsHoardDiscard.opponent=[player] está escolhendo um item para descartar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLoot.opponent=[player] está escolhendo se vai saquear.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLootItem.opponent=[player] está escolhendo um item para saquear.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsBattleBitter.opponent=[player] está escolhendo uma turba para substituir com guerreiros.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildClearing.opponent=[player] está construindo.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildCard.opponent=[player] está construindo.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsBattleAbility.opponent=[player] está escolhendo Batalhar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsDaylightRelentless.opponent=[player] está escolhendo Mover ou Batalhar.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteClearing.opponent=[player] está Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteCard.opponent=[player] está Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteCard.opponent=[player] está Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteMob.opponent=[player] está Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.JubilantChooseRoll.opponent=[player] está colocando uma turba usando Jubilante.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseMoveWarlord.opponent=[player] está movendo.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoWarlord.opponent=[player] está avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOrBattle.opponent=[player] está avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOnly.opponent=[player] está avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceBattleOnly.opponent=[player] está avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoActions.opponent=[player] está avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.CommandNoActions.opponent=[player] está escolhendo uma ação de Comando para realizar.
+scenario.ironritual.name=Ritual de Ferro
+scenario.ironritual.tier1description=Você não pode vencer a menos que tenha 3 relíquias de tipos diferentes (figuras, tábuas, jóias) espalhadas uniformemente entre 3 clareiras de canto diferentes.
+scenario.ironritual.tier2description=Você não pode vencer a menos que tenha 3 relíquias de valores diferentes (1, 2, 3) distribuídas uniformemente entre as 3 clareiras de canto diferentes nas quais você não começou o jogo.
+scenario.winterschill.name=Frio do Inverno
+scenario.winterschill.tier1description=Deixe a Terra é substituído por Reunir-se - No início do Anoitecer, remova cada guerreiro Guardião em uma clareira sem outros guerreiros Guardiões.
+scenario.winterschill.tier2description=Deixe a Terra é substituído por Relíquia Vinculada - No início do Anoitecer, remova um guerreiro Guardião de cada clareira sem uma relíquia.
+scenario.deliverymission.name=Missão de Entrega
+scenario.deliverymission.tier1description=Você não pode se recuperar em estações. Em vez disso, as relíquias são recuperadas automaticamente no início do seu Anoitecer enquanto estiver em uma clareira com um Malandro. A coluna Mover ou Recuperar do seu Séquito é substituída por Mover.
+scenario.deliverymission.tier2description=Você não pode se recuperar em estações. Em vez disso, as relíquias são recuperadas automaticamente no início do seu Anoiteccer enquanto estiver em uma clareira com a Torre da Guarda dos Marqueses ou uma Base da Aliança da Floresta. A coluna Mover ou Recuperar do seu Séquito é substituída por Mover. Você só pode recrutar em estações que tenham uma relíquia correspondente em sua clareira.
+scenario.temperamental.name=Temperamental
+scenario.temperamental.tier1description=Seu humor é determinado aleatoriamente a cada turno (dentre opções legais). Uma vez por turno, você pode rerolar seu humor para um novo.
+scenario.temperamental.tier2description=Seu humor é determinado aleatoriamente a cada turno (dentre opções legais). Você só pode construir quando estiver Grandioso,  Esbanjador ou Teimoso. Você só pode criar quando estiver Implacável, Cruel ou Jubilante. Você só pode Arrasar quando estiver Conflitante ou Colérico.
+scenario.infiltrationmission.name=Missão de Infiltração
+scenario.infiltrationmission.tier1description=A Opressão é substituída pela Infiltração - Pontue no Anoitecer com base nas clareiras governadas por inimigos e que contenham um guerreiro das Centenas ou o Senhor da Guerra.
+scenario.infiltrationmission.tier2description=A Opressão é substituída pela Infiltração - Pontue no Anoitecer com base nas clareiras governadas por inimigos com pelo menos quatro peças e que contenham um guerreiro das Centenas ou o Senhor da Guerra.
+scenario.mobjustice.name=Justiça da Turba
+scenario.mobjustice.tier1description=Você não pode começar batalhas em clareiras sem uma turba presente.
+scenario.mobjustice.tier2description=Você não pode começar batalhas em clareiras sem uma turba presente. Você começa com menos 1 turba e menos 3 fortes em seu suprimento.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitStronghold=No limite de suprimento de guerreiros. Escolha um Forte para recrutar um guerreiro. ([X] restantes)
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitStronghold.opponent=[player] está recrutando.
+tuber.canis.abilities.LordOfTheHundredsPlayer.TemperamentalChallengeAbility.ChooseCard=Gaste uma carta correspondente para redefinir seu humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsSetup.ChooseMobJustice=Escolha uma clareira para colocar uma turba.
+tuber.canis.actions.ContinueToEvening=Continue para o Anoitecer.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.DeliveryMissionRecruitClearing=Escolha uma clareira com uma estação para recrutar um guerreiro lá.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.DeliveryMissionRecruitClearing.opponent=[player] está Recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.TemperamentalMoodChosen=Humor determinado aleatoriamente.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.TemperamentalMoodChosen.opponent=[player] está escolhendo um novo Humor.
+aiplayername.keepersiniron=Guardiões de Ferro
+aiplayername.lordofthehundreds=Senhor das Centenas
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.LavishNoItems=Nenhum item para remover para Esbanjador. Pressione continuar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.LavishNoItems.opponent=[player] está removendo itens de seu Tesouro para colocar guerreiros.
+lht.intro.1=A Floresta treme - as <color=#B40518>Centenas</color> convocaram um novo Senhor da Guerra. Suas legiões de guerreiros e turbas empunhando tochas arrasarão Clareiras ao comando de seu demagogo.<br>Ganhar itens aumenta suas ações, e o humor inconstante de seu líder fortalece suas forças.
+lht.intro.2=Você aí! O velho <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> caiu. Um novo <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color> foi escolhido para tomar seu lugar. Vida longa ao <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color>!
+lht.setup.1=Coloque seu <sprite name="Stronghold"><b><color=#B40518>Forte</color></b>, <sprite name="HundredsWarlord"><color=#B40518><b>Senhor da Guerra</b></color> e 4 <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> nesta clareira.
+lht.setup.2=Deste <sprite name="Stronghold"><color=#B40518>forte</color> você recrutará <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> e criará itens para encher seu <color=#B40518><b>tesouro</b></color>, fortalecendo suas ações.
+lht.1.1=Durante o Amanhecer, seu <sprite name="Stronghold"><color=#B40518>forte</color> recruta 1 <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color>, e outro é recrutado em seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> devido à <color=#B40518><b>Proeza das Centenas</color></b>.
+lht.1.2=Agora vamos ver... qual é o <b><color=#B40518>humor</color></b> do seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> hoje?
+lht.1.3=<color=#B40518>Humores</color> dão novas habilidades poderosas às <color=#B40518>Centenas</color>, mas eles mudam a cada turno! Neste turno, vamos mostrar aos <color=#CC6633>Marqueses</color> seu poder <color=#B40518>Colérico</color>!
+lht.1.4=O dia está começando! Espere para criar qualquer coisa por enquanto.
+lht.1.5=O número de ações que você pode realizar é determinado pelo seu <color=#B40518>Tesouro</color>, que pode ser visualizado selecionando seu retrato.
+lht.1.6=Os itens <sprite name="boot">, <sprite name="bag"> e <sprite name="coinstack"> são adicionados ao seu <color=#B40518><b>Comando</b></color>, aumentando sua capacidade de construir <sprite name="Stronghold"><color=#B40518>fortes</color>, mover-se e batalhar.
+lht.1.7=Os itens <sprite name="hammer">, <sprite name="teapot">, <sprite name="sword"> e <sprite name="crossbow"> aumentam sua <color=#B40518><b>Proeza</b></color>, aumentando o número de <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> que você recruta e dando ao seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> ações extras.
+lht.1.8=Como você não tem itens de <color=#B40518>Comando</color>, você só pode realizar uma única ação. Expulse esse <sprite name="marquise"><color=#CC6633>guerreiro</color> rebelde da sua clareira inicial!
+lht.1.9=Ótimo. Agora é hora do seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> <b><color=#B40518>avançar</color></b>!
+lht.1.10=Sem itens de <color=#B40518>Proeza</color>, você só pode <color=#B40518>avançar</color> uma vez, movendo seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> junto com quaisquer <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> na mesma clareira e, em seguida, batalhando na nova clareira.
+lht.1.11=Lidere seus <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> em uma batalha gloriosa contra os <color=#CC6633>Marqueses</color>! Mova dois deles com seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> para esta clareira.
+lht.1.12=Agora, batalhe!
+lht.1.13=Um teste infeliz, mas seu <color=#B40518>humor Colérico</color> deu um golpe de qualquer forma! Os <color=#CC6633>Marqueses</color> pensarão duas vezes antes de ficarem tão pertos de suas forças no futuro.
+lht.1.14=O Anoitecer começa, mas o ataque está apenas começando. Você pode gastar uma carta para <color=#B40518><b>Incitar</b></color> uma <sprite name="Mob"><color=#B40518><b>turba</b></color> em uma clareira correspondente que tenha um <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color>, mas nenhum <sprite name="Mob">!
+lht.1.14b=Se os <color=#CC6633>Marqueses</color> não lidarem com isso, você reivindicará um item da ruína.
+lht.1.15=A cada turno, você ganha pontos para cada clareira que você <color=#B40518><b>Oprimiu</b></color>. Clareiras <color=#B40518>Oprimidas</color> são aquelas que você governa e que não têm nenhuma peça inimiga - nenhum guerreiro, nenhuma ficha, nenhuma construção, nada.
+lht.1.16=Você <color=#B40518>Oprimiu</color> uma clareira, marcando <sprite name="1VP">. Você precisará fazer muito melhor se quiser dominar a Floresta!
+lht.1.17=Por fim, você compra uma carta. Então veremos o que aqueles mesquinhos dos <color=#CC6633>Marqueses</color> tentarão!
+lht.2.1=Ha! Os <color=#CC6633>Marqueses</color> tolos nem tentaram dispersar sua turba. Agora essa clareira será <color=#B40518><b>Arrasada</b></color>!
+lht.2.2=Quando uma turba <color=#B40518>Arrasa</color> uma clareira, todos os edifícios e fichas inimigas são removidos - mas não os guerreiros. Você pontua normalmente por isso.
+lht.2.3=Então, se essa clareira tiver uma ruína, você reivindica um item dela para adicionar ao seu <color=#B40518>Tesouro</color>.
+lht.2.4=Depois, a turba se espalha de sua clareira atual. O <sprite name="MobDie"><color=#B40518>Dado de Turba</color> dita o naipe de clareira...
+lht.2.5=...<sprite name="ClearingMouse">! Coloque a nova turba na clareira <sprite name="ClearingMouse"> ao Leste. Ela não <color=#B40518>Arrasará</color> seus próprios <sprite name="Stronghold"><color=#B40518>fortes</color>, e você poderá defendê-lo mais facilmente dos <color=#CC6633>Marqueses</color>.
+lht.2.6=Graças à <sprite name="sword"> que sua <sprite name="Mob"><color=#B40518>turba</color> desenterrou, sua <color=#B40518>Proeza</color> aumentou para 2! Agora você recrutará <i>2</i> <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> na clareira do seu <sprite name="HundredsWarlord"><color=#B40518>Senha da Guerra</color> a cada turno, além do 1 usual em cada <sprite name="Stronghold"><color=#B40518>forte</color>.
+lht.2.7=Hoje, vamos mostrar aos <color=#CC6633>Marqueses</color> o quão <color=#B40518>Teimosas</color> as <color=#B40518>Centenas</color> podem ser!
+lht.2.8=Use seu <sprite name="Stronghold"><color=#B40518>forte</color> para criar a <sprite name="bag"> que você comprou no último turno.
+lht.2.9=Há duas maneiras diferentes de criar um item: se você quiser ganhar pontos por ele, ele não será adicionado ao seu <color=#B40518>Tesouro</color> - você terá que descartá-lo devido ao seu <color=#B40518><b>Desprezo pelo Comércio</b></color>.
+lht.2.10=Mas você pode escolher abrir mão dos pontos e adicionar o item ao seu <color=#B40518>Tesouro</color>, aumentando sua <color=#B40518>Proeza</color> ou <color=#B40518>Comando</color> (dependendo do item). Faça isso agora.
+lht.2.11=Agora, é hora de <color=#B40518>Comandar as Centenas</color>. Construa outro <sprite name="Stronghold"><color=#B40518>forte</color>.
+lht.2.12=Para construir um <sprite name="Stronghold"><color=#B40518>forte</color>, você deve gastar uma carta de um naipe correspondente à clareira que deseja construir.
+lht.2.13=Boa! Como a <sprite name="bag"> que você criou antes é um item de <color=#B40518>Comando</color>, você pode realizar outra ação a cada turno! Reforce a clareira <sprite name="ClearingRabbit"> que você invadiu com outro <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color>.
+lht.2.14=Mais uma vez é hora de <color=#B40518>avançar</color>! Dois <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> devem ficar para trás para proteger sua clareira <sprite name="ClearingRabbit">, mas mova o resto com seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> para esmagar aqueles gatos!
+lht.2.15=Ótimo! Seu <color=#B40518>humor Teimoso</color> bloqueou o golpe. Você tem 2 <color=#B40518>Proezas</color> agora, graças a encontrar aquela <sprite name="sword">, então <color=#B40518>avance</color> novamente com dois de seus <color=#B40518>guerreiros</color>.
+lht.2.16=A Floresta se encolhe diante de você! Continue até o Anoitecer.
+lht.2.17=Guarde suas cartas em vez de <color=#B40518>Incitar</color> ainda mais.
+lht.2.18=Você está <color=#B40518>Oprimindo</color> 4 clareiras, então você ganha <sprite name="2VP">!
+lht.3.1=Hora da <sprite name="Mob"><color=#B40518>turba</color> se espalhar. A jogada é... <sprite name="ClearingRabbit">. Adicione uma <sprite name="Mob"> à clareira do <sprite name="ClearingRabbit"> Norte.
+lht.3.2=O esforço de recrutamento está indo bem graças à sua <color=#B40518>Proeza</color> aumentada e ao <sprite name="Stronghold"><color=#B40518>forte</color> que você construiu no último turno.
+lht.3.3=Cada item em seu <color=#B40518>Tesouro</color> impede que você escolha um certo <color=#B40518>humor</color>. Tenha cuidado para não criar itens que impeçam um <color=#B40518>Humor</color> que você planeja usar mais tarde.
+lht.3.4=Está na hora de uma <color=#B40518>Grandiosa</color> demonstração de poder! Ao permitir que seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> <color=#B40518>avance</color> antes de você tomar outras ações, você pode reivindicar clareiras e construir <sprite name="Stronghold"><color=#B40518>fortes</color> nelas no mesmo turno.
+lht.3.5=Crie o <sprite name="teapot"> em sua mão para continuar aumentando seu <color=#B40518>Tesouro</color>.
+lht.3.6=Isso progride na <color=#B40518>trilha de Proeza</color>, mas seu total permanece 2 por enquanto. Mais um item de <color=#B40518>Proeza</color> aumentará para 3!
+lht.3.7=Agora, ataque com seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color>! Deixe 1 <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color> para trás para continuar <color=#B40518>Oprimindo</color> aquela clareira.
+lht.3.8=Mova mais 2 <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> com seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> e ataque aquele bando de gatos sarnentos!
+lht.3.9=Você pode ter derrotado nosso líder, <color=#CC6633>Marquês</color>, mas outro em breve tomará seu lugar!
+lht.3.10=<sprite name="Stronghold"><color=#B40518>Fortes</color> são ainda mais importantes para as <color=#B40518>Centenas</color> do que os edifícios <color=#CC6633>Marqueses</color> são para eles - como uma <color=#CC6633>oficina</color> e um <color=#CC6633>recrutador</color> combinados. Seria sensato construir mais.
+lht.3.11=Reposicione dois dos seus <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> naquela clareira oriental <sprite name="ClearingFox">.
+lht.3.12=Nenhuma carta para <color=#B40518>Incitar</color>...
+lht.3.13=As 5 clareiras que você está <color=#B40518>Oprimindo</color> valem <sprite name="3VP">!
+lht.4.1=Sem clareiras <sprite name="ClearingRabbit"> adjacentes a uma de suas <sprite name="Mob"><color=#B40518>turbas</color> que ainda não tenham uma <sprite name="Mob">, elas não poderão espalhar seu caos miserável neste turno!
+lht.4.2=Sem um <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color>, você não pode recrutar <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> com base em sua <color=#B40518>Proeza</color>. Seus <sprite name="Stronghold"><color=#B40518>fortes</color> ainda recrutam <sprite name="HundredsWarrior">, mas sem um líder, as <color=#B40518>Centenas</color> serão perdidas!
+lht.4.3=Qualquer <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color> digno pode se tornar um líder em tempos tão difíceis. <color=#B40518><b>Convoque</b></color> um <sprite name="HundredsWarrior"> nesta clareira como seu novo <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color>!
+lht.4.4=Hah! Sob uma nova liderança ousada, reivindicaremos a Floresta para sempre! Primeira ordem do dia - as <color=#B40518>Centenas</color> exigem cartas. É hora de ficar <color=#B40518>Conflitante</color>!
+lht.4.5=Nada para criar por enquanto...
+lht.4.6=Em seguida, marche três <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> para reforçar seu novo <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color>!
+lht.4.7=Mantenha-os em movimento!
+lht.4.8=Os <color=#CC6633>Marqueses</color> criaram uma <sprite name="boot"> na última rodada. <color=#B40518>Avance</color> com quatro <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> e <color=#B40518><b>Saqueie</b></color> deles!
+lht.4.9=Sempre que você atacar, você pode escolher <color=#B40518>Saquear</color>. Você não causa nenhum acerto rolado, mas se você governar a clareira no final da batalha, você rouba um item da caixa de itens do defensor.
+lht.4.10=Haha! Faça as habilidades de criação do seu inimigo trabalharem para <i>você</i>! Pegue essa <sprite name="boot">!
+lht.4.11=Ao <color=#B40518>Avançar</color> com seu <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color>, você pode escolher apenas se mover ou batalhar em vez de fazer as duas coisas. Lute novamente para amolecer os <color=#CC6633>Marqueses</color>.
+lht.4.12=Eles sentiram isso! Continue até o Anoitecer.
+lht.4.13=Espere um pouco para <color=#B40518>Incitar</color> mais por enquanto.
+lht.4.14=Você está <color=#B40518>Oprimindo</color> 5 clareiras por <style="vpnum">3</style>!
+lht.5.1=Você fez bem em nos guiar até aqui. Pontue <style="vpnumddteen">20</style> para mostrar de uma vez por todas que as <color=#B40518>Centenas</color> não podem ser paradas!
+lht.5.2=Lembre-se, você continua marcando pontos a cada rodada que você <color=#B40518>Oprimir</color> as clareiras. Remova peças inimigas e mantenha seu domínio, e os <color=#CC6633>Marqueses</color> não conseguirão acompanhar.
+lht.trigger.tutorialcomplete=Suas legiões estão triunfantes!
+lotht.goal.20vp=Pontue <size=130%><style="vpnumddteen"></size>20</style>. ({0}/{1})
+lht.ftt.lavish=Você coletou um de cada tipo de item, desabilitando todos os seus <color=#B40518>humores</color>, exceto <color=#B40518>Esbanjador</color>. Você permanecerá <color=#B40518>Esbanjador</color> até descartar itens de um tipo específico.
+label.retinue=Séquito
+kii.intro.1=Estandartes marchando e o barulho de ferro sinalizam que os <color=#575757>Guardiões</color> estão aqui para recuperar o que é deles.<br><br>Se deixados sozinhos, eles vão vasculhar relíquias esquecidas nas florestas, mas esteja avisado: esses cavaleiros blindados são guerreiros formidáveis ​​e, se seu séquito de guias locais crescer muito rápido, eles podem dominar a Floresta!
+kii.setup.1=Comandante, esta clareira <sprite name="ClearingFox"> é um bom lugar para montar acampamento.
+kii.setup.2=Seus próximos 4 <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> devem apoiá-los na clareira <sprite name="ClearingMouse"> ao sul.
+kii.t1.1=Os batedores avançados estão relatando as posições das <color=#575757><b>relíquias</b></color>: há <sprite name="RelicJewelry"><b><color=#575757>jóias</color>, <sprite name="RelicTablet"><color=#575757>tábuas</color>,</b> e <b><sprite name="RelicFigure"><color=#575757>figuras</color></b> espalhadas por toda a Floresta.
+kii.t1.2=Sua missão é <color=#575757><b>recuperar</b></color> essas <color=#575757>relíquias</color>. Para fazer isso, você precisará estabelecer <color=#575757><b>estações</b></color>.
+kii.t1.3=Durante o Amanhecer, uma vez em cada clareira você pode <color=#575757><b>Acampar</b></color>, gastando um <sprite name="KeeperWarrior"><color=#575757>guerreiro</color> lá para construir uma de suas <color=#575757>estações</color>.<br>Coloque uma <color=#575757>estação</color> nesta <sprite name="ClearingFox"> clareira.
+kii.t1.4=Cada <color=#575757>estação</color> tem dois lados. Você pode escolher qual lado de uma <color=#575757>estação</color> terá a face para cima quando você a posicionar.
+kii.t1.5=Por enquanto, escolha esta <color=#575757>estação</color> com o lado <sprite name="RelicTablet"> voltado para cima.
+kii.t1.6=Você conseguiu. Agora, coloque outra <color=#575757>estação</color> na sua clareira <sprite name="ClearingMouse">.
+kii.t1.7=Coloque o lado <sprite name="RelicJewelry"> voltado para cima.
+kii.t1.8=Agora que você estabeleceu <color=#575757>estações</color>, você pode recrutar mais <sprite name="KeeperWarrior"><color=#575757>guerreiros</color>. Escolha esta <sprite name="ClearingMouse"> clareira novamente e gaste uma <sprite name="ClearingMouse"> carta da sua mão para recrutar 2 <sprite name="KeeperWarrior">.
+kii.t1.8.gamepad=Agora que você estabeleceu <color=#575757>estações</color>, você pode recrutar mais <sprite name="KeeperWarrior"><color=#575757>guerreiros</color>. Escolha esta <sprite name="ClearingMouse"> clareira novamente e gaste uma <sprite name="ClearingMouse"> carta da sua mão para recrutar 2 <sprite name="KeeperWarrior">.
+kii.t1.9=Você pode criar cartas com custos correspondentes às clareiras em que suas <color=#575757>estações</color> estão. Você não pode comprar nenhuma agora, então continue.
+kii.t1.10=Durante o Dia, você realiza ações usando seu <color=#575757><b>Séquito</b></color>. O <color=#575757>Séquito</color> funciona de forma semelhante ao <color=#336699>Decreto das Rapinas</color>, mas, diferentemente daqueles pássaros briguentos, as fileiras disciplinadas dos <color=#575757>Guardiões</color> não cairão em <color=#336699>Tumulto</color> se você não realizar uma ação.
+kii.t1.11=Você começa com um <color=#575757>Seguidor Fiel</color> em cada coluna do <color=#575757>Séquito</color>. Como os <color=#575757>Seguidores Fiéis</color> têm o naipe <sprite name="birdicon">, eles lhe dão flexibilidade em suas ações.
+kii.t1.12=Você usa o <color=#575757>Séquito</color> na sua coluna mais à esquerda primeiro, que é <color=#575757><b>Mover</b></color>. Você deve mover de uma clareira de um naipe correspondente à carta de <color=#575757>Séquito</color> usada - neste caso, o <sprite name="birdicon"> permite que você escolha qualquer clareira.
+kii.t1.13=Envie 4 <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> da sua clareira <sprite name="ClearingMouse"> em direção ao centro da Floresta.
+kii.t1.14=A coluna do meio no <color=#575757>Séquito</color> é <color=#575757><b>Batalhe e Escave</b></color>. Para realizar esta ação, você deve escolher uma clareira de um naipe correspondente à sua carta de <color=#575757>Séquito</color> onde você tenha pelo menos 1 <sprite name="KeeperWarrior"><color=#575757>guerreiro</color>.
+kii.t1.15=Se houver alguma peça inimiga lá, você <i>deve</i> batalhar. Não há nenhuma nesta clareira no momento.
+kii.t1.16=Então, se você governar a clareira com pelo menos 1 <sprite name="KeeperWarrior"><color=#575757>guerreiro</color>, você pode <color=#575757><b>escavar</b></color> uma <color=#575757>relíquia</color> de uma floresta adjacente. Pegue essa <sprite name="RelicJewelry">.
+kii.t1.17=Vai valer <sprite name="3VP"> se pudermos <color=#575757>recuperá-la</color>! Que achado!
+kii.t1.18=<color=#575757>Escavar</color> pode ser perigoso, no entanto. Se você governar menos clareiras adjacentes à floresta que você <color=#575757>escavou</color> do que os <style="vptext">PVs</style> da <color=#575757>relíquia</color>, a carta de <color=#575757>Séquito</color> que você usou para <color=#575757>escavar</color> será perdida!
+kii.t1.19=Felizmente, seus <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> estão posicionados ao redor desta floresta - você governa estas 3 clareiras adjacentes a ela, então seu <color=#575757>Séquito</color> está seguro.
+kii.t1.20=A ação final do <color=#575757>Séquito</color> é <color=#575757><b>Mover ou Recuperar</b></color>. Sem <color=#575757>relíquias</color> em uma clareira com uma <color=#575757>estação</color> correspondente, você não pode <color=#575757>recuperar</color> ainda.
+kii.t1.21=Mova um <sprite name="KeeperWarrior"><color=#575757>guerreiro</color> para cercar a <sprite name="RelicFigure"> a oeste.
+kii.t1.22=Depois de usar seu <color=#575757>Séquito</color>, você tem a oportunidade de aumentá-lo adicionando qualquer número de cartas da sua mão a qualquer uma das colunas, ou alterá-lo movendo 1 carta de uma coluna para outra.
+kii.t1.23=Seu <color=#575757>Séquito</color> pode conter até 10 cartas de uma vez. Quanto mais cartas você adicionar, mais ações poderá tomar.
+kii.t1.24=Adicione <b>Mãos ao Alto!</b> à sua coluna <color=#575757>Mover</color>. Manter seus <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> móveis permitirá que você obtenha mais <color=#575757>relíquias</color> rapidamente.
+kii.t1.24.gamepad=Adicione <b>Mãos ao Alto!</b> à sua coluna <color=#575757>Mover</color>. Manter seus <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> móveis permitirá que você obtenha mais <color=#575757>relíquias</color> rapidamente.
+kii.t1.26=Em seguida, adicione <b>Batedores</b> à sua coluna <color=#575757>Mover ou Recuperar</color>.
+kii.t1.26.gamepad=Em seguida, adicione <b>Batedores</b> à sua coluna <color=#575757>Mover ou Recuperar</color>.
+kii.t1.28=Por fim, no final de cada Anoitecer, você compra 1 carta e mais outra carta para cada <color=#575757>estação</color> no mapa.
+kii.t2.1=Caw! Texugo fora! Esta floresta pertence às <color=#336699>Rapinas</color>!
+kii.t2.2=O inimigo avança, mas sua missão permanece. <color=#575757>Acampe</color> para criar uma <color=#575757>estação</color> aqui, com o lado <sprite name="RelicFigure"> voltado para cima.
+kii.t2.3=A <color=#575757>estação</color> que você acabou de criar ao <color=#575757>Acampar</color> está em uma boa posição para recrutamento. Selecione-o e gaste uma carta <sprite name="ClearingFox"> para recrutar mais <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> lá.
+kii.t2.3.gamepad=A <color=#575757>estação</color> que você acabou de usar para <color=#575757>Acampar</color> está em uma boa posição para recrutamento. Selecione-o e gaste uma carta <sprite name="ClearingFox"> para recrutar mais <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> lá.
+kii.t2.4=Continue — fortaleça suas forças!
+kii.t2.4.gamepad=Continue — fortaleça suas forças!
+kii.t2.5=Ainda não há necessidade de criar - as cartas são muito valiosas para os <color=#575757>Guardiões</color> e, por enquanto, seu melhor uso é aumentar seu <color=#575757>Séquito</color>.
+kii.t2.6=Hora de usar seu <color=#575757>Séquito</color>. Primeiro, faça com que um <sprite name="KeeperWarrior"><color=#575757>guerreiro</color> leve aquela <sprite name="RelicJewelry"> de volta para a <color=#575757>estação</color> correspondente.
+kii.t2.6b=Cada <sprite name="KeeperWarrior"><color=#575757>guerreiro</color> que você mover pode carregar até 1 <color=#575757>relíquia</color> de sua clareira.
+kii.t2.7=Em seguida, reforce sua posição ao sul com mais 3 <sprite name="KeeperWarrior"><color=#575757>guerreiros</color>.
+kii.t2.8=<color=#575757>Batalhe e Escave</color> nesta clareira <sprite name="ClearingRabbit"> para reivindicar a <sprite name="RelicFigure"> na floresta acima.
+kii.t2.9=Ah, uma <sprite name="1VP"> <color=#575757>relíquia</color> menor. Pode não valer muitos pontos, mas isso a torna mais fácil de <color=#575757>recuperar</color> mais tarde.
+kii.t2.10=Falando em <color=#575757>recuperação</color> - é hora de pontuar a <color=#575757>relíquia</color> que você <color=#575757>escavou</color> no último turno.
+kii.t2.11=Mas há um porém. Se você não governar pelo menos tantas clareiras que combinem com o naipe da clareira em que você está <color=#575757>recuperando</color> quanto o <sprite name="VpIcon"> da <color=#575757>relíquia</color>, a carta de <color=#575757>Séquito</color> que você usou para a ação será perdida.
+kii.t2.12=<color=#575757>Recupere</color> essa <sprite name="RelicJewelry"> agora.
+kii.t2.13=A carta <sprite name="ClearingMouse"> do seu <color=#575757>Séquito</color> é perdida porque você não governa 3 clareiras de <sprite name="ClearingMouse">, mas <sprite name="3VP"> é uma recompensa digna!
+kii.t2.14=Use sua segunda ação <color=#575757>Mover ou Recuperar</color> para mover 2 <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> e sua <sprite name="RelicFigure"> e continue cercando a floresta ao sul.
+kii.t2.14b=As <color=#336699>Rapinas</color> terão uma surpresa se forem tolas o suficiente para brigar por isso.
+kii.t2.15=Hora de reabastecer seu <color=#575757>Séquito</color>. Adicione uma carta à coluna <color=#575757>Batalhe e Escave</color>.
+kii.t2.15.gamepad=Hora de reabastecer seu <color=#575757>Séquito</color>. Adicione uma carta à coluna <color=#575757>Batalhe e Escave</color>.
+kii.t2.16=Hora de reabastecer seu <color=#575757>Séquito</color>. Adicione uma carta à coluna <color=#575757>Batalhe e Escave</color>.
+kii.t2.17=Termine seu turno. As <color=#336699>Rapinas</color> podem ser tentadas a lutar - deixe-as vir.
+kii.ait2.1=<color=#336699>Guerreiros das Rapinas</color>, derrotem os invasores e confisquem seu tesouro!
+kii.ait2.2=Ha! Essas <color=#336699>Rapinas</color> idiotas subestimaram o que significa lutar com os <color=#575757>Guardiões de Ferro</color>. Sua habilidade <color=#575757><b>Cavaleiros Devotos</b></color> significa que você recebe 1 golpe a menos ao lutar em uma clareira com uma <color=#575757>relíquia</color>!
+kii.t3.1=As <color=#336699>Rapinas</color> decidiram iniciar hostilidades, e os <color=#575757>Guardiões</color> responderão na mesma moeda!
+kii.t3.2=<color=#575757>Levante Acampamento</color> nesta <color=#575757>estação</color>, pois não há mais <sprite name="RelicJewelry"> por perto.
+kii.t3.3=<color=#575757>Levantar Acampamento</color> é o oposto de <color=#575757>Acampar</color> - você substitui uma <color=#575757>estação</color> por um <color=#575757>guerreiro</color> <sprite name="KeeperWarrior">.
+kii.t3.4=Recrute mais <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> em sua <sprite name="RelicFigure"> <color=#575757>estação</color>. Você precisará deles para levar a luta até as <color=#336699>Rapinas</color>.
+kii.t3.4.gamepad=Recrute mais <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> em sua <sprite name="RelicFigure"> <color=#575757>estação</color>. Você precisará deles para levar a luta até as <color=#336699>Rapinas</color>.
+kii.t3.5=Você ainda pode usar um pouco mais de força. Recrute na <sprite name="RelicFigure"> <color=#575757>estação</color> novamente.
+kii.t3.5.gamepad=Você ainda pode usar um pouco mais de força. Recrute na <sprite name="RelicFigure"> <color=#575757>estação</color> novamente.
+kii.t3.6=Vá em frente e crie aquele <b>Aço das Raposas</b> usando suas <color=#575757>estações</color>.
+kii.t3.6.gamepad=Vá em frente e crie aquele <b>Aço das Raposas</b> usando suas <color=#575757>estações</color>.
+kii.t3.7=É hora de agir. Primeiro, mova um guerreiro para continuar cercando a floresta do norte. As <color=#336699>Rapinas</color> devem ser derrotadas, mas seu objetivo principal ainda é <color=#575757>recuperar</color> <color=#575757>relíquias</color>.
+kii.t3.8=Agora, é hora de mostrar a esses cérebros de pássaro o que significa travar uma guerra contra os <color=#575757>Guardiões</color>. Mova quatro <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> para ameaçar o <color=#336699>ninho</color> mais próximo das <color=#336699>Rapinas</color>.
+kii.t3.9=Suas forças estão bem posicionadas. Lute na <sprite name="RelicFigure">!
+kii.t3.10=Uma emboscada! Aqueles pássaros astutos...
+kii.t3.11=Ai! As <color=#336699>Rapinas</color> não só derrotaram seus <sprite name="KeeperWarrior"><color=#575757>guerreiros</color>, como também levaram a <color=#575757>relíquia</color>!
+kii.t3.12=Como <color=#575757>relíquias</color> são <color=#575757><b>Troféus Premiados</b></color>, quando um inimigo remove uma, ele ganha <sprite name="2VP"> em vez do usual <sprite name="1VP">. Então, ele escolhe uma floresta para devolvê-la.
+kii.t3.13=Pegue aquela <sprite name="RelicFigure"> de volta. <color=#575757>Batalhe e Escave</color> no <color=#336699>ninho das Rapinas</color>. Mostre a elas sua fúria justa!
+kii.t3.14=Agora que você dispensou os pássaros, recupere a <sprite name="RelicFigure"> que eles roubaram - já que ela está virada para cima, podemos ver que seu valor <sprite name="1VP"> significa que podemos <color=#575757>escavá-la</color> com segurança.
+kii.t3.15=Retire <sprite name="RelicFigure"> e seus 3 <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> de volta para um lugar seguro.
+kii.t3.16=No seu próximo turno, você pode usar sua <color=#575757>estação</color> para <color=#575757>recuperar</color> aquela <sprite name="RelicFigure">.
+kii.t3.17=Seus <sprite name="KeeperWarrior"><color=#575757>guerreiros</color> não têm linhas de suprimento - eles <color=#575757><b>Deixam a Terra</b></color>. Ao Anoitecer, em cada clareira com 4 ou mais <sprite name="KeeperWarrior"> , 1 é removido.
+kii.t3.18=Opa, acho que deveríamos ter movido 1 <sprite name="KeeperWarrior"><color=#575757>guerreiro</color> a menos! Bem, saberemos na próxima vez.
+kii.t3.19=Adicione cartas às suas colunas do <color=#575757>Séquito</color> ou mova uma carta de uma coluna para outra. Tenha em mente que você pode examinar os ícones no topo de cada coluna para obter mais informações sobre as ações.
+kii.t4.1=Daqui, você comanda os <color=#575757>Guardiões</color> sozinho. Seu primeiro objetivo é <color=#575757>recuperar</color> uma <color=#575757>relíquia</color> de cada tipo.
+kii.t4.2=Você já tem uma <sprite name="RelicJewelry">, então concentre-se em obter uma <sprite name="RelicTablet"> e uma <sprite name="RelicFigure">.
+kii.trigger.column1=Muito bem. Quando você <color=#575757>recupera</color> um conjunto completo de 3 <color=#575757>relíquias</color> - 1 de cada tipo - você ganha <sprite name="2VP"> adicionais!
+kii.trigger.column2=Agora, pontue <style="vpnumddteen">15</style> para provar seu valor como comandante dos <color=#575757>Guardiões de Ferro</color>.
+kii.trigger.tutorialcomplete=Você conseguiu! A Floresta treme com seu poder!
+tutorial.title.TutorialM01=Retornado do Exílio
+tutorial.description.TutorialM01=Aprenda a jogar com os Guardiões do Ferro
+tutorial.title.TutorialM02=Agitadores da Ralé
+tutorial.description.TutorialM02=Aprenda a jogar com o Senhor dos Centenas
+lht.2.8.gamepad=Use seu <sprite name="Stronghold"><color=#B40518>forte</color> para criar a <sprite name="bag"> que você comprou no último turno.
+tuber.canis.actions.ContinueToEvening.opponent=[player] está movendo.
+kiit.goal.figure=Recupere uma <sprite name="RelicFigure">
+kiit.goal.tablet=Recupere uma <sprite name="RelicTablet">
+kiit.goal.15vp=Pontue <style="vpnumddteen">15</style> ({0}/{1})
+Log.Hundreds.Start.Location=[faction name] coloca seu Senhor da Guerra e forte em uma clareira [suit icon].
+Log.Keepers.Start.Location=[faction name] coloca 4 guerreiros em uma clareira [suit icon].
+Log.exile.start=O capanga Exilado é colocado em uma floresta
+Log.uprising.start=O dado da Insurgência rola [suit icon] e um guerreiro da Insurgência é colocado em uma clareira correspondente.
+Log.dynasty.start=5 guerreiros da Dinastia são colocados em uma clareira [suit icon] na borda do mapa.
+log.patrol.start=Um guerreiro de Patrulha é colocado em cada clareira
+log.band.start=Os guerreiros da Banda são colocados em duas clareiras diferentes.
+log.vault.keepers.start=2 guerreiros Guardiões e um Cofre são colocados em uma clareira [ícone de traje]
+log.bearers.start=2 guerreiros Portadores são colocados em clareiras
+log.encamp=[faction name] substitui um guerreiro por uma [type] estação dento de um clareira [suit icon].
+log.decamp=[faction name] substitui uma [type] estação dentro de uma clareira [suit icon] por um guerreiro.
+log.recruit.keepers=[faction name] gaste [card] para recrutar dois guerreiros em uma clareira [suit icon]
+log.delve=[faction name] escave dentro de uma clareira [suit icon], descobrindo uma relíquia [X] [type].
+log.retinue.lost=[faction name] descarte [card] de seu [type] Séquito.
+log.recover=[faction name] recupera uma relíquia [type], pontuando [X] <style=""vptext"">VP</style>.
+log.live.off.land=[faction name] perde um guerreiro em uma clareira [suit icon] devido à Deixe a Terra.
+log.gather.retinue=[faction name] adiciona [card] para seu [type] Séquito.
+log.shift.retinue=[faction name] muda o [suit icon] de [type1] Séquito para [type2] Séquito.
+log.move.relic=[faction name] move uma relíquia [type] para uma clareira [suit icon].
+log.prized.relic=[faction name] pontua um 1 <style=""vptext"">PV</style> extra de Troféu Premiado por remover uma relíquia e a colocar de volta em uma floresta
+log.raze=[faction name] arrasa uma clareira [suit icon], removendo todas as ruínas, construções inimigas e marcadores.
+log.razeitem=[faction name] arrasa uma ruína em uma clareira [suit icon]. Eles ganham um [item icon].
+log.razeitem.noitems=[faction name] arrasa uma ruína em uma clareira [suit icon], mas não havia nenhum item lá.
+log.mob.spread=A turba do [faction name] se espalha para uma clareira [suit icon].
+log.anoint=[faction name] convoca um novo líder em uma clareira [suit icon].
+log.mood=[faction name] se torna [name].
+log.trash.item=[faction name] descarta [item icon] para pontuar [X] <style=""vptext"">PV</style>.
+log.hundreds.craft=[faction name] adiciona [item icon] para sua trilha [type].
+log.incite=[faction name] incita uma turba em uma clareira [suit icon].
+log.oppress=[faction name] oprime [X] clareira(s) por [X2] <style=""vptext"">PV</style>.
+log.loot=[faction name] saqueia [item icon] de [faction name 2].
+log.stubborn=A teimosia do [faction name] faz com que receba 1 dano a menos!
+log.bitter=[faction name] remove uma turba de uma clareira [suit icon] para recrutar um guerreiro.
+log.lavish=[faction name] remove [items] de seu tesouro para recrutar [X] guerreiro(s).
+log.wrathful=[faction name] recebe 1 dano extra devido ao humor Colérico!
+log.winterschill=[faction name] perde um guerreiro em uma clareira [suit icon] devido ao Frio do Inverno.
+log.infiltration=[faction name] se infiltra em [X] clareira(s) por [X2] <style=""vptext"">PV</style>.
+log.deliverymission.recover=[faction name] recupera relíquias, pontuando [X] <style=""vptext"">PV</style>.
+log.move.warlord=[faction name] move o Senhor da Guerra para uma clareira [suit icon].
+tooltip.ui.hundreds.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
+tooltip.ui.hundreds.drawrate=<size=125%><b>Cartão na Mão</b></size>\nO Senhor das Centenas compra cartas adicionais usando o humor Conflitante.
+tooltip.ui.hundreds.strongholds=<size=125%><b>Fortes</b></size>
+tooltip.ui.hundreds.mob=<size=125%><b>Turbas</b></size>
+tooltip.ui.hundreds.command=<size=125%><b>Comando</b></size> O número de vezes que você pode Comandar as Centenas (Mover, Batalha, Construir) a cada turno.
+tooltip.ui.hundreds.prowess=<size=125%><b>Proeza</b></size>\nO número de vezes que você pode Avançar o Senhor da Guerra (Mover e/ou Batalhar) a cada turno.
+tooltip.ui.hundreds.oppression=<size=125%><b>Espaços Oprimidos</b></size>
+tooltip.ui.hundreds.infiltration=<size=125%><b>Espaços Infiltrados</b></size>
+tooltip.ui.hundreds.moods=<size=125%><b>Humores</b></size>
+tooltip.ui.hundreds.protectwarlord=<size=125%><b>Proteger o Senhor da Guerra</b></size>\nQuando ativado, seu Senhor da Guerra será o último guerreiro removido durante o combate.
+tooltip.ui.keepers.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
+tooltip.ui.keepers.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas ao Anoitecer. Aumente sua taxa acampando em estações.
+tooltip.ui.keepers.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nOs Guardiões compram uma carta adicional para cada estação que construíram.
+tooltip.ui.keepers.waystations.tablet=<size=125%><b>Estações de Tábua</b></size>
+tooltip.ui.keepers.waystations.figure=<size=125%><b>Estações de Figura</b></size>
+tooltip.ui.keepers.waystations.jewelry=<size=125%><b>Estações de Jóias</b></size>
+tooltip.ui.keepers.relics.tablet=<size=125%><b>Relíquias de Tábua</b></size>
+tooltip.ui.keepers.relics.figure=<size=125%><b>Relíquias de Figura</b></size>
+tooltip.ui.keepers.relics.jewelry=<size=125%><b>Relíquias de Jóias</b></size>
+tooltip.ui.keepers.retinue.moveorrecover=<size=125%><b>Mover ou Recuperar</b></size>\nEscolha uma clareira cujo naipe corresponda ao naipe da carta. Mova-se a partir dela ou recupere relíquias nela.
+tooltip.ui.keepers.retinue.battleanddelve=<size=125%><b>Batalhar e então Escavar</b></size>\nEscolha uma clareira cujo naipe corresponda ao naipe da carta onde você tenha pelo menos 1 guerreiro. Eles devem iniciar uma batalha lá se houver peças inimigas. Em seguida, se eles controlarem a clareira e houver pelo menos um guerreiro Guardião, poderão escavar lá conforme descrito <i>(mesmo que não haja inimigos para batalhar)</i>.
+tooltip.ui.keepers.retinue.move=<size=125%><b>Mover</b></size>\nRealize um movimento a partir de uma clareira cujo naipe corresponda ao naipe da carta.
+tooltip.keepersiniron.relics.description=<size=125%><b>Relíquias</b></size>
+tooltip.keepersiniron.waystations.description=<size=125%><b>Estações</b></size>
+tooltip.ui.keepers.crafteditems=<size=125%><b>Itens criados</b></size>\nOs Guardiões criam itens usando estações.
+tooltip.ui.keepers.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nOs Guardiões criam cartas usando estações.
+tooltip.ui.hundreds.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nO Senhor das Centenas cria cartas usando fortes.
+tooltip.ui.hundreds.warriormovementtoggle=Quando ativado, o padrão será mover seu Senhor da Guerra sempre que você se mover a partir de uma clareira com seu Senhor da Guerra.
+tooltip.hangar.hirelings.ability=<b>Habilidade</b><br><br>As habilidades estão sempre ativas, embora algumas indiquem quando ocorrem.
+tooltip.hangar.hirelings.whenhiredaction=<b>Ação ao Ser Contratado</b><br><br>Quando ganham o controle do contratado, o jogador controlador deve realizar esta ação.
+tooltip.hangar.hirelings.startofbirdsongaction=<b>Ação no Início do Amanhecer</b><br><br>No início de seu Amanhecer, o jogador controlador deve ou pode realizar esta ação, conforme descrito.
+tooltip.hangar.hirelings.onceperdaylightaction=<b>Ação Uma Vez por Dia</b><br><br>Uma vez durante o Dia, o jogador controlador pode realizar esta ação.
+tooltip.playmat.relic.tablet=<size=125%><b>Relíquia</b></size>\nRelíquia de Tábua
+tooltip.playmat.relic.figure=<size=125%><b>Relíquia</b></size>\nRelíquia de Figura
+tooltip.playmat.relic.jewelry=<size=125%><b>Relíquia</b></size>\nRelíquia de Jóias
+tooltip.playmat.stronghold=<size=125%><b>Forte</b></size>
+tooltip.playmat.mob=<size=125%><b>Turba </b></size>
+tooltip.playmat.waystation=Estação
+tooltip.playmat.waystation.figure.backj=Estação: <sprite name="RelicFigure"><br>Verso: <sprite name="RelicJewelry">
+tooltip.playmat.waystation.figure.backt=Estação: <sprite name="RelicFigure"><br>Verso : <sprite name="RelicTablet">
+tooltip.playmat.waystation.jewelry.backf=Estação: <sprite name="RelicJewelry"><br>Verso : <sprite name="RelicFigure">
+tooltip.playmat.waystation.jewelry.backt=Estação: <sprite name="RelicJewelry"><br>Verso: <sprite name="RelicTablet">
+tooltip.playmat.waystation.tablet.backf=Estação: <sprite name="RelicTablet"><br>Verso : <sprite name="RelicFigure">
+tooltip.playmat.waystation.tablet.backj=Estação: <sprite name="RelicTablet"><br>Verso : <sprite name="RelicJewelry">
+tooltip.hirelingsenabled=Capangas Habilitados
+tooltip.playerinfo.keepers.relic.figure=<sprite name="RelicFigure"> relíquia
+tooltip.playerinfo.keepers.relic.figure.empty=<sprite name="RelicFigure"> relíquia (vazio)
+tooltip.playerinfo.keepers.relic.jewelry=<sprite name="RelicJewelry"> relíquia
+tooltip.playerinfo.keepers.relic.jewelry.empty=<sprite name="RelicJewelry"> relíquia (vazio)
+tooltip.playerinfo.keepers.relic.tablet=<sprite name="RelicTablet"> relíquia
+tooltip.playerinfo.keepers.relic.tablet.empty=<sprite name="RelicTablet"> relíquia (vazio)
+tooltip.playerinfo.hundreds.oppress=<b>Espaços Oprimidos</b><br>Clareiras que você governa que têm uma peça das Centenas e nenhuma peça inimiga.
+tooltip.playerinfo.hundreds.infiltration.normal=<b>Espaços Infiltrados</b><br>Clareiras governadas por inimigos e que contenham um guerreiro das Centenas ou o Senhor da Guerra.
+tooltip.playerinfo.hundreds.infiltration.heroic=<b>Espaços Infiltrados</b><br>Clareiras governadas por inimigos com pelo menos quatro peças e que contenham também um guerreiro das Centenas ou o Senhor da Guerra.
+tooltip.playmat.keeperstack=<size=125%><b>Guerreiros Guardiões</b></size>
+tooltip.playmat.hundredsstack=<size=125%><b>Guerreiros das Centenas</b></size>
+tooltip.playmat.hundredswarlord=<size=125%><b>Senhor da Guerra</b></size>
+tooltip.ability.hundreds.craftforvp=<size=125%><b>Criar para <style="vptext">VP</style></b></size>\nCriar um item e marcar seus pontos de vitória normalmente. Remova o item do jogo em vez de colocá-lo em seu Tesouro.
+tooltip.ability.hundreds.crafttohoard=<size=125%><b>Criar para o Tesouro</b></size>\unCriar um item e colocá-lo em seu Tesouro. Devido ao Desprezo pelo Comércio, você não ganhará pontos de vitória por fazer isso.
+tooltip.ability.hundreds.build=<size=125%><b>Construir</b></size>\nGaste uma carta para colocar um forte em uma clareira correspondente que você governa.
+tooltip.playmat.relic.title=<size=125%><b>Relíquias</b></size>\n
+tooltip.configure.player=Configurar o Jogador
+tooltip.ability.hundreds.temperamental.normal=<size=125%><b>Temperamental</b></size>\nUma vez por turno, você pode rerolar seu humor para um novo.
+tooltip.ability.hundreds.temperamental.heroic=<size=125%><b>Temperamental</b></size>\nUma vez por turno, você pode descartar uma carta que corresponda ao naipe do seu Senhor da Guerra para redefinir seu humor para um novo.
+title.lordofthehundreds=Senhor das Centenas
+rule.lordofthehundreds.intro1=<i>Afirmando ser a única verdadeira voz da Floresta, o Senhor das Centenas consolida seu poder esmagando toda dissidência. Durante seu Anoitecer, ele pontua com base em quantas clareiras ele</i> <b>oprime</b>—<i>clareiras que governa e que não possuem peças inimigas. Seu exército numeroso é liderado pelo</i> <b>Senhor da Guerra</b><i>, um guerreiro-demagogo cuja mudança de</i> <b>humor</b> <i>oferece vantagens temporárias.
+rule.lordofthehundreds.intro2=Ao acumular itens em seu imponente</i> <b>Tesouro</b><i>, os Centenas aumentam seu</i> <b>Comando</b> <i>e sua</i> <b>Proeza</b><i>, permitindo que realizem mais ações e atraiam mais guerreiros para o Senhor da Guerra. Se isso não for suficiente, eles podem incitar</i> <b>turbas</b> <i>empunhando tochas para incendiar a Floresta.</i>
+rule.lordofthehundreds.setup1=<b>Passo 1: Posicionar Guerreiros</b><br>Coloque seu Senhor da Guerra, 4 guerreiros e 1 forte em uma clareira de canto que outro jogador não tenha escolhido como clareira inicial.
+lht.1.14.gamepad=O Anoitecer começa, mas o ataque está apenas começando. Você pode descartar uma carta para <color=#B40518><b>Incitar</b></color> uma <sprite name="Mob"><color=#B40518><b>turba</b></color> em uma clareira correspondente que tenha um <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color>, mas nenhuma <sprite name="Mob">!
+lht.2.12.gamepad=Para construir um <sprite name="Stronghold"><color=#B40518>forte</color>, você deve gastar uma carta de um naipe correspondente à clareira que deseja construir.
+lht.3.5.gamepad=Crie o <sprite name="teapot"> em sua mão para continuar aumentando seu <color=#B40518>Tesouro</color>.
+title.keepersiniron=Guardiões de Ferro
+prompt.hundreds.choosetoloot.header=Saquear o Defensor?
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveNumber=Escolha o número de guerreiros para mover com seu Senhor da Guerra
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveNumber.opponent=[player] está avançando o Senhor da Guerra.
+shortfactionnames.keepersiniron=Guardiões
+shortfactionnames.lordofthehundreds=Centenas
+prompt.advancedsetup.keepersiniron.homeland.1=Escolha uma clareira de origem para colocar quatro guerreiros. Ela deve estar na borda do mapa com 2+ clareiras entre ela e as clareiras de origem inimigas.
+prompt.advancedsetup.keepersiniron.homeland.1.opponent=[player] está escolhendo uma clareira de origem.
+prompt.advancedsetup.keepersiniron.homeland.2=Escolha uma segunda clareira de origem para colocar quatro guerreiros. Ela deve ser adjacente à sua outra clareira de origim, na borda do mapa e com 2+ clareiras entre ela e as clareiras de origem inimigas.
+prompt.advancedsetup.keepersiniron.homeland.2.opponent=[player] está escolhendo uma segunda clareira de origem.
+prompt.advancedsetup.lordofthehundreds.homeland=Escolha uma clareira de origem para colocar seu Senhor da Guerra, 4 guerreiros e um forte. Ela deve estar na borda do mapa com 2+ clareiras entre ela e as clareiras de origem inimigas.
+prompt.advancedsetup.lordofthehundreds.homeland.opponent=[player] está escolhendo uma clareira de origem.
+tooltip.devoutknights.battle=<size=125%><b>Cavaleiros Devotos</b></size><br>O primeiro golpe é ignorado porque há uma relíquia e um guerreiro Guardião nesta clareira.
+tooltip.wrathful.battle=<size=125%><b>Humor Colérico</b></size><br>Como atacante em batalha com seu Senhor da Guerra, Centenas causam um golpe adicional.
+tooltip.stubborn.battle=<size=125%><b>Humor Teimoso</b></size><br>Na batalha com seu Senhor da Guerra, Centenas ignoram o primeiro golpe que recebem.
+warning.keepers.ironritual=Você não poderá mais vencer este desafio se recuperar esta relíquia. Tem certeza de que quer fazer isso?
+prompt.retinueselect.header=Escolha a carta de Séquito para usar
+prompt.supporterselect.header=Escolha a carta de Apoiador para usar
+prompt.buildingselect.cats.toggle=Escolha a madeira para gastar
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseNoCraftTemp=Impossível criar (Temperamental). Pressione continuar.
 scenario.classic.tier1description=Jogo normal contra duas IAs Fáceis.
 scenario.classic.tier2description=Jogo normal contra duas IAs Médias.
 scenario.classic.tier3description=Jogo normal contra três IAs Difíceis.
@@ -1927,8 +2430,8 @@ scenario.fairfight.description=Cartas de Emboscada são removidas do baralho.
 scenario.fairfight.tier2description=Cartas de Emboscada são removidas do baralho. Os oponentes começam com <style="vpnum">5</style>.
 scenario.assemblyline.description.1=Ganhe <style="vpone">1</style> adicional sempre que criar uma carta. Os oponentes começam com <style="vpnumddteen">10</style> e todos os jogadores precisam de <style="vpnumdd">40</style> para vencer.
 scenario.assemblyline.description.3=Ganhe <style="vpnum">2</style> adicionais sempre que criar uma carta. Os oponentes começam com <style="vpnumdd">25</style> e todos os jogadores precisam de <style="vpnumdd">50</style> para vencer.
-scenario.scrappyfighters.tier1description=Não há Armeiros no baralho. O número de Armadilheiros, Táticas Brutais e Comando Warren é dobrado.
-scenario.scrappyfighters.tier2description=Não há Armeiros no baralho. O número de Armadilheiros, Táticas Brutais e Comando Warren no baralho é dobrado, e cada oponente começa com uma dessas cartas.
+scenario.scrappyfighters.tier1description=Não há Armeiros no baralho. O número de Armadilheiros, Táticas Brutais e Comando é dobrado.
+scenario.scrappyfighters.tier2description=Não há Armeiros no baralho. O número de Armadilheiros, Táticas Brutais e Comando no baralho é dobrado, e cada oponente começa com uma dessas cartas.
 scenario.riverwaywarfare.description=Clareiras conectadas por rios são consideradas adjacentes.
 scenario.riverwaywarfare.tier2description=Clareiras conectadas por rios são consideradas adjacentes. Os oponentes começam com <style="vpnum">5</style>.
 scenario.totaldomination.description=Você começa o jogo com uma carta de domínio aleatória na mão. Você só pode vencer usando domínio.
@@ -1942,9 +2445,9 @@ scenario.builder.tier2description=Você começa com três serrarias no início d
 scenario.builder.tier3description=Você começa com três serrarias no início do jogo e um guerreiro nesses espaços em vez de um guerreiro em cada clareira. Erguer serrarias não lhe dá pontos de vitória.
 scenario.castlesiege.tier1description=Você não pode vencer a menos que o forte dos Marqueses seja destruído.
 scenario.castlesiege.tier3description=Você não pode vencer a menos que o forte dos Marqueses seja destruído. Os Marqueses começam com três guerreiros adicionais em seu forte.
-scenario.thetrueking.tier1description=Sempre que você entrar em caos, mantém o mesmo líder, mas perde <style="vpone">1</style> adicional.
-scenario.thetrueking.tier2description=Sempre que você entrar em caos, mantém o mesmo líder, mas perde <style="vpnum">2</style> adicionais.
-scenario.thetrueking.tier3description=Se você entrar em caos, perde o jogo.
+scenario.thetrueking.tier1description=Sempre que você entrar em Tumulto, mantém o mesmo líder, mas perde <style="vpone">1</style> adicional.
+scenario.thetrueking.tier2description=Sempre que você entrar em Tumulto, mantém o mesmo líder, mas perde <style="vpnum">2</style> adicionais.
+scenario.thetrueking.tier3description=Se você entrar em Tumulto, perde o jogo.
 scenario.ruletheroost.tier1description=Você não pode pontuar <style="vptext">PV</style>. Em vez disso, vence se posicionar todos os seus ninhos. Os inimigos ganham <style="vpnum">3</style> ao destruir seus ninhos.
 scenario.ruletheroost.tier2description=Você não pode pontuar <style="vptext">PV</style>. Em vez disso, vence se posicionar todos os seus ninhos. Os inimigos ganham <style="vpnum">4</style> ao destruir seus ninhos e focam em destruí-los.
 scenario.pacifist.tier1description=Você não pode iniciar ataques ou emboscadas.
@@ -1977,43 +2480,43 @@ scenario.statehood.name=Estado Independente
 root.attribute.mouse=rato
 root.attribute.fox=raposa
 root.attribute.rabbit=coelho
-root.cardname.favorofthefoxes=Favor das Raposas
-root.cardname.favorofthemice=Favor dos Ratos
-root.cardname.favoroftherabbits=Favor dos Coelhos
+root.cardname.favorofthefoxes=Proteção das Raposas
+root.cardname.favorofthemice=Proteção dos Ratos
+root.cardname.favoroftherabbits=Proteção dos Coelhos
 root.cardname.royalclaim=Reivindicação Real
-root.cardname.bakesale=Venda de Bolos
+root.cardname.bakesale=Vendinha de Bolos
 root.cardname.investments=Investimentos
 root.cardname.protectionracket=Proteção
 root.cardname.scoutingparty=Batedores
 root.cardname.armorers=Armeiros
 root.cardname.brutaltactics=Táticas Brutais
 root.cardname.sword=Espada
-root.cardname.armstrader=Mercador de Armas
-root.cardname.foxfolksteel=Aço Raposano
+root.cardname.armstrader=Negociante de Armas
+root.cardname.foxfolksteel=Aço das Raposas
 root.cardname.roottea=Chá de Raízes
 root.cardname.anvil=Bigorna
 root.cardname.sappers=Armadilheiros
-root.cardname.smugglerstrail=Trilha dos Contrabandistas
+root.cardname.smugglerstrail=Caminho do Contrabandista
 root.cardname.birdybindle=Trouxa de Pássaro
-root.cardname.gentlyusedknapsack=Mochila Usada
+root.cardname.gentlyusedknapsack=Sacola Pouco Usada
 root.cardname.mouseinasack=Rato no Saco
 root.cardname.travelgear=Equipamento de Viagem
-root.cardname.woodlandrunners=Corredores da Floresta
+root.cardname.woodlandrunners=Andarilhos da Floresta
 root.cardname.avisittofriends=Visita aos Amigos
 root.cardname.crossbow=Besta
-root.cardname.commandwarren=Comando Warren
-root.cardname.standanddeliver=Parar e Entregar
+root.cardname.commandwarren=Comando
+root.cardname.standanddeliver=Mãos ao Alto!
 root.cardname.betterburrowbank=Banco Bom Bocado
-root.cardname.taxcollector=Coletor de Impostos
+root.cardname.taxcollector=Coletor de Taxas
 root.cardname.cobbler=Sapateiro
-root.cardname.codebreakers=Decifradores
+root.cardname.codebreakers=Decodificadores
 root.cardname.dominance=Domínio
 root.cardname.coalition=Coalizão
 root.cardname.ambush=Emboscada!
 root.cardtext.favoroftherabbits=Remova todas as peças inimigas nas clareiras de coelho.
 root.cardtext.favorofthefoxes=Remova todas as peças inimigas nas clareiras de raposa.
 root.cardtext.favorofthemice=Remova todas as peças inimigas nas clareiras de rato.
-root.cardtext.royalclaim=Durante a Alvorada, você pode descartar isto para pontuar um ponto por clareira que você governa.
+root.cardtext.royalclaim=Durante o Amanhecer, você pode descartar isto para pontuar um ponto por clareira que você governa.
 root.cardtext.craftcoinstack=<size=200%><sprite name="coinstack">, <sprite name="3VP"></size>
 root.cardtext.scoutingparty=Como atacante em batalha, você não é afetado por cartas de emboscada.
 root.cardtext.armorers=Em batalha, você pode descartar isto para ignorar todos os acertos rolados que receber.
@@ -2026,46 +2529,46 @@ root.cardtext.craftbag=<size=200%><sprite name="bag">, <sprite name="1VP"></size
 root.cardtext.craftboot=<size=200%><sprite name="boot">, <sprite name="1VP"></size>
 root.cardtext.crossbow=<size=200%><sprite name="crossbow">, <sprite name="1VP"></size>
 root.cardtext.commandwarren=No início do Dia, você pode iniciar uma batalha.
-root.cardtext.standanddeliver=Durante a Alvorada, você pode pegar uma carta aleatória de outro jogador. Esse jogador pontua um ponto.
-root.cardtext.betterburrowbank=No início da Alvorada, você e outro jogador compram uma carta.
+root.cardtext.standanddeliver=Durante o Amanhecer, você pode pegar uma carta aleatória de outro jogador. Esse jogador pontua um ponto.
+root.cardtext.betterburrowbank=No início do Amanhecer, você e outro jogador compram uma carta.
 root.cardtext.taxcollector=Uma vez por Dia, você pode remover um de seus guerreiros para comprar uma carta.
 root.cardtext.cobbler=No início do Anoitecer, você pode se mover.
 root.cardtext.codebreakers=Uma vez por Dia, você pode olhar a mão de outro jogador.
 root.cardtext.dominance.suit=Se usado como naipe, torne disponível.
 root.cardtext.dominance.points=Se você tiver ao menos 10 pontos, jogue durante o Dia. Você não pode mais pontuar <style="vptext">PV</style>.
-root.cardtext.dominance.clearingtext.rabbit=Você vence o jogo se governar três clareiras de coelho no início de sua Alvorada.
-root.cardtext.dominance.clearingtext.fox=Você vence o jogo se governar três clareiras de raposa no início de sua Alvorada.
-root.cardtext.dominance.clearingtext.mouse=Você vence o jogo se governar três clareiras de rato no início de sua Alvorada.
-root.cardtext.dominance.clearingtext.bird=Você vence o jogo se governar duas clareiras em cantos opostos no início de sua Alvorada.
+root.cardtext.dominance.clearingtext.rabbit=Você vence o jogo se governar três clareiras de coelho no início de seu Amanhecer.
+root.cardtext.dominance.clearingtext.fox=Você vence o jogo se governar três clareiras de raposa no início de seu Amanhecer.
+root.cardtext.dominance.clearingtext.mouse=Você vence o jogo se governar três clareiras de rato no início de seu Amanhecer.
+root.cardtext.dominance.clearingtext.bird=Você vence o jogo se governar duas clareiras em cantos opostos no início de seu Amanhecer.
 root.cardtext.dominance.vagabond=Em jogos com quatro ou mais jogadores, como Malandro, você pode formar uma coalizão.
 root.cardtext.ambush.any=Você pode emboscar em qualquer clareira.
 root.cardtext.ambush.fox=Você pode emboscar em uma clareira de raposa.
 root.cardtext.ambush.mouse=Você pode emboscar em uma clareira de rato.
 root.cardtext.ambush.rabbit=Você pode emboscar em uma clareira de coelho.
 root.cardtext.ambush.startofbattle=No início da batalha, o defensor pode jogar para causar dois acertos imediatos. Cancele se o atacante jogar uma emboscada correspondente.
-root.quest.header=Carta de Missão
+root.quest.header=Carta de Tarefa
 root.quest.clearingtype.rabbit=em uma clareira de coelho.
 root.quest.clearingtype.fox=em uma clareira de raposa.
 root.quest.clearingtype.mouse=em uma clareira de rato.
-root.quest.claimtext=Reivindique esta missão e escolha uma recompensa.
+root.quest.claimtext=Reivindique esta tarefa e escolha uma recompensa.
 root.quest.eitheror=ou
 root.quest.requireditems=Itens Necessários
 root.quest.drawtwo=Compre <size=200%><sprite name="twocards"></size>
 root.quest.foxvp=<size=200%><sprite name="1VP"></size> por <size=200%><sprite name="foxquest"></size>
 root.quest.mousevp=<size=200%><sprite name="1VP"></size> por <size=200%><sprite name="mousequest"></size>
 root.quest.rabbitvp=<size=200%><sprite name="1VP"></size> por <size=200%><sprite name="rabbitquest"></size>
-root.quest.repairashed=Reparar um Galpão
+root.quest.repairashed=Consertar o Galpão
 root.quest.logisticshelp=Ajuda Logística
-root.quest.guardduty=Dever de Guarda
-root.quest.giveaspeech=Fazer um Discurso
-root.quest.fundraising=Arrecadação de Fundos
+root.quest.guardduty=Serviço de Guarda
+root.quest.giveaspeech=Discursar
+root.quest.fundraising=Levantar Fundos
 root.quest.fendoffabear=Afastar um Urso
-root.quest.expelbandits=Expulsar Bandidos
-root.quest.escort=Escolta
-root.quest.errand=Entrega
+root.quest.expelbandits=Expulsar os Bandidos
+root.quest.escort=Escoltar
+root.quest.errand=Mensageiro
 root.eyrie.leader=Líder das Rapinas
 root.eyrie.builder=Construtor
-root.eyrie.builder.text=Ignore seu Desdém pelo Comércio ao criar.
+root.eyrie.builder.text=Ignore seu Desprezo pelo Comércio ao criar.
 root.eyrie.commander=Comandante
 root.eyrie.commander.text=Como atacante em batalha, você causa um acerto extra.
 root.eyrie.despot=Déspota
@@ -2075,14 +2578,14 @@ root.eyrie.charismatic.text=Você posiciona dois guerreiros, não um, cada vez q
 root.eyrie.actions={0} & {1}
 root.eyrie.action.move=Mover
 root.eyrie.action.recruit=Recrutar
-root.eyrie.action.build=Erguer
+root.eyrie.action.build=Construir
 root.eyrie.action.battle=Batalha
 root.eyrie.loyalvizier=Vizir Leal
-root.vagabond.ranger=Guarda-florestal
+root.vagabond.ranger=Andarilho
 root.vagabond.ranger.ability.title=Esconderijo
 root.vagabond.ranger.ability.text=Repare três itens. Em seguida, termine imediatamente o Dia.
-root.vagabond.tinker=Inventor
-root.vagabond.tinker.ability.title=Trabalho Diurno
+root.vagabond.tinker=Funileiro
+root.vagabond.tinker.ability.title=Dia de Trabalho
 root.vagabond.tinker.ability.text=Pegue uma carta do descarte que corresponda à sua clareira.
 root.vagabond.thief=Ladrão
 root.vagabond.thief.ability.title=Roubar
@@ -2102,7 +2605,7 @@ root.cardtext.crossbow.override.eyrie=<size=200%><sprite name="crossbow">, <spri
 root.rootbot.trait.empty=
 root.mechMarquise.trait.ironWill=Vontade de Ferro
 root.mechMarquise.trait.ironWill.bold=<size=125%><b>Vontade de Ferro</b></size>
-root.mechMarquise.trait.ironWill.text=Sempre que você recrutar durante o Dia Intensificado, posicione o dobro de guerreiros.
+root.mechMarquise.trait.ironWill.text=Sempre que você recrutar durante o Dia Expandido, posicione o dobro de guerreiros.
 root.mechMarquise.trait.hospitals=Hospitais
 root.mechMarquise.trait.hospitals.bold=<size=125%><b>Hospitais</b></size>
 root.mechMarquise.trait.hospitals.text=Ao final da batalha, como defensor, se dois ou mais guerreiros dos Marqueses forem removidos na batalha, posicione dois guerreiros na clareira com o marcador de forte.
@@ -2123,7 +2626,7 @@ root.electricEyrie.trait.relentless.bold=<size=125%><b>Implacável</b></size>
 root.electricEyrie.trait.relentless.text=Após resolver o Decreto, remova todas as construções e marcadores indefesos em qualquer clareira com guerreiros das Rapinas.
 root.electricEyrie.trait.nobility=Nobreza
 root.electricEyrie.trait.nobility.bold=<size=125%><b>Nobreza</b></size>
-root.electricEyrie.trait.nobility.text=Agora você entra em caos se não puder posicionar um ninho ou um guerreiro.<br>Sempre que entrar em caos, você não perde pontos de vitória. Em vez disso, pontue um ponto por carta de pássaro no Decreto.
+root.electricEyrie.trait.nobility.text=Agora você entra em tumulto se não puder posicionar um ninho ou um guerreiro.<br>Sempre que entrar em tumulto, você não perde pontos de vitória. Em vez disso, pontue um ponto por carta de pássaro no Decreto.
 root.automatedAlliance.trait.informants=Informantes
 root.automatedAlliance.trait.informants.bold=<size=125%><b>Informantes</b></size>
 root.automatedAlliance.trait.informants.text=Marcadores de simpatia indefesos se beneficiam de Emboscada Automática.
@@ -2132,7 +2635,7 @@ root.automatedAlliance.trait.popularity.bold=<size=125%><b>Popularidade</b></siz
 root.automatedAlliance.trait.popularity.text=Os inimigos não pontuam ao remover marcadores de simpatia.
 root.automatedAlliance.trait.veterans=Veteranos
 root.automatedAlliance.trait.veterans.bold=<size=125%><b>Veteranos</b></size>
-root.automatedAlliance.trait.veterans.text=Ganhe a habilidade de Guerra de Guerrilha da Aliança da Floresta.<br>(Em batalha como defensor, você usa o maior resultado e o atacante usa o menor.)
+root.automatedAlliance.trait.veterans.text=Ganhe a habilidade de Guerrilha da Aliança da Floresta.<br>(Em batalha como defensor, você usa o maior resultado e o atacante usa o menor.)
 root.automatedAlliance.trait.wildfire=Fogo Selvagem
 root.automatedAlliance.trait.wildfire.bold=<size=125%><b>Fogo Selvagem</b></size>
 root.automatedAlliance.trait.wildfire.text=Ao final do Anoitecer, Espalhe Simpatia. Não pontue ao posicionar este marcador de simpatia.
@@ -2141,15 +2644,15 @@ root.vagabot.trait.marksman.bold=<size=125%><b>Atirador de Elite</b></size>
 root.vagabot.trait.marksman.text=No início da batalha como atacante, cause um acerto imediato.
 root.vagabot.trait.helper=Ajudante
 root.vagabot.trait.helper.bold=<size=125%><b>Ajudante</b></size>
-root.vagabot.trait.helper.text=Sempre que você Ajudar, pontue um ponto de vitória adicional, e o jogador ajudado compra duas cartas em vez de uma.
+root.vagabot.trait.helper.text=Sempre que você Ajuda, pontue um ponto de vitória adicional, e o jogador ajudado compra duas cartas em vez de uma.
 root.vagabot.trait.berserker=Berserker
 root.vagabot.trait.berserker.bold=<size=125%><b>Berserker</b></size>
 root.vagabot.trait.berserker.text=Sempre que você batalhar, mova-se para a clareira mais próxima com mais peças e ataque o jogador que tiver mais peças lá.<br>Durante o Anoitecer, repare um item adicional.
 root.vagabot.trait.adventurer=Aventureiro
 root.vagabot.trait.adventurer.bold=<size=125%><b>Aventureiro</b></size>
-root.vagabot.trait.adventurer.text=Você só pode batalhar uma vez por turno.<br>Ao final do Dia, repita a Missão quantas vezes for possível.
+root.vagabot.trait.adventurer.text=Você só pode batalhar uma vez por turno.<br>Ao final do Dia, repita a Tarefa quantas vezes for possível.
 root.vagabot.thief.text=Roubar: Pegue uma carta aleatória do inimigo em sua clareira com mais pontos lá e, em seguida, mais peças lá.
-root.vagabot.tinker.text=Trabalho Diurno: Crie a carta do topo do descarte com um item, pontuando <sprite name="1VP">.<br>Comece o jogo com um item a menos.
+root.vagabot.tinker.text=Dia de Trabalho: Crie a carta do topo do descarte com um item, pontuando <sprite name="1VP">.<br>Comece o jogo com um item a menos.
 root.vagabot.ranger.text=Esconderijo: Se você tiver três ou mais itens danificados, deslize para uma floresta adjacente aleatória.
 root.mechMarquise.difficulty.easy=Fácil
 root.mechMarquise.difficulty.normal=Normal
@@ -2161,6 +2664,9 @@ root.vagabot.difficulty.easy=Fácil
 root.vagabot.difficulty.normal=Normal
 root.difficulty.challenging=Desafiante
 root.difficulty.nightmare=Pesadelo
+root.suit.mouse=Rato
+root.suit.fox=Raposa
+root.suit.rabbit=Coelho
 tutorial1.turn1.preintro=Bem-vindo a Root, um jogo de poder, guerra e aventura, onde quatro facções únicas lutam pelo domínio da vasta Floresta da Madeira.
 tutorial1.turn1.intro=Neste cenário, você jogará como os ambiciosos <color=#CC6633>Marqueses</color>. Muito antes de se tornarem a potência militar e industrial que são hoje, os <color=#CC6633>Marqueses</color> chegaram à floresta com um pequeno grupo de guerreiros e algumas construções modestas.
 tutorial1.turn1.movelesson=Mova um <sprite name="marquise"><color=#CC6633>guerreiro</color> para uma clareira vizinha para expandir seu domínio.
@@ -2180,26 +2686,26 @@ tutorial1.goal.movewarriorstoeyrie=Marche com seus <sprite name="marquise"><colo
 tutorial1.firstbattle.intro=Nossos <sprite name="marquise"><color=#CC6633>guerreiros</color> certamente triunfarão sobre as Rapinas. Selecione Batalha para enfrentá-las e tomar a clareira.
 tutorial1.goal.defeatalleyrie=Derrote todos os <sprite name="eyrie"><color=#336699>guerreiros das Rapinas</color>
 tutorial1.roostintroduction=<color=#336699>As Rapinas</color> construíram um <sprite name="Roost"><color=#336699>ninho</color> que pode recrutar mais guerreiros. Você deve atacá-lo e destruí-lo antes que sua tropa fique muito forte!
-tutorial1.goal.destroy2roosts=Destrua o <sprite name="Roost"><color=#336699>ninho das Rapinas</color>
-tutorial1.roostbattle=Durante a batalha, seus acertos derrotam primeiro os <sprite name="eyrie"><color=#336699>guerreiros da Dinastia das Rapinas</color> inimigos. Qualquer acerto restante atinge o <sprite name="Roost"><color=#336699>ninho das Rapinas</color>.
-tutorial1.destroyroost=Muito bem! Você destruiu o <sprite name="Roost"><color=#336699>ninho das Rapinas</color> deles. A floresta é nossa... por enquanto.
+tutorial1.goal.destroy2roosts=Destrua o <sprite name="Roost"><color=#336699>ninho</color>
+tutorial1.roostbattle=Durante a batalha, seus acertos derrotam primeiro os <sprite name="eyrie"><color=#336699>guerreiros da Dinastia das Rapinas</color> inimigos. Qualquer acerto restante atinge o <sprite name="Roost"><color=#336699>ninho</color>.
+tutorial1.destroyroost=Muito bem! Você destruiu o <sprite name="Roost"><color=#336699>ninho</color> deles. A floresta é nossa... por enquanto.
 tutorial2.faction.info=Os invasores <color=#CC6633>Marqueses</color> desejam aproveitar os vastos recursos da Floresta da Madeira para alimentar sua máquina econômica e militar. Eles marcam Pontos de Vitória <style="vptext">PV</style> ao construir construções na Floresta da Madeira. <br><br>Em uma partida típica, o primeiro jogador a alcançar <style="vpnumdd">30</style> pontos vence! Neste cenário, vamos ver se você consegue chegar a <style="vpnumddteen">12</style>.
 tutorial2.setup.keep=Quando você inicia uma partida como os <color=#CC6633>Marqueses</color>, posicione sua <sprite name="KeepToken"><color=#CC6633>Torre da Guarda</color> em uma das clareiras de canto.
-tutorial2.setup.keep2=A <sprite name="KeepToken"><color=#CC6633>torre da guarda</color> é a pedra angular do seu reino. Os inimigos não podem erguer ou posicionar peças na clareira com sua <sprite name="KeepToken"><color=#CC6633>torre da guarda</color>, mas podem se mover para lá.
+tutorial2.setup.keep2=A <sprite name="KeepToken"><color=#CC6633>torre da guarda</color> é a pedra angular do seu reino. Os inimigos não podem construir ou posicionar peças na clareira com sua <sprite name="KeepToken"><color=#CC6633>torre da guarda</color>, mas podem se mover para lá.
 tutorial2.setup.keep3=Posicione sua <sprite name="KeepToken"><color=#CC6633>torre da guarda</color> agora.
 tutorial2.setup.warriors=O exército dos <color=#CC6633>Marqueses</color> supera em muito os números das outras facções. Você começa com um <sprite name="marquise"><color=#CC6633>guerreiro</color> em cada clareira, exceto na clareira de canto oposta à sua <sprite name="KeepToken"><color=#CC6633>Torre da Guarda</color>. Essa clareira pertence ao território das <color=#336699>Rapinas</color>.
 tutorial2.setup.buildings=Por fim, você deve posicionar uma de cada construção na clareira com sua <sprite name="KeepToken"><color=#CC6633>torre da guarda</color> ou em qualquer uma adjacente.
-tutorial2.setup.eyrie=A <color=#336699>Dinastia das Rapinas</color> chegou rapidamente e ergueu um <sprite name="Roost"><color=#336699>ninho das Rapinas</color> na clareira vazia. Está bem defendido.
+tutorial2.setup.eyrie=A <color=#336699>Dinastia das Rapinas</color> chegou rapidamente e construiu um <sprite name="Roost"><color=#336699>ninho</color> na clareira vazia. Está bem defendido.
 tutorial2.turn1.workshops=No início do Dia, você tem a oportunidade de criar cartas da sua mão usando as <sprite name="CatWorkshop"><color=#CC6633>oficinas</color>.
-tutorial2.turn1.craftcost.a=Cada <sprite name="CatWorkshop"><color=#CC6633>oficina</color> contribui com o naipe de sua clareira para pagar os custos de criação. Por exemplo, você poderia criar este Mercador de Armas se tivesse duas <sprite name="CatWorkshop"><color=#CC6633>oficinas</color> em clareiras <sprite name="foxicon">.
-tutorial2.turn1.craftcost=Você pode criar Trilha dos Contrabandistas, pois tem uma <sprite name="CatWorkshop"><color=#CC6633>oficina</color> em uma clareira <sprite name="mouseicon"> e ela custa 1 <sprite name="mouseicon">.
+tutorial2.turn1.craftcost.a=Cada <sprite name="CatWorkshop"><color=#CC6633>oficina</color> contribui com o naipe de sua clareira para pagar os custos de criação. Por exemplo, você poderia criar este Negociante de Armas se tivesse duas <sprite name="CatWorkshop"><color=#CC6633>oficinas</color> em clareiras <sprite name="foxicon">.
+tutorial2.turn1.craftcost=Você pode criar Caminho do Contrabandista, pois tem uma <sprite name="CatWorkshop"><color=#CC6633>oficina</color> em uma clareira <sprite name="mouseicon"> e ela custa 1 <sprite name="mouseicon">.
 tutorial2.turn1.suit=O custo para criar uma carta é mostrado no tabuleiro de madeira abaixo de seu naipe.
-tutorial2.turn1.victorypoints=Criar a Trilha dos Contrabandistas lhe rendeu um ponto de vitória <style="vptext">PV</style>! Você está a caminho do seu objetivo de <style="vpnumddteen">12</style>.
+tutorial2.turn1.victorypoints=Criar o Caminho do Contrabandista lhe rendeu um ponto de vitória <style="vptext">PV</style>! Você está a caminho do seu objetivo de <style="vpnumddteen">12</style>.
 tutorial2.goal.15VP=Pontue <style="vpnumddteen">12</style>. ({0}/{1})
-tutorial2.turn1.moz=Você pode revisar o texto das cartas em sua mão passando o mouse sobre elas. Revise Mercador de Armas agora.
-tutorial2.turn1.moz.gamepad=Você pode revisar o texto das cartas em sua mão mantendo o dedo sobre elas ou pressionando <sprite name="Switch_Action4">. Revise Mercador de Armas agora.
-tutorial2.turn1.moz.gamepad.switch=Você pode revisar o texto das cartas em sua mão mantendo o dedo sobre elas ou pressionando <sprite name="Switch_Action3">. Revise Mercador de Armas agora.
-tutorial2.turn1.moz.touch=Você pode revisar o texto das cartas em sua mão mantendo o dedo sobre elas. Revise Mercador de Armas agora.
+tutorial2.turn1.moz=Você pode revisar o texto das cartas em sua mão passando o mouse sobre elas. Revise Negociante de Armas agora.
+tutorial2.turn1.moz.gamepad=Você pode revisar o texto das cartas em sua mão mantendo o dedo sobre elas ou pressionando <sprite name="Switch_Action4">. Revise Negociante de Armas agora.
+tutorial2.turn1.moz.gamepad.switch=Você pode revisar o texto das cartas em sua mão mantendo o dedo sobre elas ou pressionando <sprite name="Switch_Action3">. Revise Negociante de Armas agora.
+tutorial2.turn1.moz.touch=Você pode revisar o texto das cartas em sua mão mantendo o dedo sobre elas. Revise Negociante de Armas agora.
 tutorial2.turn1.actions=Após criar cartas, os <color=#CC6633>Marqueses</color> podem realizar <color=#CC6633>3 ações</color>.
 tutorial2.turn1.build=Os <color=#CC6633>Marqueses</color> também pontuam <style="vptext">PV</style> ao erguer construções.
 tutorial2.turn1.buildslot=Você só pode posicionar <color=#CC6633>construções</color> em clareiras que você governa e que tenham espaços de construção disponíveis.
@@ -2213,7 +2719,7 @@ tutorial2.turn1.move3=Lembre-se, ao escolher Marchar, você pode fazer dois movi
 tutorial2.turn1.move4=Mova os dois <sprite name="marquise"><color=#CC6633>guerreiros</color>.
 tutorial2.turn1.controlmove=Para se mover, você deve governar a clareira de onde está saindo ou para onde está indo. Isso pode tornar complicado avançar profundamente no território inimigo sem um exército considerável.
 tutorial2.turn1.evening=Durante o Anoitecer, você compra 1 carta. Você pode comprar cartas adicionais <sprite name="DrawCard"> tendo mais <sprite name="CatRecruiter"><color=#CC6633>recrutadores</color> no mapa.
-tutorial2.aiturn1.Birdsong=Os <color=#CC6633>Marqueses</color> são intrusos! A linhagem das <color=#336699>Dinastias das Rapinas</color> certamente retomará a floresta.
+tutorial2.aiturn1.Birdsong=Os <color=#CC6633>Marqueses</color> são intrusos! A linhagem da <color=#336699>Dinastia das Rapinas</color> certamente retomará a floresta.
 tutorial2.aiturn1.factions=A <color=#336699>Dinastia das Rapinas</color> está atribuindo ações ao seu <color=#336699>Decreto</color>. Cada facção tem capacidades únicas e sua própria forma de realizar ações.
 tutorial2.aiturn1.factions2=A <color=#336699>Dinastia das Rapinas</color> pode não parecer muito forte agora, mas seu <color=#336699>Decreto</color> em constante crescimento permitirá que realizem cada vez mais ações a cada turno, desde que seu líder permaneça no poder.
 tutorial2.aiturn1.battle=Eles encontraram o ponto fraco em nossa defesa. Prepare-se para lutar!
@@ -2224,7 +2730,7 @@ tutorial2.turn2.refrence.gamepad=Você pode revisar habilidades especiais exclus
 tutorial2.playerturn2.action1=Não retalie ainda. Erga mais duas construções para continuar ganhando <style="vptext">PV</style>.
 tutorial2.playerturn2.goal=Erga 2 construções ({0}/{1})
 tutorial2.playerturn2.build=Erga outra construção de sua escolha.
-tutorial2.overwork1=Podemos usar mais <sprite name="Wood"><color=#CC6633>madeira</color> para construir. Vamos usar <color=#CC6633>Sobrecarga</color> para forçar uma <sprite name="CatSawmill"><color=#CC6633>serraria</color> a produzir mais <sprite name="Wood">.
+tutorial2.overwork1=Podemos usar mais <sprite name="Wood"><color=#CC6633>madeira</color> para construir. Vamos usar <color=#CC6633>Hora Extra</color> para forçar uma <sprite name="CatSawmill"><color=#CC6633>serraria</color> a produzir mais <sprite name="Wood">.
 tutorial2.overwork2=Para usar <color=#CC6633>Sobrecarga</color>, você deve descartar uma carta que corresponda ao naipe de uma das clareiras de sua <sprite name="CatSawmill"><color=#CC6633>serraria</color> para ganhar uma <sprite name="Wood"><color=#CC6633>madeira</color>. Cartas de naipe <sprite name="birdicon"> atuam como “coringas” e podem ser usadas no lugar de qualquer outro naipe.
 tutorial2.connectedclearings=Excelente. Você tem madeira suficiente para fazer outra construção. Você pode gastar qualquer <sprite name="Wood"> no mapa conectada à clareira onde deseja construir, desde que estejam conectadas por clareiras que você governa.
 tutorial2.playerturn2.build2=Erga uma segunda construção para completar seu objetivo.
@@ -2246,21 +2752,21 @@ tutorial.towerbanner=Torre
 tutorial.ferrybanner=Balsa
 tutorial.mountainpassbanner=Passagem pela Montanha
 tutorial3.goal.1=Tenha 3 <sprite name="Roost"> <color=#336699>ninhos das Rapinas</color> ({0}/{1})
-tutorial3.opening.1=As orgulhosas <color=#336699>Dinastias das Rapinas</color> desejam recuperar a glória de sua antiga e grandiosa aristocracia e retomar a Floresta da Madeira dos Marqueses. Elas pontuam a cada turno ao construir e proteger ninhos na Floresta da Madeira.
-tutorial3.opening.2=Você começa com um <sprite name="Roost"> <color=#336699>ninho das Rapinas</color> e 6 <sprite name="eyrie"><color=#336699>guerreiros das Rapinas</color>.
+tutorial3.opening.1=A orgulhosa <color=#336699>Dinastia das Rapinas</color> deseja recuperar a glória de sua antiga e grandiosa aristocracia e retomar a Floresta da Madeira dos Marqueses. Elas pontuam a cada turno ao construir e proteger ninhos na Floresta da Madeira.
+tutorial3.opening.2=Você começa com um <sprite name="Roost"> <color=#336699>ninho</color> e 6 <sprite name="eyrie"><color=#336699>guerreiros das Rapinas</color>.
 tutorial3.opening.roosts.info=Os <sprite name="Roost"><color=#336699>ninhos</color> são o único tipo de construção das Rapinas. Eles são usados para criar cartas da sua mão, recrutar guerreiros e pontuar <style="vptext">PV</style> a cada turno.
-tutorial3.opening.3=Ca Caw! Precisaremos de um líder que possa expandir nosso império aviário! Vamos selecionar o <color=#336699>Déspota</color>, pois ele nos permitirá <color=#336699>erguer</color> construções desde o primeiro turno.
+tutorial3.opening.3=Ca Caw! Precisaremos de um líder que possa expandir nosso império aviário! Vamos selecionar o <color=#336699>Déspota</color>, pois ele nos permitirá <color=#336699>construir</color> desde o primeiro turno.
 tutorial3.opening.4=A <color=#336699>Dinastia das Rapinas</color> deve seguir o <color=#336699>Decreto</color> oficial a cada turno! Cada coluna do Decreto está associada a uma ação diferente.
-tutorial3.opening.5=Seu líder determina as ações iniciais no seu <color=#336699>Decreto</color>: Neste caso, <sprite name="EyrieMove"> <color=#336699>mover</color> e <sprite name="EyrieBuild"> <color=#336699>erguer</color>.
+tutorial3.opening.5=Seu líder determina as ações iniciais no seu <color=#336699>Decreto</color>: Neste caso, <sprite name="EyrieMove"> <color=#336699>mover</color> e <sprite name="EyrieBuild"> <color=#336699>construir</color>.
 tutorial3.Birdsong.1=A cada turno, devemos adicionar 1 ou 2 cartas ao nosso <color=#336699>Decreto</color>. Apenas uma das cartas adicionadas pode ser de naipe <sprite name="birdicon">. Vamos adicionar uma <sprite name="mouseicon"> agora.
 tutorial3.Birdsong.2=À medida que seu <color=#336699>Decreto</color> cresce, você poderá fazer cada vez mais a cada turno.
 tutorial3.Birdsong.2.b=Quando você atribui cartas ao seu <color=#336699>Decreto</color>, apenas o naipe delas é relevante. Se quiser usar o efeito de uma carta, você deve guardá-la para a fase de criação.
 tutorial3.craft.0=Durante o Dia, você pode criar cartas da sua mão ativando os <sprite name="Roost"> <color=#336699>ninhos</color>. O naipe da clareira onde cada <color=#336699>ninho</color> está localizado conta como um recurso necessário para pagar o custo de criação, assim como acontece com as oficinas dos <color=#CC6633>Marqueses</color>.
-tutorial3.craft.1=Seu <sprite name="Roost"> <color=#336699>ninho</color> na clareira <sprite name="ClearingMouse"> permitirá que você crie Sappers. Essa carta será útil se você for atacado.
+tutorial3.craft.1=Seu <sprite name="Roost"> <color=#336699>ninho</color> na clareira <sprite name="ClearingMouse"> permitirá que você crie Armadilheiros. Essa carta será útil se você for atacado.
 tutorial3.recruit.1=Durante o Dia, seu <color=#336699>Decreto</color> é resolvido da esquerda para a direita. Recrute um <sprite name="eyrie"><color=#336699>guerreiro</color> em um <sprite name="Roost"><color=#336699>ninho</color> que corresponda ao naipe atribuído ao seu <color=#336699>Decreto</color>.
 tutorial3.move.1=Cartas de naipe <sprite name="birdicon"> atribuídas ao <color=#336699>Decreto</color> podem ser usadas em qualquer clareira. Mova 3 <sprite name="eyrie"><color=#336699>guerreiros das Rapinas</color> para a clareira <sprite name="ClearingFox"> abaixo.
 tutorial3.battle.1=Pulamos a ação de <sprite name="EyrieBattle"> <color=#336699>batalha</color>, pois você não tem cartas atribuídas à coluna de batalha do seu <color=#336699>Decreto</color>.
-tutorial3.build.1=Por fim, podemos <sprite name="EyrieBuild"> <color=#336699>erguer</color> nosso segundo <sprite name="Roost"> <color=#336699>ninho</color>.
+tutorial3.build.1=Por fim, podemos <sprite name="EyrieBuild"> <color=#336699>construir</color> nosso segundo <sprite name="Roost"> <color=#336699>ninho</color>.
 tutorial3.score.2=No início do Anoitecer, você pontua Pontos de Vitória pelos seus <sprite name="Roost"> <color=#336699>ninhos</color>. Selecione seu avatar para mais detalhes.
 tutorial3.score.2.gamepad=No início do Anoitecer, você pontua Pontos de Vitória pelos seus <sprite name="Roost"> <color=#336699>ninhos</color>. Pressione <sprite name="Switch_LeftBumper"> para mais detalhes.
 tutorial3.score.1=A <color=#336699>Pista dos Ninhos</color> mostra nosso progresso em retomar a floresta. Quanto mais <sprite name="Roost"> <color=#336699>ninhos</color> você tiver, mais <style="vptext">PV</style> você pontua a cada turno!
@@ -2272,22 +2778,22 @@ tutorial3.turntwo.fight=Hora de ensinar a esses gatinhos o poder do voo!
 tutorial3.turntwo.move=Mova três <sprite name="eyrie"><color=#336699>guerreiros das Rapinas</color> para a clareira <sprite name="ClearingMouse"> com o <color=#CC6633>recrutador</color> do seu oponente para preparar uma batalha.
 tutorial3.turntwo.ai.fowl=Um cheiro estranho no ar? As Rapinas devem estar se aproximando!
 tutorial3.turntwo.battle=Hora de lutar. Faça esses habitantes do solo tremerem na presença de seus guerreiros alados.
-tutorial3.turntwo.control.2=Que batalha gloriosa! Precisamos governar uma clareira para posicionar um <sprite name="Roost"> <color=#336699>ninho das Rapinas</color> lá. Guerreiros e construções em uma clareira contribuem para definir quem a governa. As <color=#336699>Rapinas</color> sempre vencem empates.
+tutorial3.turntwo.control.2=Que batalha gloriosa! Precisamos governar uma clareira para posicionar um <sprite name="Roost"><color=#336699>ninho</color> lá. Guerreiros e construções em uma clareira contribuem para definir quem a governa. As <color=#336699>Rapinas</color> sempre vencem empates.
 tutorial3.turntwo.goal.1=Bom trabalho erguendo esses <sprite name="Roost"><color=#336699>ninhos das Rapinas</color>! Destrua construções inimigas, crie cartas e mantenha o controle sobre seus <sprite name="Roost"><color=#336699>ninhos</color> para pontuar <style="vpnumddteen">15</style> e completar este cenário.
 tutorial3.goal.2=Pontue <style="vpnumddteen">10</style> ({0}/{1})
-tutorial3.turmoilReminder=Não dê um passo maior do que a perna. Lembre-se, se você não puder realizar uma ação atribuída ao seu <color=#336699>Decreto</color>, seu bando entrará em <color=#336699>turmoil</color>.
+tutorial3.turmoilReminder=Não dê um passo maior do que a perna. Lembre-se, se você não puder realizar uma ação atribuída ao seu <color=#336699>Decreto</color>, seu bando entrará em <color=#336699>tumulto</color>.
 tutorial3.extraCardDraw=Você compra uma carta adicional <sprite name="DrawCard"> durante o Anoitecer para cada três <sprite name="Roost"> <color=#336699>ninhos das Rapinas</color> que você tiver em jogo.
-tutorial3.Turmoil.1=Skwak! Entramos em <color=#336699>turmoil</color> porque não conseguimos realizar todas as ações do nosso <color=#336699>Decreto</color>!
-tutorial3.Turmoil.2=Durante o <color=#336699>turmoil</color>, você descarta todas as cartas do seu <color=#336699>Decreto</color> e perde <sprite name="1VP"> para cada carta <sprite name="birdicon"> descartada. Em seguida, você escolhe um novo líder e prossegue para o Anoitecer.
-tutorial3.Turmoil.3=Evitar o <color=#336699>turmoil</color> requer um posicionamento cuidadoso das cartas no seu <color=#336699>Decreto</color>. Tente combinar os naipes com as clareiras onde você planeja interagir.
-tutorial3.Turmoil.4=Cartas <sprite name="birdicon"> podem fazer você perder <style="vptext">PV</style> durante o <color=#336699>turmoil</color>, mas oferecem flexibilidade que pode ajudar a evitá-lo.
+tutorial3.Turmoil.1=Skwak! Entramos em <color=#336699>tumulto</color> porque não conseguimos realizar todas as ações do nosso <color=#336699>Decreto</color>!
+tutorial3.Turmoil.2=Durante o <color=#336699>tumulto</color>, você descarta todas as cartas do seu <color=#336699>Decreto</color> e perde <sprite name="1VP"> para cada carta <sprite name="birdicon"> descartada. Em seguida, você escolhe um novo líder e prossegue para o Anoitecer.
+tutorial3.Turmoil.3=Evitar o <color=#336699>tumulto</color> requer um posicionamento cuidadoso das cartas no seu <color=#336699>Decreto</color>. Tente combinar os naipes com as clareiras onde você planeja interagir.
+tutorial3.Turmoil.4=Cartas <sprite name="birdicon"> podem fazer você perder <style="vptext">PV</style> durante o <color=#336699>tumulto</color>, mas oferecem flexibilidade que pode ajudar a evitá-lo.
 tutorial3.turn4.hint.1=Se você estiver com dificuldades para decidir quais naipes de cartas atribuir ao seu <color=#336699>Decreto</color>, sempre pode minimizá-lo e revisar o mapa.
 tutorial3.turn4.hint.2=Depois de ter uma ideia melhor de sua posição no tabuleiro, você pode expandir novamente o <color=#336699>Decreto</color> e atribuir cartas com mais confiança.
-firsttime.NoRoosts=As Rapinas são criaturas resilientes. Como você não tem <sprite name="Roost"><color=#336699>ninhos</color> no mapa durante a Alvorada, você pode posicionar um <sprite name="Roost"> <color=#336699>ninho</color> e 3 <sprite name="eyrie"><color=#336699>guerreiros</color> na clareira com o menor número de <color=#336699>guerreiros</color>.
-tutorial3.badDecree.recruit=Atribuir uma carta [SUITNAME] a Recrutar levará ao Turmoil, pois você não tem ninhos nas clareiras [SUITNAME]. Pressione o botão de cancelar no Decreto para desfazer.
-tutorial3.badDecree.move=Atribuir uma carta [SUITNAME] a Mover pode levar ao Turmoil, pois você não tem guerreiros nas clareiras [SUITNAME]. Pressione o botão de cancelar no Decreto se quiser desfazer.
-tutorial3.badDecree.battle=Atribuir uma carta [SUITNAME] a Batalha levará ao Turmoil, a menos que você mova guerreiros para uma clareira inimiga [SUITNAME] neste turno. Pressione o botão de cancelar no Decreto se quiser desfazer.
-tutorial3.badDecree.build=Atribuir uma carta [SUITNAME] a Erguer levará ao Turmoil, a menos que você conquiste uma clareira [SUITNAME] com um espaço de construção disponível neste turno. Pressione o botão de cancelar no Decreto se quiser desfazer.
+firsttime.NoRoosts=As Rapinas são criaturas resilientes. Como você não tem <sprite name="Roost"><color=#336699>ninhos</color> no mapa durante o Amanhecer, você pode posicionar um <sprite name="Roost"> <color=#336699>ninho</color> e 3 <sprite name="eyrie"><color=#336699>guerreiros</color> na clareira com o menor número de <color=#336699>guerreiros</color>.
+tutorial3.badDecree.recruit=Atribuir uma carta [SUITNAME] a Recrutar levará ao Tumulto, pois você não tem ninhos nas clareiras [SUITNAME]. Pressione o botão de cancelar no Decreto para desfazer.
+tutorial3.badDecree.move=Atribuir uma carta [SUITNAME] a Mover pode levar ao Tumulto, pois você não tem guerreiros nas clareiras [SUITNAME]. Pressione o botão de cancelar no Decreto se quiser desfazer.
+tutorial3.badDecree.battle=Atribuir uma carta [SUITNAME] a Batalha levará ao Tumulto, a menos que você mova guerreiros para uma clareira inimiga [SUITNAME] neste turno. Pressione o botão de cancelar no Decreto se quiser desfazer.
+tutorial3.badDecree.build=Atribuir uma carta [SUITNAME] a Construir levará ao Tumulto, a menos que você conquiste uma clareira [SUITNAME] com um espaço de construção disponível neste turno. Pressione o botão de cancelar no Decreto se quiser desfazer.
 tutorial4.opening.1=A ascendente <color=#008D3F>Aliança da Floresta</color> deseja unir as criaturas da floresta e se revoltar contra seus opressores. Eles pontuam ao espalhar simpatia pela causa deles nas clareiras da Floresta.
 tutorial4.opening.2=Por serem os azarões, não começaremos com nenhum <sprite name="AlliWarrior"><color=#008D3F>guerreiro</color> ou construção no mapa. Em vez disso, começamos com três <color=#008D3F>apoiadores</color> que podem espalhar <sprite name="Sympathy"><color=#008D3F>marcadores de simpatia</color> para nossa causa.
 tutorial4.sympathy.goal=Espalhe <sprite name="Sympathy"><color=#008D3F>simpatia</color> cinco vezes ({0}/{1})
@@ -2298,7 +2804,7 @@ tutorial4.sympathy.3=Selecione uma segunda clareira para espalhar <sprite name="
 tutorial4.sympathy.4=Bom trabalho. Colocar nosso segundo <sprite name="Sympathy"><color=#008D3F>marcador de simpatia</color> nos rendeu <sprite name="1VP">.
 tutorial4.sympathy.4b=Selecione seu avatar para aprender mais sobre como pontuar com <sprite name="Sympathy"><color=#008D3F>simpatia</color>.
 tutorial4.sympathy.4b.gamepad=Pressione <sprite name="Switch_LeftBumper"> para aprender mais sobre como pontuar com <sprite name="Sympathy"><color=#008D3F>simpatia</color>.
-tutorial4.sympathy.5=Conforme subimos na <color=#008D3F>Pista de Simpatia</color>, ganhar <sprite name="Sympathy"><color=#008D3F>simpatia</color> custa mais <color=#008D3F>apoiadores</color> e nos rende mais <style="vptext">PV</style>.
+tutorial4.sympathy.5=Conforme subimos na <color=#008D3F>Trilha de Simpatia</color>, ganhar <sprite name="Sympathy"><color=#008D3F>simpatia</color> custa mais <color=#008D3F>apoiadores</color> e nos rende mais <style="vptext">PV</style>.
 tutorial4.craft.1=No início do Dia, a <sprite name="Sympathy"><color=#008D3F>simpatia</color> conta com o naipe de sua clareira para pagar os custos de criação, assim como os <color=#336699>ninhos das Rapinas</color> e as <color=#CC6633>oficinas dos Marqueses</color>. Vamos criar!
 tutorial4.mobilize.1=Use <color=#008D3F>Mobilizar</color> para transformar as cartas restantes na sua mão em <color=#008D3F>apoiadores</color>. Você não pode ter mais de 5 <color=#008D3F>apoiadores</color> até construir uma <color=#008D3F>base</color>.
 tutorial4.endturn1=A revolução despertou. Mas por ora, é hora de descansar.
@@ -2311,9 +2817,9 @@ tutorial4.turn2.revolt.5=Ahhh, parece que um <sprite name="Officer"><color=#008D
 tutorial4.turn2.evening.1=Agora você tem acesso a um número de ações de Operações Militares igual ao número de seus <sprite name="Officer"><color=#008D3F>oficiais</color>.
 tutorial4.turn2.evening.2=Use sua única ação militar para <color=#008D3F>recrutar</color> um <sprite name="AlliWarrior"><color=#008D3F>guerreiro</color>.
 tutorial4.AIturn2.1=Hora de silenciar esses coelhinhos agitadores!
-tutorial4.AIturn2.2=Quando um oponente move guerreiros para uma clareira <color=#008D3F>simpatizante</color> ou destrói um marcador de <sprite name="Sympathy"><color=#008D3F>simpatia</color>, isso causa <sprite name="Outrage"><color=#008D3F>Indignação</color>. Isso força seu oponente a adicionar uma carta da mão correspondente à clareira aos seus <color=#008D3F>apoiadores</color>.
+tutorial4.AIturn2.2=Quando um oponente move guerreiros para uma clareira <color=#008D3F>simpatizante</color> ou destrói um marcador de <sprite name="Sympathy"><color=#008D3F>simpatia</color>, isso causa <sprite name="Outrage"><color=#008D3F>Ultraje</color>. Isso força seu oponente a adicionar uma carta da mão correspondente à clareira aos seus <color=#008D3F>apoiadores</color>.
 tutorial4.AIturn2.3=Fomos ludibriados!
-tutorial4.AIturn2.4=Você está sendo atacado. Felizmente, a <color=#008D3F>Aliança da Floresta</color> é mestre em <sprite name="Guerilla"><color=#008D3F>Guerra de Guerrilha</color>. Ao se defender, você usa o dado maior no combate como se fosse o atacante.
+tutorial4.AIturn2.4=Você está sendo atacado. Felizmente, a <color=#008D3F>Aliança da Floresta</color> é mestre em <sprite name="Guerilla"><color=#008D3F>Guerrilha</color>. Ao se defender, você usa o dado maior no combate como se fosse o atacante.
 tutorial4.turn3.goal.1=Espalhe <sprite name="Sympathy"><color=#008D3F>simpatia</color>, crie cartas e remova construções inimigas para pontuar <style="vpnumddteen">15</style> e concluir este cenário.
 tutorial4.organize.goal=Use a ação <sprite name="Organize"><color=#008D3F>Organizar</color> para sacrificar um <sprite name="AlliWarrior"><color=#008D3F>guerreiro</color> por um marcador de <sprite name="Sympathy"><color=#008D3F>simpatia</color>.
 tutorial4.law.1=Espaços inimigos com três ou mais guerreiros custam um <color=#008D3F>apoiador</color> adicional para espalhar <sprite name="Sympathy"><color=#008D3F>simpatia</color> neles. Espalhe para espaços mais baratos, a menos que realmente queira atingir esse inimigo.
@@ -2324,26 +2830,26 @@ tutorial4.organize.training=Você tem uma nova ação no Dia, <color=#008D3F>Tre
 tutorial4.organize.training.supply=Oficiais vêm do mesmo suprimento que seus guerreiros. Cuidado, quando este suprimento acabar, você não poderá recrutar nenhum dos dois tipos.
 tutorial4.goal.1=Pontue <style="vpnumddteen">15</style>.  ({0}/{1})
 tutorial4.goal.2=Use a ação <sprite name="Organize"><color=#008D3F>Organizar</color>
-tutorial5.intro=O astuto <color=#4E6F89>Malandro</color> deseja ganhar fama—ou infâmia—no meio deste conflito iminente. Ele pontua completando missões para as criaturas da Floresta e ajudando ou prejudicando as outras facções.
+tutorial5.intro=O astuto <color=#4E6F89>Malandro</color> deseja ganhar fama—ou infâmia—no meio deste conflito iminente. Ele pontua completando tarefas para as criaturas da Floresta e ajudando ou prejudicando as outras facções.
 Tutorial5.pawn=Seu personagem <color=#4E6F89>Malandro</color> é representado por um único peão que pode se mover e lutar como um guerreiro, começando o jogo em uma floresta.
-Tutorial5.slip=Sendo madrugadores, <color=#4E6F89>Malandro</color> pode <color=#4E6F89>escorregar</color> entre florestas e clareiras a cada Alvorada. Vamos <color=#4E6F89>escorregar</color> para uma clareira.
+Tutorial5.slip=Sendo madrugadores, <color=#4E6F89>Malandros</color> podem <color=#4E6F89>deslizar</color> entre florestas e clareiras a cada Amanhecer. Vamos <color=#4E6F89>deslizar</color> para uma clareira.
 Tutorial5.turn1.actions=Estas são suas ações.
-Tutorial5.turn1.satchel=Suas ações disponíveis são determinadas principalmente pelos itens que você possui em sua <sprite name="Satchel"><color=#4E6F89>Bolsa</color>.
-Tutorial5.turn1.item=Quando um item é usado para realizar uma ação, ele é exausto. Você não pode realizar essa ação novamente até que o item seja <color=#4E6F89>renovado</color> na Alvorada.
+Tutorial5.turn1.satchel=Suas ações disponíveis são determinadas principalmente pelos itens que você possui em sua <sprite name="Satchel"><color=#4E6F89>Mochila</color>.
+Tutorial5.turn1.item=Quando um item é usado para realizar uma ação, ele é exaurido. Você não pode realizar essa ação novamente até que o item seja <color=#4E6F89>reanimado</color> no Amanhecer.
 Tutorial5.turn1.ruins=As <sprite name="Ruins"><color=#4E6F89>ruínas</color> estão espalhadas pelo mapa e contêm novos itens para um <color=#4E6F89>Malandro</color>. <color=#4E6F89>Explore</color> a <sprite name="Ruins"><color=#4E6F89>ruína</color> no seu espaço usando seu item <sprite name="torch"><color=#4E6F89>tocha</color>.
 Tutorial5.turn1.craft=<color=#4E6F89>Explorar</color> lhe deu <sprite name="1VP"> e um <sprite name="hammer"><color=#4E6F89>martelo</color>, que pode ser usado para criar cartas da sua mão. Mova-se para a clareira <sprite name="ClearingMouse"> à sua direita para criar uma carta que exija esse naipe.
-Tutorial5.turn1.craft2=Cada <sprite name="hammer"> que você exausta contribui com um ponto para criar cartas com custo correspondente ao naipe da sua clareira. Coletar mais <sprite name="hammer"> permitirá que você crie cartas mais caras.
-Tutorial5.turn1.craft3=Crie Mouse-in-a-Sack agora para pontuar <sprite name="1VP"> e ganhar um item <sprite name="bag">.
-Tutorial5.turn1.satchel.limit=O número de itens que você pode carregar é limitado pelos 6 slots da sua <sprite name="Satchel"><color=#4E6F89>Bolsa</color>. Cada <sprite name="bag"> que você adquire aumenta em 2 o número de itens padrão <sprite name="sword"> <sprite name="crossbow"> <sprite name="boot"> <sprite name="torch"> <sprite name="hammer"> que você pode armazenar em sua <sprite name="Satchel">.
-Tutorial5.turn1.special.items=Os itens <sprite name="bag">, <sprite name="coinstack"> e <sprite name="teapot"> não ocupam espaço em sua <sprite name="Satchel"><color=#4E6F89>Bolsa</color> e fornecem seus efeitos automaticamente, sem precisar exauri-los.
-Tutorial5.turn1.end=A maioria de seus itens está exausta, então vamos encerrar o Dia e descansar.
-Tutorial5.turn2.Birdsong=Durante a Alvorada, você <color=#4E6F89>renova</color> 3 itens, tornando suas ações disponíveis novamente.
+Tutorial5.turn1.craft2=Cada <sprite name="hammer"> que você exaure contribui com um ponto para criar cartas com custo correspondente ao naipe da sua clareira. Coletar mais <sprite name="hammer"> permitirá que você crie cartas mais caras.
+Tutorial5.turn1.craft3=Crie Rato no Saco agora para pontuar <sprite name="1VP"> e ganhar um item <sprite name="bag">.
+Tutorial5.turn1.satchel.limit=O número de itens que você pode carregar é limitado pelos 6 slots da sua <sprite name="Satchel"><color=#4E6F89>Mochila</color>. Cada <sprite name="bag"> que você adquire aumenta em 2 o número de itens padrão <sprite name="sword"> <sprite name="crossbow"> <sprite name="boot"> <sprite name="torch"> <sprite name="hammer"> que você pode armazenar em sua <sprite name="Satchel">.
+Tutorial5.turn1.special.items=Os itens <sprite name="bag">, <sprite name="coinstack"> e <sprite name="teapot"> não ocupam espaço em sua <sprite name="Satchel"><color=#4E6F89>Mochila</color> e fornecem seus efeitos automaticamente, sem precisar exauri-los.
+Tutorial5.turn1.end=A maioria de seus itens estão exauridos, então vamos encerrar o Dia e descansar.
+Tutorial5.turn2.Birdsong=Durante o Amanhecer, você <color=#4E6F89>reanime</color> 3 itens, tornando suas ações disponíveis novamente.
 Tutorial5.turn2.trade=Ahhh, vejo que a <color=#008D3F>Aliança da Floresta</color> tem uma <sprite name="crossbow"> para troca. <color=#4E6F89>Escorregue</color> para a floresta acima de você para ir ao encontro deles.
 Tutorial5.turn2.trade2=Agora, mova-se para a clareira <sprite name="ClearingMouse"> simpatizante da <color=#008D3F>Aliança da Floresta</color>.
 Tutorial5.turn2.aid=Você pode entregar uma carta que corresponda ao naipe da sua clareira para outro jogador na mesma clareira para melhorar sua <color=#4E6F89>relação</color> com ele.
 Tutorial5.turn2.aid.b=Se o jogador que você <sprite name="heart"> <color=#4E6F89>ajudar</color> tiver criado algum item, ele lhe dará um em troca.
 Tutorial5.turn2.aid2=Você também deve esgotar um item à sua escolha para <sprite name="heart"> <color=#4E6F89>ajudar</color>. Esgote sua <sprite name="bag"> bolsa.
-Tutorial5.turn2.satchel=Itens esgotados SEMPRE ocupam espaço em sua <sprite name="Satchel"><color=#4E6F89>Bolsa</color> (mesmo <sprite name="bag"> <sprite name="coinstack"> <sprite name="teapot">) e não fornecerão seu efeito até que você os <color=#4E6F89>recupere</color>.
+Tutorial5.turn2.satchel=Itens exauridos SEMPRE ocupam espaço em sua <sprite name="Satchel"><color=#4E6F89>Mochila</color> (mesmo <sprite name="bag"> <sprite name="coinstack"> <sprite name="teapot">) e não fornecerão seu efeito até que você os <color=#4E6F89>reanime</color>.
 Tutorial5.turn2.gift=Obrigado pela <sprite name="heart"> <color=#4E6F89>ajuda</color>, amigo. Cuidado com a <sprite name="crossbow"> <color=#4E6F89>besta</color> que lhe demos!
 Tutorial5.turn2.strike=A <sprite name="crossbow"> <color=#4E6F89>besta</color> pode ser usada para remover guerreiros sem a necessidade de uma batalha. Você pode até usá-la para remover uma construção ou marcador, desde que o dono não tenha guerreiros lá. Use-a agora contra esses gatos desavisados!
 Tutorial5.turn2.aicomment=En Garde! Esse astuto <color=#4E6F89>Malandro</color> não é amigo dos <color=#CC6633>Marqueses</color>!
@@ -2354,48 +2860,48 @@ Tutorial5.turn2.sword=Use sua <sprite name="sword"> espada para lutar contra o e
 Tutorial5.turn2.end=Pressione o botão continuar para finalizar o turno.
 Tutorial5.ai.turn2.attacked=Isso não parece uma luta justa!
 Tutorial5.turn3.damage=Muitos de nossos itens foram danificados na última batalha e estão inúteis até que os reparemos.
-Tutorial5.turn3.damage2=<color=#4E6F89>Esconder-se</color> na floresta permite que você repare todos os seus itens durante o Anoitecer e o protege de ser atacado durante os turnos inimigos.
+Tutorial5.turn3.damage2=<color=#4E6F89>Deslizar-se</color> para a floresta permite que você repare todos os seus itens durante o Anoitecer e o protege de ser atacado durante os turnos inimigos.
 Tutorial5.turn3.endturn=Há poucas ações que você pode realizar em uma floresta. Pressione continuar para avançar para o Anoitecer.
-Tutorial5.turn4.quest1=Agora que seus itens estão em perfeito estado, você deve estar pronto para encarar uma <sprite name="Quest"><color=#4E6F89>missão</color>! Um urso está furioso em uma clareira <sprite name="ClearingMouse"> próxima. Esconda-se lá para ver se podemos ajudar.
-Tutorial5.turn4.quest2=Selecione sua ação de <sprite name="Quest"><color=#4E6F89>missão</color> para ver o que será necessário para afastar o urso.
-Tutorial5.turn4.fendoffbear=Você tem o que é preciso para Afastar o Urso! Para completar uma <sprite name="Quest"><color=#4E6F89>missão</color>, você precisa estar em uma clareira que corresponda ao seu naipe e esgotar os itens necessários.
-Tutorial5.turn4.reward=Escolha sua recompensa! A recompensa de Pontos de Vitória <style="vptext">PV</style> para cada <sprite name="Quest"><color=#4E6F89>missão</color> é aumentada em 1 para cada <sprite name="Quest"> que você já completou do mesmo naipe.
-Tutorial5.turn4.questbook=Após completar uma <sprite name="Quest"><color=#4E6F89>Missão</color>, você compra uma nova. Você pode revisar suas três <sprite name="Quest"> ativas a qualquer momento selecionando seu <sprite name="Quest"><color=#4E6F89>Livro de Missões</color>.
+Tutorial5.turn4.quest1=Agora que seus itens estão em perfeito estado, você deve estar pronto para encarar uma <sprite name="Quest"><color=#4E6F89>tarefa</color>! Um urso está furioso em uma clareira <sprite name="ClearingMouse"> próxima. Deslize para lá para ver se podemos ajudar.
+Tutorial5.turn4.quest2=Selecione sua ação de <sprite name="Quest"><color=#4E6F89>tarefa</color> para ver o que será necessário para afastar o urso.
+Tutorial5.turn4.fendoffbear=Você tem o que é preciso para Afastar um Urso! Para completar uma <sprite name="Quest"><color=#4E6F89>tarefa</color>, você precisa estar em uma clareira que corresponda ao seu naipe e esgotar os itens necessários.
+Tutorial5.turn4.reward=Escolha sua recompensa! A recompensa de Pontos de Vitória <style="vptext">PV</style> para cada <sprite name="Quest"><color=#4E6F89>tarefa</color> é aumentada em 1 para cada <sprite name="Quest"> que você já completou do mesmo naipe.
+Tutorial5.turn4.questbook=Após completar uma <sprite name="Quest"><color=#4E6F89>Tarefa</color>, você compra uma nova. Você pode revisar suas três <sprite name="Quest"> ativas a qualquer momento selecionando seu <sprite name="Quest"><color=#4E6F89>Livro de Tarefas</color>.
 Tutorial5.relationship=Alcance o próximo <color=#4E6F89>nível de relação</color> com a <color=#008D3F>Aliança da Floresta</color> ao <sprite name="heart"> <color=#4E6F89>ajudá-los</color> duas vezes em um único turno.
 Tutorial5.relationship.2=Para melhorar sua <color=#4E6F89>relação</color> para o segundo e terceiro níveis, você deve <sprite name="heart"> <color=#4E6F89>ajudar</color> duas e três vezes respectivamente em um único turno.
 Tutorial5.relationship.3=Outros jogadores não precisam ter itens para trocar para <sprite name="heart"> <color=#4E6F89>ajudá-los</color>, mas você deve entregar a eles uma carta.
 Tutorial5.relationship.4=Cada vez que você aumenta seu <color=#4E6F89>relacionamento</color> com uma facção, você ganha mais <style="vptext">PV</style>. Quando alcançar o nível final do seu <color=#4E6F89>relacionamento</color>, você se torna <color=#4E6F89>aliado</color> e ganha <voffset=-5><sprite name="2VP"></voffset> cada vez que fornecer <sprite name="heart"> <color=#4E6F89>ajuda</color> adicional a eles.
 Tutorial5.relationship.5=Você também pode se mover e batalhar com os guerreiros de uma facção totalmente <sprite name="Allied"><color=#4E6F89>aliada</color> em sua clareira.
-Tutorial5.goaltocomplete=Explore outra <sprite name="Ruins"><color=#4E6F89>Ruína</color>, complete outra <sprite name="Quest"><color=#4E6F89>Missão</color> e pontue <style="vpnumddteen">15</style> para completar este cenário.
+Tutorial5.goaltocomplete=Explore outra <sprite name="Ruins"><color=#4E6F89>Ruína</color>, complete outra <sprite name="Quest"><color=#4E6F89>Tarefa</color> e pontue <style="vpnumddteen">15</style> para completar este cenário.
 firsttime.defenseless=Você está indefeso, recebendo um acerto extra em batalha, pois não tem itens <sprite name="sword"> sem dano.
 firsttime.hostile=Espere! Se você atacá-los, eles se tornarão <sprite name="Hostile"><color=#4E6F89>hostis</color> pelo restante do jogo e não poderão mais ser <sprite name="heart"> <color=#4E6F89>ajudados</color>.
 firsttime.coin=Cada <sprite name="coinstack"> que você tem aumenta a quantidade de cartas que você compra durante o Anoitecer em 1.
-firsttime.tea=Cada <sprite name="teapot"> que você tem aumenta a quantidade de itens que você pode <color=#4E6F89>restaurar</color> durante a Alvorada em 2.
+firsttime.tea=Cada <sprite name="teapot"> que você tem aumenta a quantidade de itens que você pode <color=#4E6F89>reanimar</color> durante o Amanhecer em 2.
 Firsttime.ally.battle=O número máximo de acertos que você pode causar equivale ao número de guerreiros aliados ali, mais seu total de itens <sprite name="sword"> sem dano.
 Firsttime.ally.battle.2=Se você receber mais acertos em uma batalha ao remover <sprite name="Allied"><color=#4E6F89>guerreiros aliados</color> do que ao danificar itens, essa facção <sprite name="Allied"><color=#4E6F89>aliada</color> se tornará <sprite name="Hostile"><color=#4E6F89>hostil</color>.
 firsttime.character=Cada personagem do Malandro começa com itens diferentes e uma habilidade especial que pode ser ativada ao exaurir uma <sprite name="torch"><color=#4E6F89>tocha</color>. Escolha seu personagem para este jogo abaixo.
 tutorial5.goal.1=<sprite name="heart"> <color=#4E6F89>Ajude</color> a <color=#008D3F>Aliança da Floresta</color> duas vezes em um turno.
 tutorial5.goal.2=Explore uma <sprite name="Ruins"><color=#4E6F89>ruína</color>.
-tutorial5.goal.3=Complete uma <sprite name="Quest"><color=#4E6F89>missão</color>.
+tutorial5.goal.3=Complete uma <sprite name="Quest"><color=#4E6F89>tarefa</color>.
 tutorial5.goal.4=Pontue <style="vpnumddteen">15</style> ({0}/{1})
 tutorial.officers=Oficiais
-tutorial.satchel=Bolsa
+tutorial.satchel=Mochila
 Tutorial5.AI.aid.goal.feedback=Seu esforço é apreciado. <sprite name="heart"> <color=#4E6F89>Ajude</color>-nos novamente para mostrar que você é um verdadeiro camarada da <color=#008D3F>Aliança</color>.
 FTT.Vagabond.Repair=Além de criar, um <sprite name="hammer"> pode ser exaurido para reparar um item danificado com a ação <color=#4E6F89>Reparar</color>.
 tutorial.title.tutorial01=A Ascensão dos Marqueses
 tutorial.description.tutorial01=Aprenda o básico de como jogar Root
 tutorial.title.tutorial02=A Longa Guerra pela Floresta
-tutorial.description.tutorial02=Aprenda a jogar com os Marqueses de Cat
+tutorial.description.tutorial02=Aprenda a jogar com os Marqueses
 tutorial.title.tutorial03=Pássaros da Mesma Pena
 tutorial.description.tutorial03=Aprenda a jogar com a Dinastia das Rapinas
 tutorial.title.tutorial04=Criaturas Unidas!
 tutorial.description.tutorial04=Aprenda a jogar com a Aliança da Floresta
-tutorial.title.tutorial05=O Viajante Solitário
+tutorial.title.tutorial05=O Andarilho Solitário
 tutorial.description.tutorial05=Aprenda a jogar com o Malandro
-tutorial.ftt.outrage.nomatch=Como seu oponente não tem cartas que correspondam ao naipe da clareira onde causaram <sprite name="Outrage"><color=#008D3F>Indignação</color>, eles devem revelar a mão e você recebe um <color=#008D3F>apoiador</color> aleatório.
+tutorial.ftt.outrage.nomatch=Como seu oponente não tem cartas que correspondam ao naipe da clareira onde causaram <sprite name="Outrage"><color=#008D3F>Ultraje</color>, eles devem revelar a mão e você recebe um <color=#008D3F>apoiador</color> aleatório.
 firsttime.openStore=Você comprou uma carta que cria um item esgotado. Toque no ícone do suprimento para ver os itens disponíveis.
 firsttime.NoItemsToCraft=Cada item que os jogadores criam é retirado do suprimento. Assim que um item estiver esgotado, cartas que recompensam esse item não poderão mais ser criadas.
-PracticeGamePrompt.MarquiseEyrie.Header=Marqueses de Cat vs. Dinastia das Rapinas
+PracticeGamePrompt.MarquiseEyrie.Header=Marqueses vs. Dinastia das Rapinas
 PracticeGamePrompt.MarquiseEyrie.Body=Agora que você conhece os Marqueses e as Rapinas,<br>deseja jogar uma partida de treino entre eles?
 PracticeGamePrompt.MarquiseEyrie.PlayMarquise=Jogar como Marqueses
 PracticeGamePrompt.MarquiseEyrie.PlayEyrie=Jogar como Rapinas
@@ -2407,11 +2913,11 @@ tutorial.reserve=Reserva
 Firsttime.discard=No final do turno, você deve descartar até o limite máximo de 5 cartas em sua mão.
 Firsttime.sympathyTokenRemoved=Seu oponente removeu seu <sprite name="Sympathy"><color=#008D3F>marcador de simpatia</color>, pontuando <sprite name="1VP">. Marcadores podem ser atacados em batalha assim como Guerreiros, mas eles não podem revidar.
 practice.openingLine=Hora de colocar seu treinamento à prova. Neste jogo de prática, a primeira facção a alcançar <style="vpnumdd">20</style> vence!
-tutorial3.turnthree.turmoil.1.b=Sinto que o caos está se aproximando, mas você deve adicionar ao <color=#336699>Decreto</color> a cada turno, não importa o que aconteça. Faça uma atribuição agora — apenas não se preocupe muito com onde.
+tutorial3.turnthree.turmoil.1.b=Sinto que o tumulto está se aproximando, mas você deve adicionar ao <color=#336699>Decreto</color> a cada turno, não importa o que aconteça. Faça uma atribuição agora — apenas não se preocupe muito com onde.
 tutorial3.turnthree.turmoil.1.cats=Aquelas malévolas <color=#CC6633>Marqueses</color> destruíram seu único <sprite name="Roost"><color=#336699>ninho</color> em uma clareira <sprite name="ClearingFox"> de Raposa no último turno, deixando você sem clareiras <sprite name="ClearingFox"> de Raposa para recrutar.
 tutorial3.aiturnthree.use.sappers=Selecione a carta de Armadilheiros que você criou para remover um guerreiro inimigo adicional.
 tutorial3.turnfour.goal.1=Parece que você está pronto para seguir sozinho. Destrua construções inimigas, crie cartas e construa e proteja <sprite name="Roost"><color=#336699>ninhos</color> para pontuar <style="vpnumddteen">10</style> e completar este cenário.
-Firsttime.ally.Marquise=Você agora está <sprite name="Allied"><color=#4E6F89>aliado</color> às <color=#CC6633>Marqueses de Cat</color>. Cada vez que você lhes fornecer <sprite name="heart"> <color=#4E6F89>ajuda</color>, você pontuará <style="vptext">PV</style>. Você também pode comandar os guerreiros deles em sua clareira para se mover e lutar ao seu lado.
+Firsttime.ally.Marquise=Você agora está <sprite name="Allied"><color=#4E6F89>aliado</color> aos <color=#CC6633>Marqueses</color>. Cada vez que você lhes fornecer <sprite name="heart"> <color=#4E6F89>ajuda</color>, você pontuará <style="vptext">PV</style>. Você também pode comandar os guerreiros deles em sua clareira para se mover e lutar ao seu lado.
 Firsttime.ally.Eyrie=Você agora está <sprite name="Allied"><color=#4E6F89>aliado</color> à <color=#336699>Dinastia das Rapinas</color>. Cada vez que você lhes fornecer <sprite name="heart"> <color=#4E6F89>ajuda</color>, você pontuará <style="vptext">PV</style>. Você também pode comandar os guerreiros deles em sua clareira para se mover e lutar ao seu lado.
 Firsttime.ally.Alliance=Você agora está <sprite name="Allied"><color=#4E6F89>aliado</color> à <color=#008D3F>Aliança da Floresta</color>. Cada vez que você lhes fornecer <sprite name="heart"> <color=#4E6F89>ajuda</color>, você pontuará <style="vptext">PV</style>. Você também pode comandar os guerreiros deles em sua clareira para se mover e lutar ao seu lado.
 tutorial4.turn2.craftOrMobilize=Você pode criar ou <color=#008D3F>Mobilizar</color> a carta em sua mão. A escolha é sua.
@@ -2429,7 +2935,7 @@ FTT.enemy.defenseless.2=Acertos extras não são limitados pela quantidade de gu
 tutorial3.move.1.trunk=<sprite name="birdicon"> atribuído a um <color=#336699>Decreto</color> pode ser usado em qualquer clareira.
 tutorial3.move.1.b.trunk=Mova 3 <color=#336699><sprite name="eyrie"> guerreiros</color> para a clareira <sprite name="ClearingFox"> de Raposa abaixo. Três guerreiros permitem que você maximize o potencial de acertos da sua rolagem de dados em batalha.
 tutorial2.ftt.encouragement=Bom trabalho destruindo aquele <sprite name="Roost"> <color=#336699>ninho</color>. Continue atacando ninhos e erguendo construções para alcançar sua meta de <style="vptext">PV</style>.
-Clockwork.tutorial.intro=Bots mecânicos são uma alternativa desafiadora e personalizável à IA. A versão bot de cada facção funciona de maneira um pouco diferente de sua contraparte viva.
+Clockwork.tutorial.intro=Bots Autômatos são uma alternativa desafiadora e personalizável à IA. A versão bot de cada facção funciona de maneira um pouco diferente de sua contraparte viva.
 Clockwork.tutorial.orders=No turno dele, um bot compra e revela uma carta de ordem e usa seu naipe para determinar as ações que realiza.
 Clockwork.tutorial.crafting=Se a carta de ordem tiver um item, o bot cria esse item. Ele ignora os pontos de vitória listados e, em vez disso, pontua apenas <sprite name="1VP">.
 Clockwork.tutorial.powers.1=Você pode revisar os poderes especiais de um bot e a ordem de seu turno selecionando o avatar dele. Vamos fazer isso agora para os Marqueses Mecânicos.
@@ -2443,8 +2949,8 @@ Clockwork.tutorial.turnorder=Para mais informações sobre as diferenças entre 
 Clockwork.tutorial.turnorder.gamepad.DEFUNCT=Para mais informações sobre as diferenças entre bots e suas contrapartes padrão, você pode ver a página de ordem de turno deles. Pressione <sprite name="Switch_RightStickButton"> agora para fazer isso.
 Clockwork.tutorial.priority=Cada clareira tem um marcador de prioridade. Se um bot precisar decidir entre duas clareiras de igual valor para ele, ele escolhe a clareira com o número mais baixo.
 Clockwork.tutorial.ending=Hora de desmontar esse pedaço de ferrugem. Pontue 10 <style="vptext">PV</style>.
-tutorial.title.MechaTutorial=Introdução ao Relógio de Engrenagem
-tutorial.description.MechaTutorial=Aprenda sobre os inimigos mecânicos
+tutorial.title.MechaTutorial=Introdução aos Autômatos
+tutorial.description.MechaTutorial=Aprenda sobre os inimigos Autômatos
 Clockwork.tutorial.goal.10vp=Pontue 10 <style="vptext">PV</style>
 tutorial.advanced.separator=Expansões
 ftt.MoveToKeepArea=Cuidado com a habilidade de Hospitais de Campo dos Marqueses. Guerreiros podem ser curados imediatamente ao serem removidos da clareira com a Torre da Guarda.
@@ -2459,14 +2965,14 @@ scenario.wartax.description=Use o Traço de Imposto de Guerra das Rapinas Elétr
 scenario.popularity.name=Popularidade
 scenario.popularity.description=Use o Traço de Popularidade da Aliança Automatizada para enfrentar inimigos automatizados poderosos. <b>Popularidade:</b> Os inimigos não pontuam ao remover marcadores de simpatia.
 scenario.marksman.name=Atirador de Elite
-scenario.marksman.description=Use o Traço de Atirador de Elite do Vagabot para enfrentar inimigos automatizados poderosos. \n<b>Atirador de Elite:</b> No início da batalha como atacante, cause um acerto imediato.
+scenario.marksman.description=Use o Traço de Atirador de Elite do Automalandro para enfrentar inimigos automatizados poderosos. \n<b>Atirador de Elite:</b> No início da batalha como atacante, cause um acerto imediato.
 tooltip.opponent.cat=<size=125%><b>Oponente: Marqueses</b></size>
 tooltip.opponent.eyrie=<size=125%><b>Oponente: Dinastia das Rapinas</b></size>
 tooltip.opponent.alliance=<size=125%><b>Oponente: Aliança da Floresta</b></size>
 tooltip.opponent.vagabond=<size=125%><b>Oponente: Malandro</b></size>
 tooltip.opponent.secondvagabond=<size=125%><b>Oponente: Malandro</b></size>
 tooltip.opponent.riverfolk=<size=125%><b>Oponente: Companhia Ribeirinha</b></size>
-tooltip.opponent.lizard=<size=125%><b>Oponente: Culto dos Lagartos</b></size>
+tooltip.opponent.lizard=<size=125%><b>Oponente: Lagartos Cultistas</b></size>
 tooltip.opponent.player=<size=125%><b>{0}</b></size>
 tooltip.ui.shopinventory=<size=125%><b>Suprimento</b></size>
 tooltip.ui.victorypoints=<size=125%><b>Pontos de Vitória</b></size><br>O primeiro jogador a alcançar <style="vpnumddteen"><size=14><space=.1em>30</size></style> vence.
@@ -2474,13 +2980,13 @@ tooltip.ui.suitdominanceactive=<size=125%><b>Domínio Ativo</b></size>\nEste jog
 tooltip.ui.birddominanceactive=<size=125%><b>Domínio Ativo</b></size>\nEste jogador vencerá se controlar 2 clareiras em cantos opostos do tabuleiro no início do turno.
 tooltip.ui.coalitionactive=<size=125%><b>Coalizão: {0}</b></size>\nO Malandro formou uma coalizão e vencerá se o jogador indicado vencer.
 tooltip.ui.advanceday=<size=125%><b>Continuar</b></size>
-tooltip.ui.cat.warriorcount=<size=125%><b>Guerreiros em Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
-tooltip.ui.cat.woodonboard=<size=125%><b>Madeira no Tabuleiro</b></size>\nMadeira colhida disponível para erguer construções. Cada Serraria gera 1 madeira durante a Alvorada. Ao erguer, apenas madeira conectada por clareiras que você governa pode ser usada. Pilhas de madeira têm um limite de 8.
+tooltip.ui.cat.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
+tooltip.ui.cat.woodonboard=<size=125%><b>Madeira no Tabuleiro</b></size>\nMadeira colhida disponível para erguer construções. Cada Serraria gera 1 madeira durante o Amanhecer. Ao erguer, apenas madeiras conectadas por clareiras que você governa podem ser usada. Pilhas de madeira têm um limite de 8.
 tooltip.ability.cat.battle=<size=125%><b>Batalha</b></size>\nTente remover peças inimigas em uma clareira onde você tenha qualquer número de guerreiros.
 tooltip.ability.cat.march=<size=125%><b>Marchar</b></size>\nMova guerreiros entre clareiras, duas vezes por uso da habilidade.
 tooltip.ability.cat.recruit=<size=125%><b>Recrutar</b></size>\nUma vez por turno, posicione um guerreiro em cada recrutador.
 tooltip.ability.cat.build=<size=125%><b>Erguer</b></size>\nGaste madeira para posicionar uma construção em uma clareira que você governa com um espaço de construção livre.
-tooltip.ability.cat.overwork=<size=125%><b>Sobrecarregar</b></size>\nGaste uma carta para posicionar uma madeira em uma clareira com uma serraria correspondente à carta.
+tooltip.ability.cat.overwork=<size=125%><b>Hora Extra</b></size>\nGaste uma carta para posicionar uma madeira em uma clareira com uma serraria correspondente à carta.
 tooltip.ability.cat.birdaction=<size=125%><b>Rapinas para Contratar</b></size>\nGaste 1 carta de pássaro para realizar uma ação adicional.
 tooltip.ui.alliance.warriorcount=<size=125%><b>Reserva (Guerreiros + Oficiais)</b></size>\nSe um jogador não tiver mais peças em reserva, ele não poderá recrutar guerreiros nem ganhar oficiais.
 tooltip.ui.alliance.officercount=<size=125%><b>Oficiais</b></size>\nA Aliança usa oficiais para comandar operações militares: Mover, Recrutar, Batalha e Organizar.
@@ -2492,28 +2998,28 @@ tooltip.ability.alliance.battle=<size=125%><b>Batalha</b></size>\nTente remover 
 tooltip.ability.alliance.move=<size=125%><b>Mover</b></size>\nMova guerreiros entre clareiras.
 tooltip.ability.alliance.train=<size=125%><b>Treinar</b></size>\nGaste uma carta da mão correspondente a uma base construída para ganhar um Oficial.
 tooltip.ability.alliance.recruit=<size=125%><b>Recrutar</b></size>\nPosicione um guerreiro em uma base.
-tooltip.ui.eyrie.warriorcount=<size=125%><b>Guerreiros em Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
+tooltip.ui.eyrie.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
 tooltip.ability.eyrie.recruitdecree=<size=125%><b>Decreto de Recrutar</b></size>\nPosicione um guerreiro em um ninho em uma clareira correspondente.
 tooltip.ability.eyrie.movedecree=<size=125%><b>Decreto de Mover</b></size>\nMova guerreiros de uma clareira correspondente.
 tooltip.ability.eyrie.battledecree=<size=125%><b>Decreto de Batalha</b></size>\nTente remover peças inimigas em uma clareira correspondente\nonde você tenha qualquer número de guerreiros.
-tooltip.ability.eyrie.builddecree=<size=125%><b>Decreto de Erguer</b></size>\nPosicione um ninho em uma clareira correspondente que você governa e que não tenha um ninho.
-tooltip.ui.vagabond.backpack=<size=125%><b>Bolsa</b></size>\nArmazena seus itens.\nCada <sprite name="bag"> aumenta a capacidade da bolsa em 2.\nItens não exauridos <sprite name="teapot">, <sprite name="coinstack"> e <sprite name="bag"> não ocupam espaço na bolsa.
-tooltip.ui.vagabond.quest=<size=125%><b>Missões Disponíveis</b></size>\nComplete missões para pontuar ou comprar cartas.
+tooltip.ability.eyrie.builddecree=<size=125%><b>Decreto de Construir</b></size>\nPosicione um ninho em uma clareira correspondente que você governa e que não tenha um ninho.
+tooltip.ui.vagabond.backpack=<size=125%><b>Mochila</b></size>\nArmazena seus itens.\nCada <sprite name="bag"> aumenta a capacidade da bolsa em 2.\nItens não exauridos <sprite name="teapot">, <sprite name="coinstack"> e <sprite name="bag"> não ocupam espaço na mochila.
+tooltip.ui.vagabond.quest=<size=125%><b>Tarefas Disponíveis</b></size>\nComplete tarefas para pontuar ou comprar cartas.
 tooltip.ability.vagabond.move=<size=125%><b>Mover</b></size>\nMova-se para uma clareira adjacente.
 tooltip.ability.vagabond.attack=<size=125%><b>Batalha</b></size>\nTente remover peças inimigas em sua clareira usando espadas.
 tooltip.ability.vagabond.explore=<size=125%><b>Explorar</b></size>\nPegue um item de uma ruína e pontue um PV.
-tooltip.ability.vagabond.aid=<size=125%><b>Ajudar</b></size>\nExaure um item e entregue uma carta correspondente à sua clareira para outro jogador naquela clareira. Pegue um item desse jogador, se possível.
-tooltip.ability.vagabond.quest=<size=125%><b>Missão</b></size>\nExaure itens em uma missão correspondente à sua clareira para pontuar PV ou comprar cartas.
+tooltip.ability.vagabond.aid=<size=125%><b>Ajuda</b></size>\nExaura um item e entregue uma carta correspondente à sua clareira para outro jogador naquela clareira. Pegue um item desse jogador, se possível.
+tooltip.ability.vagabond.quest=<size=125%><b>Tarefa</b></size>\nExaura itens em uma tarefa correspondente à sua clareira para pontuar PV ou comprar cartas.
 tooltip.ability.vagabond.strike=<size=125%><b>Ataque Preciso</b></size>\nRemova uma peça em sua clareira, começando pelos guerreiros.
 tooltip.ability.vagabond.repair=<size=125%><b>Reparar</b></size>\nRepare um item danificado.
 tooltip.ability.vagabond.craft=<size=125%><b>Criar</b></size>\nCrie uma carta da mão. Todos os seus <sprite name="hammer"> correspondem à sua clareira atual.
-tooltip.ability.vagabond.steal=<size=125%><b>Roubar</b></size> - Exaure <sprite name="torch"> para pegar uma carta aleatória de um jogador em sua clareira.
-tooltip.ability.vagabond.hideout=<size=125%><b>Esconderijo</b></size> - Exaure <sprite name="torch"> para reparar três itens. Em seguida, termine imediatamente o Dia.
-tooltip.ability.vagabond.daylabor=<size=125%><b>Trabalho Diurno</b></size> - Exaure <sprite name="torch"> para pegar uma carta do descarte correspondente à sua clareira.
-tooltip.ability.vagabond.daylabor.disabled=<size=125%><b>Trabalho Diurno</b></size> - Exaure <sprite name="torch"> para pegar uma carta do descarte correspondente à sua clareira.<br><br> Atualmente indisponível porque sua <sprite name="torch"> está exaurida, não há cartas no descarte correspondentes ao naipe de sua clareira, ou porque você está em uma floresta.
+tooltip.ability.vagabond.steal=<size=125%><b>Roubar</b></size> - Exaura <sprite name="torch"> para pegar uma carta aleatória de um jogador em sua clareira.
+tooltip.ability.vagabond.hideout=<size=125%><b>Esconderijo</b></size> - Exaura <sprite name="torch"> para reparar três itens. Em seguida, termine imediatamente o Dia.
+tooltip.ability.vagabond.daylabor=<size=125%><b>Dia de Trabalho</b></size> - Exaura <sprite name="torch"> para pegar uma carta do descarte correspondente à sua clareira.
+tooltip.ability.vagabond.daylabor.disabled=<size=125%><b>Dia de Trabalho</b></size> - Exaura <sprite name="torch"> para pegar uma carta do descarte correspondente à sua clareira.<br><br> Atualmente indisponível porque sua <sprite name="torch"> está exaurida, não há cartas no descarte correspondentes ao naipe de sua clareira, ou porque você está em uma floresta.
 tooltip.ability.vagabond.scorchedearth=<size=125%><b>Terra Queimada</b></size> - Descarte <sprite name="torch"> para remover todas as peças inimigas de sua clareira. Peças não podem mais ser posicionadas ou movidas para a clareira incendiada. Não pode ser usado em uma clareira com a Torre da Guarda.
 tooltip.clearing.vagabond.scorchedearth=<size=125%><b>Terra Queimada</b>\nPeças não podem mais ser posicionadas ou movidas para esta clareira.
-tooltip.ability.vagabond.instigate=<size=125%><b>Instigar</b></size> - Exaure <sprite name="torch"> para iniciar uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada lado.
+tooltip.ability.vagabond.instigate=<size=125%><b>Instigar</b></size> - Exaura <sprite name="torch"> para iniciar uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada lado.
 tooltip.playmat.base=<size=125%><b>Base</b></size>\nUma Base permite à Aliança da Floresta treinar oficiais, recrutar guerreiros e comprar cartas adicionais. Sempre que uma base for removida, a Aliança deve descartar todos os apoiadores do naipe correspondente (incluindo cartas de pássaro) e remover metade de seus oficiais, arredondando para cima.
 tooltip.playmat.recruiter=<size=125%><b>Recrutador</b></size>\nRecruta guerreiros neste espaço quando os Marqueses usam a ação de recrutar.
 tooltip.playmat.roost=<size=125%><b>Ninho</b></size>\nAs Rapinas usam ninhos para recrutar guerreiros, criar cartas, comprar cartas adicionais e pontuar.
@@ -2529,33 +3035,33 @@ tooltip.playmat.catstack=<size=125%><b>Guerreiros dos Marqueses</b></size>
 tooltip.playmat.birdstack=<size=125%><b>Guerreiros das Rapinas</b></size>
 tooltip.playmat.alliancestack=<size=125%><b>Guerreiros da Aliança</b></size>
 tooltip.playmat.vagabond=<size=125%><b>Malandro</b></size>
-tooltip.playmat.vagabot=<size=125%><b>Vagabot</b></size>
-tooltip.playmat.sympathystack=<size=125%><b>Marcador de Simpatia</b></size>\nA Aliança usa simpatia para criar cartas e iniciar revoltas. Mover-se para uma clareira simpática ou remover simpatia causa Indignação.
+tooltip.playmat.vagabot=<size=125%><b>Automalandro</b></size>
+tooltip.playmat.sympathystack=<size=125%><b>Marcador de Simpatia</b></size>\nA Aliança usa simpatia para criar cartas e iniciar revoltas. Mover-se para uma clareira simpática ou remover simpatia causa Ultraje.
 tooltip.playmat.cancelaction=<size=125%><b>Cancelar</b></size>
 tooltip.ability.alliance.craft=<size=125%><b>Criar</b></size>\nCrie uma carta da mão. A Aliança cria usando simpatia.
 tooltip.ability.eyrie.craft=<size=125%><b>Criar</b></size>\nJogue uma carta da mão para criá-la. As Rapinas criam usando ninhos.
 tooltip.ability.cat.craft=<size=125%><b>Criar</b></size>\nJogue uma carta da mão para criá-la. Os Marqueses criam usando oficinas.
-tooltip.item.sack=<size=125%><b>Bolsa</b></size>\nO Malandro usa <sprite name="bag"> para aumentar a capacidade de sua bolsa.
+tooltip.item.sack=<size=125%><b>Bolsa</b></size>\nO Malandro usa <sprite name="bag"> para aumentar a capacidade de sua mochila.
 tooltip.item.boot=<size=125%><b>Bota</b></size>\nO Malandro usa <sprite name="boot"> para se mover.
 tooltip.item.crossbow=<size=125%><b>Besta</b></size>\nO Malandro usa <sprite name="crossbow"> para atacar com precisão.
 tooltip.item.hammer=<size=125%><b>Martelo</b></size>\nO Malandro usa <sprite name="hammer"> para criar e reparar.
 tooltip.item.sword=<size=125%><b>Espada</b></size>\nO Malandro usa <sprite name="sword"> para batalhar.
-tooltip.item.teapot=<size=125%><b>Chá</b></size>\nO Malandro usa <sprite name="teapot"> para restaurar mais itens durante a Alvorada.
+tooltip.item.teapot=<size=125%><b>Chá</b></size>\nO Malandro usa <sprite name="teapot"> para reanimar mais itens durante o Amanhecer.
 tooltip.item.torch=<size=125%><b>Tocha</b></size>\nO Malandro usa <sprite name="torch"> para explorar.
 tooltip.item.goldstack=<size=125%><b>Pilha de Moedas</b></size>\nO Malandro usa <sprite name="coinstack"> para comprar cartas adicionais durante o Anoitecer.
 tooltip.item.fromruins=\n\nEste item foi encontrado ao explorar ruínas.
 tooltip.item.invalid=Item Inválido
-tooltip.ui.eyrie.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer. Compre mais cartas ao erguer Ninhos.
+tooltip.ui.eyrie.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer. Compre mais cartas ao construir Ninhos.
 tooltip.ui.marquise.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer. Compre mais cartas ao erguer Recrutadores.
-tooltip.ui.alliance.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer. Compre mais cartas ao erguer Bases.
+tooltip.ui.alliance.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer. Compre mais cartas ao construir Bases.
 tooltip.ui.vagabond.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer.\nCada <sprite name="coinstack"> compra 1 carta adicional.
-tooltip.ui.lizardcult.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer. Compre mais cartas ao erguer Jardins.
+tooltip.ui.lizardcult.drawrate=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas no Anoitecer. Compre mais cartas ao construir Jardins.
 tooltip.ui.eyrie.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas para pegar esses itens. As Rapinas criam itens usando Ninhos.
 tooltip.ui.marquise.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas para pegar esses itens. Os Marqueses criam itens usando Oficinas.
 tooltip.ui.alliance.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas para pegar esses itens. A Aliança cria itens usando Simpatia.
-tooltip.ui.eyrie.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nAs Rapinas compram cartas adicionais ao erguer Ninhos.
+tooltip.ui.eyrie.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nAs Rapinas compram cartas adicionais ao construir Ninhos.
 tooltip.ui.marquise.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nOs Marqueses compram cartas adicionais ao erguer Recrutadores.
-tooltip.ui.alliance.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nA Aliança compra cartas adicionais ao erguer Bases.
+tooltip.ui.alliance.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nA Aliança compra cartas adicionais ao construir Bases.
 toolitp.ui.vagabond.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nO Malandro compra cartas adicionais ao adquirir Pilhas de Moedas.
 tooltip.ui.alliance.supportersinfo=<size=125%><b>Apoiadores</b></size>\nA Aliança usa apoiadores para espalhar simpatia e iniciar revoltas. A Aliança pode manter no máximo 5 apoiadores, a menos que tenha uma base erguida.
 tooltip.ui.alliance.officersinfo=<size=125%><b>Oficiais</b></size>\nA Aliança usa oficiais para comandar operações militares: Mover, Recrutar, Batalhar e Organizar.
@@ -2571,30 +3077,30 @@ tooltip.ui.marquise.sawmillcost=<size=125%><b>Custo da Serraria</b></size>\nA pr
 tooltip.ui.marquise.workshopcost=<size=125%><b>Custo da Oficina</b></size>\nA próxima oficina erguida custará esta quantidade de madeira.
 tooltip.ui.marquise.recruitercost=<size=125%><b>Custo do Recrutador</b></size>\nO próximo recrutador erguido custará esta quantidade de madeira.
 tooltip.ui.marquise.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nOs Marqueses criam cartas usando Oficinas.
-tooltip.ui.vagabond.refreshrate=<size=125%><b>Taxa de Restauração</b></size>\nO Malandro restaura esta quantidade de itens a cada turno.\nCada <sprite name="teapot"> restaura 2 itens adicionais.
+tooltip.ui.vagabond.refreshrate=<size=125%><b>Taxa de Reanimação</b></size>\nO Malandro reanima esta quantidade de itens a cada turno.\nCada <sprite name="teapot"> reanima 2 itens adicionais.
 tooltip.ui.vagabond.attackpower=<size=125%><b>Poder de Ataque</b></size>\nO Malandro causa, no máximo, esta quantidade de dano em batalhas.\nCada <sprite name="sword"> fornece 1 ponto de poder de ataque adicional.
 tooltip.ui.vagabondrelationship.hostile=<size=125%><b>Hostil</b></size>\nO Malandro deve exaurir 1 <sprite name="boot"> adicional para entrar em clareiras hostis e pontua <sprite name="1VP"> extra por peça hostil removida em batalha.
 tooltip.ui.vagabondrelationship.indifferent=<size=125%><b>Indiferente</b></size>\nO Malandro pode Ajudar um jogador para melhorar essa relação e pontuar <sprite name="1VP">. O progresso para esse objetivo é representado por marcas preenchidas à direita do coração.
 tooltip.ui.vagabondrelationship.one=<size=125%><b>Relacionamento</b></size>\nO Malandro pode Ajudar um jogador duas vezes em um turno para melhorar essa relação e pontuar <sprite name="2VP">. O progresso para esse objetivo é representado por marcas preenchidas à direita do coração.
 tooltip.ui.vagabondrelationship.two=<size=125%><b>Relacionamento</b></size>\nO Malandro pode Ajudar um jogador três vezes em um turno para melhorar essa relação e pontuar <sprite name="2VP">. O progresso para esse objetivo é representado por marcas preenchidas à direita do coração.
 tooltip.ui.vagabondrelationship.allied=<size=125%><b>Aliado</b></size>\nO Malandro pode se mover e batalhar com guerreiros aliados. Ajudar um aliado concede <sprite name="2VP">.
-tooltip.ui.vagabond.vagabond_ranger=<size=125%><b>Ranger</b></size>\n<b>Esconderijo</b> — Exaure <sprite name="torch"> para reparar três itens. Em seguida, termine imediatamente o Dia.
-tooltip.ui.vagabond.vagabond_thief=<size=125%><b>Ladrão</b></size>\n<b>Roubar</b> — Exaure <sprite name="torch"> para pegar uma carta aleatória de um jogador em sua clareira.
-tooltip.ui.vagabond.vagabond_tinker=<size=125%><b>Serralheiro</b></size>\n<b>Trabalho Diurno</b> — Exaure <sprite name="torch"> para pegar uma carta do descarte correspondente à sua clareira.
+tooltip.ui.vagabond.vagabond_ranger=<size=125%><b>Andarilho</b></size>\n<b>Esconderijo</b> — Exaura <sprite name="torch"> para reparar três itens. Em seguida, termine imediatamente o Dia.
+tooltip.ui.vagabond.vagabond_thief=<size=125%><b>Ladrão</b></size>\n<b>Roubar</b> — Exaura <sprite name="torch"> para pegar uma carta aleatória de um jogador em sua clareira.
+tooltip.ui.vagabond.vagabond_tinker=<size=125%><b>Funileiro</b></size>\n<b>Dia de Trabalho</b> — Exaura <sprite name="torch"> para pegar uma carta do descarte correspondente à sua clareira.
 tooltip.item.status.damaged=\n<b>Danificado</b> — Este item foi danificado e não pode ser usado até ser reparado.
-tooltip.item.status.exhausted=\n<b>Exaurido</b> — Este item está exaurido e não pode ser usado para realizar ações até ser restaurado durante a Alvorada.
+tooltip.item.status.exhausted=\n<b>Exaurido</b> — Este item está exaurido e não pode ser usado para realizar ações até ser reanimado durante o Amanhecer.
 tooltip.prompts.shop.availableitems=<size=125%><b>Itens Criáveis</b></size>\nEsses itens são obtidos ao criar cartas. O Malandro pode Ajudar para negociar itens criados.
 tooltip.prompts.shop.availabledominance=<size=125%><b>Cartas de Domínio Disponíveis</b></size>\nVocê pode comprar uma Carta de Domínio do suprimento ao descartar uma carta do naipe correspondente durante o Dia.
 tooltip.playmat.foundation=<size=125%><b>Espaço de Construção</b></size>\nConstruções só podem ser erguidas em clareiras com um espaço de construção livre.
 tooltip.ui.alliance.sympathysupporterbracket=<size=125%><b>Escala de Custo de Apoiadores</b></size>\n Esses marcadores de Simpatia custarão esta quantidade de apoiadores para serem posicionados.
 tooltip.gameoptions.timer.fast=<size=125%><b>3 Minutos</b></size>\nPara jogadores que desejam terminar uma partida em uma única sessão. Cada jogador tem três minutos para realizar seu turno antes que suas ações sejam resolvidas por uma IA. Após três turnos inativos seguidos, eles serão substituídos permanentemente por uma IA.
 tooltip.gameoptions.timer.slow=<size=125%><b>3 Dias</b></size>\nPara jogadores que desejam jogar uma partida em várias sessões ou sem se preocupar com limites curtos de tempo. Cada jogador deve realizar uma jogada a cada três dias, ou será substituído por uma IA.
-tooltip.ui.vagabond.satcheldiscard=<size=125%>Sua Bolsa está sobrecarregada. No final do turno, você deve descartar {0} itens.
+tooltip.ui.vagabond.satcheldiscard=<size=125%>Sua Mochila está sobrecarregada. No final do turno, você deve descartar {0} itens.
 tooltip.ui.buildmodal.woodcost=<size=125%><b>Custo de Madeira</b></size>
-tooltip.ui.buildmodal.extracard=Erguer isso desbloqueia a compra de uma carta adicional durante o Anoitecer.
-tooltip.ui.buildmodal.victorypoints=Pontos de Vitória concedidos ao erguer.
+tooltip.ui.buildmodal.extracard=Construir isso desbloqueia a compra de uma carta adicional durante o Anoitecer.
+tooltip.ui.buildmodal.victorypoints=Pontos de Vitória concedidos ao construir.
 tooltip.ui.actions=<size=125%><b>Ações Restantes</b></size>
-tooltip.ui.phase.Birdsong=<size=125%><b>Alvorada</b></size>
+tooltip.ui.phase.Birdsong=<size=125%><b>Amanhecer</b></size>
 tooltip.ui.phase.daylight=<size=125%><b>Dia</b></size>
 tooltip.ui.phase.evening=<size=125%><b>Anoitecer</b></size>
 tooltip.playmat.foxclearing=<size=125%><b>Clareira de Raposa</b></size>
@@ -2612,7 +3118,7 @@ tooltip.ui.phase.cancel=<size=125%><b>Cancelar</b></size>
 tooltip.ui.defenseless=Indefeso
 tooltip.ui.commander=Comandante
 tooltip.ui.brutaltactics=Táticas Brutais
-tooltip.ui.sappers=Sapadores
+tooltip.ui.sappers=Armadilheiros
 tooltip.ui.armorers=Armeiros
 tooltip.ui.totalhitdef=Acertos Totais (Defensor)
 tooltip.ui.totalhitatk=Acertos Totais (Atacante)
@@ -2620,41 +3126,41 @@ tooltip.ui.rolledhit=Acertos Rolados
 tooltip.ui.factionwarning=Esta combinação de facções pode ter pouca interação. Jogue por sua conta e risco.
 tooltip.ui.victorypoints.practice=<size=125%><b>Pontos de Vitória</b></size>\nNeste jogo de prática, o primeiro jogador a alcançar <style="vpnumdd">20</style> vence.
 tooltip.ui.victorypoints.altwin.challenges=<size=125%><b>Pontos de Vitória</b></size>\nEm um jogo típico, o primeiro jogador a alcançar <style="vpnumdd">30</style> vence. Revise o ícone de regras de desafio à direita para obter instruções sobre como vencer este desafio.
-tooltip.ui.hand.reveal.cat=<size=125%><b>Mão dos Marqueses</b></size> Visualize a mão dos Marqueses revelada na última Indignação.
-tooltip.ui.hand.reveal.eyrie=<size=125%><b>Mão das Rapinas</b></size> Visualize a mão da Dinastia das Rapinas revelada na última Indignação.
-tooltip.ui.hand.reveal.vagabond=<size=125%><b>Mão do Malandro</b></size> Visualize a mão do Malandro revelada na última Indignação.
+tooltip.ui.hand.reveal.cat=<size=125%><b>Mão dos Marqueses</b></size> Visualize a mão dos Marqueses revelada no último Ultraje.
+tooltip.ui.hand.reveal.eyrie=<size=125%><b>Mão das Rapinas</b></size> Visualize a mão da Dinastia das Rapinas revelada no último Ultraje.
+tooltip.ui.hand.reveal.vagabond=<size=125%><b>Mão do Malandro</b></size> Visualize a mão do Malandro revelada no último Ultraje.
 tooltip.ui.martiallaw=<size=125%><b>Lei Marcial</b></size> Você deve gastar um apoiador adicional correspondente se a clareira alvo tiver pelo menos 3 guerreiros de outro jogador.
-tooltip.mechorder=<size=125%><b>Ordem</b></size><br>O naipe da ordem determina quais ações um jogador Relógio realiza em seu turno.
+tooltip.mechorder=<size=125%><b>Ordem</b></size><br>O naipe da ordem determina quais ações um jogador Autômato realiza em seu turno.
 tooltip.ui.firstturn=Este jogador fará o primeiro turno após a preparação. A ordem do jogo segue a lista para baixo.
 landing.achievements.gc=Conquistas
 tooltip.ui.actionlog=<size=125%><b>Registro de Ações</b></size><br>Exibe as ações realizadas anteriormente no jogo.
 tooltip.ui.hitsearned=Os acertos obtidos com sua rolagem de dados não podem exceder o número de guerreiros que você tem nesta clareira.
-tooltip.ui.vagabondhitsearned=Os acertos obtidos com sua rolagem de dados não podem exceder o número de espadas que você tem na bolsa.
+tooltip.ui.vagabondhitsearned=Os acertos obtidos com sua rolagem de dados não podem exceder o número de espadas que você tem na mochila.
 tooltip.ui.daylightactions=<size=125%><b>Ações do Dia</b></size><br>Ações determinadas pelo naipe da carta de ordem.
-tooltip.ui.vbbattletrack=<size=125%><b>Trilha de Batalha</b></size><br>Os acertos máximos rolados do Vagabot em batalha começam em um. Enquanto o Vagabot tiver pelo menos seis, nove e doze itens não danificados, um item é colocado aqui. Os espaços do sexto e do nono item aumentam os acertos máximos em um, e o décimo segundo faz com que ele cause um acerto adicional.
+tooltip.ui.vbbattletrack=<size=125%><b>Trilha de Batalha</b></size><br>Os acertos máximos rolados do Automalandro em batalha começam em um. Enquanto o Automalandro tiver pelo menos seis, nove e doze itens não danificados, um item é colocado aqui. Os espaços do sexto e do nono item aumentam os acertos máximos em um, e o décimo segundo faz com que ele cause um acerto adicional.
 tooltip.ui.crackdown=<size=125%><b>Repressão:</b></size><br>Sempre que uma base for removida, devolva todos os marcadores de simpatia das clareiras correspondentes ao naipe da base removida.
-tooltip.ui.coop=<size=125%><b>Jogo Cooperativo</b></size><br>Jogue como um time contra oponentes Relógio. Para vencer, os jogadores (e a IA) devem pontuar 30 pontos de vitória antes que qualquer oponente Relógio alcance 30 pontos de vitória. Cartas de Domínio são removidas.
+tooltip.ui.coop=<size=125%><b>Jogo Cooperativo</b></size><br>Jogue como um time contra oponentes Autômatos. Para vencer, os jogadores (e a IA) devem pontuar 30 pontos de vitória antes que qualquer oponente Autômato alcance 30 pontos de vitória. Cartas de Domínio são removidas.
 landing.grm=Ir para o aplicativo Dire Wolf Game Room
 grm.return=Voltar ao aplicativo Dire Wolf Game Room
 tooltip.opponent.mechanical.marquise=<size=125%><b>Oponente Marqueses Mecânicos</b></size>
 tooltip.opponent.electric.eyrie=<size=125%><b>Oponente Rapinas Elétricas</b></size>
 tooltip.opponent.automated.alliance=<size=125%><b>Oponente Aliança Automatizada</b></size>
-tooltip.opponent.vagabot=<size=125%><b>Oponente Vagabot</b></size>
+tooltip.opponent.vagabot=<size=125%><b>Oponente Automalandro</b></size>
 tooltip.regularmap=<size=125%><b>Mapa de Outono</b></size><br> O mapa padrão de Root.
 tooltip.fallmap=<size=125%><b>Mapa de Outono</b></size><br> O mapa padrão de Root.
 tooltip.wintermap=<size=125%><b>Mapa de Inverno</b></size><br> Um mapa avançado com localizações de naipes das clareiras randomizadas. Diferente do mapa de Outono, o rio divide a floresta como se fosse um caminho.
-tooltip.outrage.reminder=Mover-se para esta clareira ativará Indignação.
+tooltip.outrage.reminder=Mover-se para esta clareira ativará Ultraje.
 tooltip.giftegg=<size=125%><b>Ovo</b></size><br>Mova-se para uma clareira com um ovo para chocar um guerreiro da Dinastia das Rapinas. No início de cada turno dos oponentes, eles quebram um ovo em uma clareira onde estiverem, pontuando <style="vpnum">1</style>.
-tooltip.clockwork.settings=Configurações de Traço e Dificuldade Relógio
+tooltip.clockwork.settings=Configurações de Traço e Dificuldade dos Autômatos
 tooltip.undo=Desfazer
 tooltip.armorers.battle=<size=125%><b>Armeiros:</b></size><br>Ignore todos os acertos rolados recebidos.
 tooltip.electriceyrie.battle=<size=125%><b>Acerto Extra</b></size><br>Acerto adicional concedido porque as Rapinas Elétricas possuem mais cartas na coluna de batalha do decreto do que em qualquer outra coluna.
 tooltip.brutaltactics.battle=<size=125%><b>Táticas Brutais:</b></size><br>Cause um acerto adicional. O defensor pontua 1<style="vptext">PV</style>.
 tooltip.defenseless.battle=<size=125%><b>Indefeso:</b></size><br>Cause um acerto adicional, pois o defensor não possui guerreiros nesta clareira.
 tooltip.commander.battle=<size=125%><b>Comandante:</b></size><br>Como atacante em batalha, você causa um acerto adicional.
-tooltip.sappers.battle=<size=125%><b>Sapadores:</b></size><br>O defensor causa um acerto adicional.
+tooltip.sappers.battle=<size=125%><b>Armadilheiros:</b></size><br>O defensor causa um acerto adicional.
 tooltip.autoambush.battle=<size=125%><b>Emboscada Automatizada:</b></size><br>O defensor causa um acerto adicional em batalha com qualquer guerreiro da Aliança.
-tooltip.arbiterprotector.battle=<size=125%><b>Protetor:</b></size><br>O Árbitro adiciona suas espadas não danificadas ao número máximo de acertos rolados pelo defensor.
+tooltip.arbiterprotector.battle=<size=125%><b>Proteção:</b></size><br>O Árbitro adiciona suas espadas não danificadas ao número máximo de acertos rolados pelo defensor.
 tooltip.settingsmenu=<b>Configurações</b>
 tooltip.direbytes=<b>Notícias da Dire Wolf</b>
 tooltip.leaderboards=<b>Classificações</b>
@@ -2667,51 +3173,12 @@ decree.rabbit.tooltip=Os naipes de Coelho são usados para interagir com clareir
 decree.bird.tooltip=Os naipes de Pássaro são usados para interagir com qualquer tipo de clareira.
 cat.nowood.tooltip=Esta clareira está isolada de algumas de suas fontes de madeira. Lembre-se de que você só pode erguer construções usando madeira conectada através de clareiras que você controla.
 cat.snareblock.tooltip=Você não pode erguer aqui devido à Armadilha da Conspiração Corvídea.
-tooltip.ui.randomfactionsonly=<size=125%><b>Facções Aleatórias</b></size><br>Os jogadores e a IA não terão a opção de escolher sua facção. Facções Relógio estão excluídas desta regra.
+tooltip.ui.randomfactionsonly=<size=125%><b>Facções Aleatórias</b></size><br>Os jogadores e a IA não terão a opção de escolher sua facção. Facções Autômatas estão excluídas desta regra.
 tooltip.ui.hand.revealed=Cartas Reveladas
 tooltip.chat=<b>Chat</b>
-tooltip.ui.hundreds.warriorcount=<size=125%><b>Guerreiros em Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
-tooltip.ui.hundreds.drawrate=O Senhor das Centenas compra cartas adicionais usando o humor Tumultuado.
-tooltip.ui.hundreds.strongholds=<size=125%><b>Contagem de Suprimentos da Fortaleza</b></size>
-tooltip.ui.hundreds.mob=<size=125%><b>Mobs</b></size>
-tooltip.ui.hundreds.command=<size=125%><b>Número de Comandos</b></size> O número de vezes que você pode Comandar as Centenas (Mover, Batalhar, Erguer) a cada turno.
-tooltip.ui.hundreds.prowess=<size=125%><b>Número de Prowess</b></size>\nO número de vezes que você pode Avançar o Senhor da Guerra (Mover e/ou Batalhar) a cada turno.
-tooltip.ui.hundreds.oppression=<size=125%><b>Número de Oprimidos</b></size>
-tooltip.ui.hundreds.moods=<size=125%><b>Humores</b></size>
-tooltip.ui.hundreds.protectwarlord=<size=125%><b>Proteger o Senhor da Guerra</b></size>\nQuando ativado, seu Senhor da Guerra será o último guerreiro removido durante o combate.
-tooltip.ui.keepers.warriorcount=<size=125%><b>Guerreiros em Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
-tooltip.ui.keepers.drawrate=Os Guardiões compram uma carta adicional para cada estação de retransmissão que construíram.
-tooltip.ui.keepers.waystations.tablet=<size=125%><b>Estações de Retransmissão de Tábua</b></size>
-tooltip.ui.keepers.waystations.figure=<size=125%><b>Estações de Retransmissão de Figura</b></size>
-tooltip.ui.keepers.waystations.jewelry=<size=125%><b>Estações de Retransmissão de Joias</b></size>
-tooltip.ui.keepers.relics.tablet=<size=125%><b>Relíquias de Tábua</b></size>
-tooltip.ui.keepers.relics.figure=<size=125%><b>Relíquias de Figura</b></size>
-tooltip.ui.keepers.relics.jewelry=<size=125%><b>Relíquias de Joias</b></size>
-tooltip.ui.keepers.retinue.moveorrecover=<size=125%><b>Mover ou Recuperar</b></size>\nEscolha uma clareira cujo naipe corresponda ao naipe da carta. Mova-se a partir dela ou recupere relíquias nela.
-tooltip.ui.keepers.retinue.battleanddelve=<size=125%><b>Batalhar e então Escavar</b></size>\nEscolha uma clareira cujo naipe corresponda ao naipe da carta onde você tenha pelo menos 1 guerreiro. Eles devem iniciar uma batalha lá se houver peças inimigas. Em seguida, se eles controlarem a clareira e houver pelo menos um guerreiro Guardião, poderão escavar lá conforme descrito <i>(mesmo que não haja inimigos para batalhar)</i>.
-tooltip.ui.keepers.retinue.move=<size=125%><b>Mover</b></size>\nRealize um movimento a partir de uma clareira cujo naipe corresponda ao naipe da carta.
-tooltip.keepersiniron.relics.description=<size=125%><b>Relíquias</b></size>
-tooltip.keepersiniron.waystations.description=<size=125%><b>Estações de Retransmissão</b></size>
-tooltip.ui.hundreds.thehoard.description=<size=125%><b>O Tesouro</b></size>\nTexto temporário de O Tesouro
-tooltip.ui.hundreds.oppressedspaces.description=<size=125%><b>Espaços Oprimidos</b></size>\nTexto temporário de Espaços Oprimidos
-tooltip.ui.keepers.crafteditems=Os Guardiões criam itens usando estações de retransmissão.
-tooltip.ui.keepers.craftedcards=Os Guardiões criam cartas usando estações de retransmissão.
-tooltip.ui.hundreds.craftedcards=O Senhor das Centenas cria cartas usando fortalezas.
-tooltip.ui.hundreds.warriormovementtoggle=Quando ativado, o padrão será mover seu senhor da guerra sempre que você se mover a partir de uma clareira com seu senhor da guerra.
-tooltip.hangar.hirelings.ability=<b>Habilidade</b><br><br>As habilidades estão sempre ativas, embora algumas indiquem quando ocorrem.
-tooltip.hangar.hirelings.whenhiredaction=<b>Ação ao Ser Contratado</b><br><br>Quando ganham o controle do contratado, o jogador controlador deve realizar esta ação.
-tooltip.hangar.hirelings.startofbirdsongaction=<b>Ação no Início da Alvorada</b><br><br>No início de sua Alvorada, o jogador controlador deve ou pode realizar esta ação, conforme descrito.
-tooltip.hangar.hirelings.onceperdaylightaction=<b>Ação Uma Vez por Dia</b><br><br>Uma vez durante o Dia, o jogador controlador pode realizar esta ação.
-tooltip.playmat.relic.tablet=<size=125%><b>Relíquia</b></size>\nRelíquia de Tábua
-tooltip.playmat.relic.figure=<size=125%><b>Relíquia</b></size>\nRelíquia de Figura
-tooltip.playmat.relic.jewelry=<size=125%><b>Relíquia</b></size>\nRelíquia de Joias
-tooltip.playmat.stronghold=Fortaleza
-tooltip.playmat.mob=Mob
-tooltip.playmat.waystation=Estação de Retransmissão
-tooltip.hirelingsenabled=Contratados Habilitados
 title.introduction=Introdução
 title.flowofplay=Fluxo de Jogo
-rule.eachturn=Cada turno é dividido em três fases: Alvorada, Dia e Anoitecer. Assim que você jogar todas essas fases em ordem, seu turno termina, e o próximo jogador na ordem de turno começa seu turno.
+rule.eachturn=Cada turno é dividido em três fases: Amanhecer, Dia e Anoitecer. Assim que você jogar todas essas fases em ordem, seu turno termina, e o próximo jogador na ordem de turno começa seu turno.
 title.howtowin=Como Vencer
 rule.howtowin=Você pode vencer de duas formas: pontuando 30 Pontos de Vitória (PV) ou jogando e completando uma Carta de Domínio. Veja a <link="dominance"><color=#462C1B><u>seção de Cartas de Domínio</u></color></link>.
 title.factions=Facções
@@ -2720,14 +3187,14 @@ title.eyrie=Dinastia das Rapinas
 title.alli=Aliança da Floresta
 title.vaga=Malandro
 title.riverfolk=Companhia Ribeirinha
-title.lizard=Culto dos Lagartos
+title.lizard=Lagartos Cultistas
 title.twovagabond=Malandros Duplos
 title.corvidconspiracy=Conspiração Corvídea
 title.undergroundduchy=Ducado Subterrâneo
 rule.marq=Os invasores Marqueses desejam explorar a Floresta, usando seus vastos recursos para alimentar sua máquina econômica e militar. Eles pontuam ao construir construções na Floresta.
 rule.eyrie=A orgulhosa Dinastia das Rapinas deseja recuperar a glória de sua outrora grande aristocracia e retomar a Floresta dos Marqueses. Eles pontuam a cada turno ao construir e proteger ninhos na Floresta.
 rule.alli=A emergente Aliança da Floresta deseja unir as criaturas da floresta e se rebelar contra seus opressores. Eles pontuam ao espalhar simpatia por sua causa em toda a Floresta.
-rule.vaga=O astuto Malandro deseja ganhar fama — ou infâmia — no meio desse conflito iminente. Ele pontua ao completar missões para as criaturas da Floresta e ao ajudar ou prejudicar as outras facções.
+rule.vaga=O astuto Malandro deseja ganhar fama — ou infâmia — no meio desse conflito iminente. Ele pontua ao completar tarefas para as criaturas da Floresta e ao ajudar ou prejudicar as outras facções.
 title.themap=O Mapa
 rule.themap=A maior parte da ação em Root acontece no mapa da Floresta, composto por 12 clareiras conectadas por caminhos.
 title.moving=Movendo-se pelo Mapa
@@ -2743,28 +3210,28 @@ rule.crafting=A maioria das cartas tem um segundo uso — você pode criar a car
 title.battling=Batalhando
 rules.battling=Você pode batalhar com outros jogadores para remover suas peças do mapa. <br><br>Ao batalhar, escolha qualquer clareira onde você tenha guerreiros. Você é o atacante, e escolhe outra facção com qualquer peça lá como o defensor.<br><br>Para determinar os golpes, dois dados com lados de 0-3 são rolados. O atacante causa golpes máximos iguais ao maior resultado, e o defensor causa golpes máximos iguais ao menor resultado. No entanto, cada jogador só pode causar golpes até o máximo de guerreiros que possuir na clareira da batalha. O jogador que sofre os golpes escolhe quais peças remover, mas deve remover todos os seus guerreiros na clareira da batalha antes de remover suas construções ou marcadores.<br><br><style=RSH>Pontos de Vitória</style><br><br>Sempre que você causar a remoção de uma construção ou marcador inimigo — mesmo fora da batalha — você pontua um ponto de vitória!<br><br><style=RSH>Golpes Extras</style><br><br>Alguns efeitos permitem causar golpes extras. Golpes extras representam posicionamento superior, táticas ou liderança. Eles não estão limitados ao número de guerreiros na clareira da batalha, de modo que um único guerreiro poderia causar múltiplos golpes.<br><br>O atacante causa um golpe extra se o defensor não tiver guerreiros na clareira da batalha, deixando-se indefeso.
 rules.marq=Os Marqueses ocupam a Floresta e querem transformá-la em uma potência industrial e militar. Cada vez que os Marqueses constroem um de seus prédios — uma oficina, serraria ou recrutador — eles pontuam pontos de vitória. Quanto mais prédios do mesmo tipo estiverem no mapa, mais pontos eles pontuam. No entanto, para sustentar a construção contínua, os Marqueses precisam manter e proteger uma economia de madeira forte e interconectada.
-title.setup=Configuração
-rules.marqsetup=<style=RSH>Configuração</style><br><br>∙Compre 3 cartas.<br>∙Coloque o marcador de Torre da Guarda na clareira de canto à sua escolha.<br>∙Você ganha 1 guerreiro em cada clareira, exceto na clareira de canto diagonalmente oposta à da sua Torre da Guarda.<br>∙Coloque 1 serraria, 1 oficina e 1 recrutador entre a clareira com o marcador da Torre da Guarda e qualquer uma adjacente a ela.
+title.setup=Preparação
+rules.marqsetup=<style=RSH>Preparação</style><br><br>∙Compre 3 cartas.<br>∙Coloque o marcador de Torre da Guarda na clareira de canto à sua escolha.<br>∙Você ganha 1 guerreiro em cada clareira, exceto na clareira de canto diagonalmente oposta à da sua Torre da Guarda.<br>∙Coloque 1 serraria, 1 oficina e 1 recrutador entre a clareira com o marcador da Torre da Guarda e qualquer uma adjacente a ela.
 title.thekeep=A Torre da Guarda
 rules.thekeep=A Torre da Guarda dos Marqueses concede duas habilidades especiais enquanto estiver no mapa. Primeiro, ninguém além dos Marqueses pode colocar peças na clareira com o marcador da Torre da Guarda. Além disso, sempre que guerreiros dos Marqueses forem removidos, os Marqueses podem recorrer a seus Hospitais de Campo, gastando uma carta correspondente ao naipe da clareira dos guerreiros para colocá-los de volta na clareira com o marcador da Torre da Guarda. Essa habilidade pode ser usada instantaneamente para resgatar guerreiros removidos da clareira da Torre e no início do turno dos Marqueses para guerreiros removidos de outras clareiras.
-rules.marqturn=<style=RSH><sprite index=66>Alvorada</style><br><br>Cada serraria gera um marcador de madeira.<br><br><style=RSH><sprite index=65>Dia</style><br><br>Primeiro, você pode criar qualquer carta em sua mão usando oficinas.<br><br>Em seguida, você pode realizar até três das seguintes ações:<br><br><style=RB>Batalha:</style> Inicie uma batalha.<br><style=RB>Marchar:</style> Realize dois movimentos.<br><style=RB>Recrutar:</style> Coloque um guerreiro em cada recrutador. Você só pode realizar essa ação uma vez por turno.<br><style=RB>Erguer:</style> Coloque uma construção em uma clareira que você controle com um espaço livre ao gastar marcadores de madeira iguais ao custo da construção. Você pode gastar qualquer madeira no mapa conectada a essa clareira por qualquer número de clareiras que você controle. Ao colocar a construção, pontue os pontos de vitória mostrados na sua trilha de construções.<br><style=RB>Sobrecarregar:</style> Gaste uma carta para colocar um marcador de madeira em uma serraria em uma clareira cujo naipe corresponda à carta gasta.
-rules.hawks=Falcões para Contratar: Você pode realizar qualquer número de ações extras ao gastar uma carta de pássaro por ação extra.
+rules.marqturn=<style=RSH><sprite index=66>Amanhecer</style><br><br>Cada serraria gera um marcador de madeira.<br><br><style=RSH><sprite index=65>Dia</style><br><br>Primeiro, você pode criar qualquer carta em sua mão usando oficinas.<br><br>Em seguida, você pode realizar até três das seguintes ações:<br><br><style=RB>Batalha:</style> Inicie uma batalha.<br><style=RB>Marchar:</style> Realize dois movimentos.<br><style=RB>Recrutar:</style> Coloque um guerreiro em cada recrutador. Você só pode realizar essa ação uma vez por turno.<br><style=RB>Erguer:</style> Coloque uma construção em uma clareira que você controle com um espaço livre ao gastar marcadores de madeira iguais ao custo da construção. Você pode gastar qualquer madeira no mapa conectada a essa clareira por qualquer número de clareiras que você controle. Ao colocar a construção, pontue os pontos de vitória mostrados na sua trilha de construções.<br><style=RB>Hora Extra:</style> Gaste uma carta para colocar um marcador de madeira em uma serraria em uma clareira cujo naipe corresponda à carta gasta.
+rules.hawks=Rapinas para Contratar: Você pode realizar qualquer número de ações extras ao gastar uma carta de pássaro por ação extra.
 rules.marqeve=<style=RSH><sprite index=64>Anoitecer</style><br><br>Compre uma carta, mais uma carta por cada bônus de compra descoberto. Em seguida, se você tiver mais de cinco cartas em sua mão, descarte até ficar com cinco.
 rules.eyrie=A Dinastia das Rapinas deseja restaurar sua outrora digna linhagem à antiga glória na Floresta, reassentando as clareiras da floresta. Durante o Anoitecer, a Dinastia das Rapinas pontua pontos de vitória com base no número de ninhos no mapa. Quanto maior sua presença, maiores seus ganhos. No entanto, a Dinastia das Rapinas está vinculada ao seu Decreto, um conjunto de ações obrigatórias prometidas por seu líder que cresce a cada turno. A cada turno, eles devem realizar todas as ações do Decreto, ou então entrar em tumulto.
-rules.eyriesetup=<style=RSH>Configuração</style><br><br>∙ Compre 3 cartas.<br>∙ Você começa com 6 guerreiros e 1 ninho na clareira de canto diagonalmente oposta à clareira com a Torre da Guarda. Se os Marqueses não estiverem jogando, coloque essas peças na clareira de canto à sua escolha.<br>Escolha um líder.</margin=3em>
-rule.emergencyorders=Ordens de Emergência: Se você não tiver cartas no início da Alvorada, compre uma.
+rules.eyriesetup=<style=RSH>Preparação</style><br><br>∙ Compre 3 cartas.<br>∙ Você começa com 6 guerreiros e 1 ninho na clareira de canto diagonalmente oposta à clareira com a Torre da Guarda. Se os Marqueses não estiverem jogando, coloque essas peças na clareira de canto à sua escolha.<br>Escolha um líder.</margin=3em>
+rule.emergencyorders=Ordens de Emergência: Se você não tiver cartas no início do Amanhecer, compre uma.
 rule.newroost=Um Novo Ninho: Se você não tiver ninhos, coloque um ninho e três guerreiros na clareira com menos guerreiros.
-rule.eyrieturn=<style=RSH>Habilidades</style><br><br>A Dinastia das Rapinas é composta pelos Senhores da Floresta. Eles controlam uma clareira quando empatam com o maior número de guerreiros e construções combinados, desde que tenham pelo menos uma peça da Dinastia das Rapinas lá. No entanto, seu Desdém pelo Comércio faz com que pontuem apenas 1 ponto de vitória ao criar itens.  <style=RSH><sprite index=66>Alvorada</style><br><br>Você deve adicionar uma ou duas cartas em qualquer coluna do Decreto. Apenas uma carta adicionada pode ser uma carta de pássaro. <style=RSH><sprite index=65>Dia</style><br><br>Primeiro, você pode criar qualquer número de cartas, usando ninhos.<br>Em seguida, você deve resolver o Decreto, começando pela coluna mais à esquerda e movendo-se para a direita.<br>Para cada carta em uma coluna, você deve realizar a ação indicada pela coluna em uma clareira correspondente à carta.<br><br>Aqui estão as ações nas quatro colunas do Decreto:<br><br><style=RB>Recrutar</style>: Coloque um guerreiro em uma clareira correspondente com um ninho.<br><style=RB>Mover</style>: Mova pelo menos um guerreiro de uma clareira correspondente.<br><style=RB>Batalhar</style>: Inicie uma batalha em uma clareira correspondente.<br><style=RB>Erguer</style>: Coloque um ninho em uma clareira correspondente que você controle com um espaço livre e sem ninho.<br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Primeiro, pontue os pontos de vitória mostrados no espaço vazio mais à direita da sua trilha de ninhos.<br>Em seguida, compre uma carta, mais uma por cada bônus de compra descoberto. Se você tiver mais de cinco cartas em sua mão, descarte até ficar com cinco.<br><br><style=RSH>Tumulto</style><br><br>Se você não puder realizar uma ação por qualquer motivo, entra em tumulto. Os seguintes passos ocorrem:<br><margin=3em>∙ Primeiro, seu regime é humilhado. Perda 1 ponto de vitória por cada carta de pássaro no Decreto.<br>∙ Em seguida, seu tribunal é purgado. Descarte todas as cartas do Decreto.<br>∙ Depois, seu líder é deposto. Você deve escolher um novo líder para assumir o comando.<br>∙ Por fim, você descansa. Termine o Dia e vá para o Anoitecer.</margin=3em>
-rule.turmoil=Há muitas formas de cair em tumulto! Por exemplo, você pode não ter mais guerreiros em sua reserva para recrutar, ou talvez todas as clareiras que você controla já tenham um ninho, o que significa que você não pode erguer mais ninhos.
+rule.eyrieturn=<style=RSH>Habilidades</style><br><br>A Dinastia das Rapinas é composta pelos Lorders da Floresta. Eles controlam uma clareira quando empatam com o maior número de guerreiros e construções combinados, desde que tenham pelo menos uma peça da Dinastia das Rapinas lá. No entanto, seu Desprezo pelo Comércio faz com que pontuem apenas 1 ponto de vitória ao criar itens.  <style=RSH><sprite index=66>Amanhecer</style><br><br>Você deve adicionar uma ou duas cartas em qualquer coluna do Decreto. Apenas uma carta adicionada pode ser uma carta de pássaro. <style=RSH><sprite index=65>Dia</style><br><br>Primeiro, você pode criar qualquer número de cartas, usando ninhos.<br>Em seguida, você deve resolver o Decreto, começando pela coluna mais à esquerda e movendo-se para a direita.<br>Para cada carta em uma coluna, você deve realizar a ação indicada pela coluna em uma clareira correspondente à carta.<br><br>Aqui estão as ações nas quatro colunas do Decreto:<br><br><style=RB>Recrutar</style>: Coloque um guerreiro em uma clareira correspondente com um ninho.<br><style=RB>Mover</style>: Mova pelo menos um guerreiro de uma clareira correspondente.<br><style=RB>Batalha</style>: Inicie uma batalha em uma clareira correspondente.<br><style=RB>Construir</style>: Coloque um ninho em uma clareira correspondente que você controle com um espaço livre e sem ninho.<br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Primeiro, pontue os pontos de vitória mostrados no espaço vazio mais à direita da sua trilha de ninhos.<br>Em seguida, compre uma carta, mais uma por cada bônus de compra descoberto. Se você tiver mais de cinco cartas em sua mão, descarte até ficar com cinco.<br><br><style=RSH>Tumulto</style><br><br>Se você não puder realizar uma ação por qualquer motivo, entra em tumulto. Os seguintes passos ocorrem:<br><margin=3em>∙ Primeiro, seu regime é humilhado. Perda 1 ponto de vitória por cada carta de pássaro no Decreto.<br>∙ Em seguida, seu tribunal é purgado. Descarte todas as cartas do Decreto.<br>∙ Depois, seu líder é deposto. Você deve escolher um novo líder para assumir o comando.<br>∙ Por fim, você descansa. Termine o Dia e vá para o Anoitecer.</margin=3em>
+rule.turmoil=Há muitas formas de cair em tumulto! Por exemplo, você pode não ter mais guerreiros em sua reserva para recrutar, ou talvez todas as clareiras que você controla já tenham um ninho, o que significa que você não pode construir mais ninhos.
 rules.alliance=A Aliança da Floresta trabalha para conquistar a simpatia das diversas criaturas oprimidas da Floresta. Cada vez que a Aliança coloca um marcador de simpatia, ela pode pontuar pontos de vitória. Quanto mais simpatia houver no mapa, mais pontos de vitória ela pontua. Conquistar a simpatia do povo requer apoiadores. Esses apoiadores também podem ser usados para promover revoltas violentas. Uma revolta estabelece uma nova base, permitindo que a Aliança treine oficiais que aumentam sua flexibilidade militar.
-rules.allisetup=<style=RSH>Configuração</style><br><br>∙ Compre 3 cartas.<br>∙ Ganhe 3 apoiadores em naipes aleatórios.
+rules.allisetup=<style=RSH>Preparação</style><br><br>∙ Compre 3 cartas.<br>∙ Ganhe 3 apoiadores em naipes aleatórios.
 rules.baseremoval=Sempre que uma base for removida, você perde metade dos seus oficiais (arredondado para cima) e descarta todos os apoiadores correspondentes ao naipe daquela base — até mesmo seus apoiadores pássaros!
 rules.spreadsympathy=<style=RB>Espalhar Simpatia:</style> Coloque um marcador de simpatia em uma clareira sem simpatia, adjacente a uma clareira simpática, se possível. Você deve gastar apoiadores conforme mostrado pelo custo na sua trilha de Simpatia. Se a clareira alvo tiver três ou mais guerreiros de outro jogador, você deve gastar um apoiador adicional correspondente para colocar simpatia lá.
 rules.nosympathy=Se não houver marcadores de simpatia no tabuleiro, você pode colocar sua primeira simpatia em qualquer clareira.
 rules.alliturn2=<style=RSH><sprite index=65>Dia</style><br><br>Você pode realizar as seguintes ações usando cartas em sua mão. <br><br><style=RB>Criar:</style> Crie uma carta, usando marcadores de simpatia.<br><style=RB>Mobilizar:</style> Adicione uma carta à pilha de Apoiadores.<br><style=RB>Treinar:</style> Gaste uma carta cujo naipe corresponda a uma base construída para colocar um guerreiro na caixa de Oficiais. Este guerreiro agora é um oficial.<br>Seus oficiais determinam o número de operações militares que você pode realizar durante o Anoitecer. Sem oficiais, você não pode mover ou batalhar com seus guerreiros! Treinar oficiais também permitirá que você recrute novos guerreiros e coloque marcadores de simpatia sem gastar apoiadores.<br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Você pode realizar essas operações militares, até o seu número de oficiais.<br><br><style=RB>Mover:</style> Faça um movimento.<br><style=RB>Batalhar:</style> Inicie uma batalha.<br><style=RB>Recrutar:</style> Coloque um guerreiro em uma clareira com uma base.<br><style=RB>Organizar:</style> Remova um de seus guerreiros de uma clareira sem simpatia para colocar um marcador de simpatia lá. Pontue os pontos de vitória revelados.<br>Depois de terminar as operações militares, compre uma carta, mais uma carta adicional por base que você tenha no mapa. Em seguida, se você tiver mais de cinco cartas em sua mão, descarte até ficar com cinco.
-rules.vaga=O Malandro joga com todos os lados do conflito, fazendo amigos e inimigos conforme seus objetivos, enquanto realiza missões para aumentar sua fama por toda a Floresta. À medida que o Malandro melhora seus relacionamentos com outras facções ou remove peças de facções hostis a ele, ele pontua pontos de vitória.<br><br><style=RSH>Configuração</style><br><br>∙ Compre 3 cartas.<br>∙ Escolha um personagem.<br>∙ Escolha uma floresta para seu peão.<br>∙ Compre 3 missões.
-rules.slip=Escorregar é a única maneira de entrar em uma floresta!
-rules.vagaturn2=<style=RSH><sprite index=65>Dia</style><br><br>Você pode realizar várias ações ao exaurir itens.<br><br><style=""RB"">Mover:</style> Exaure uma <sprite name="boot"> para fazer um movimento.<br><style=""RB"">Batalhar:</style> Exaure uma <sprite name="sword"> para iniciar uma batalha.<br><style=""RB"">Atacar:</style> Exaure uma <sprite name="crossbow"> para remover um guerreiro em sua clareira. Se um jogador não tiver guerreiros lá, você pode, em vez disso, remover uma construção ou marcador daquele jogador.<br><style=""RB"">Explorar:</style> Exaure uma <sprite name="torch"> para pegar um item de uma ruína em sua clareira e pontuar 1 ponto de vitória. <br><style=""RB"">Ajudar:</style> Exaure qualquer item e entregue uma carta da sua mão correspondente à sua clareira para qualquer jogador na sua clareira. Em seguida, pegue um item, se houver, da caixa de Itens Criados daquele jogador.<br><style=""RB"">Missão:</style> Realize uma missão cujo naipe corresponda à sua clareira ao exaurir os dois itens listados na missão. Em seguida, você pode comprar duas cartas do baralho, ou pode pontuar um ponto de vitória por missão desse naipe que você tenha concluído, incluindo esta. Finalmente, compre uma nova carta de missão. <br><style=""RB"">Criar:</style> Exaure <sprite name="hammer"> em número igual ao custo de criação mostrado na carta. Todos os seus <sprite name="hammer"> correspondem ao naipe da sua clareira.<br><style=""RB"">Reparar:</style> Exaure um <sprite name="hammer"> para reparar um item danificado.<br><style=""RB"">Ação Especial:</style> Exaure uma <sprite name="torch"> para realizar a ação especial do seu personagem.<br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Se você estiver em uma floresta, repare todos os seus itens danificados.<br><br>Em seguida, compre uma carta, mais uma carta por <sprite name="coinstack"> em sua trilha de <sprite name="coinstack">. Se você tiver mais de cinco cartas em sua mão, descarte até ficar com cinco.<br><br>Finalmente, se você tiver mais itens em sua Mochila do que seu limite de itens — seis, mais dois por <sprite name="bag"> em sua trilha de <sprite name="bag"> — você deve remover itens da Mochila até atingir seu limite de itens.
+rules.vaga=O Malandro joga com todos os lados do conflito, fazendo amigos e inimigos conforme seus objetivos, enquanto realiza tarefas para aumentar sua fama por toda a Floresta. À medida que o Malandro melhora seus relacionamentos com outras facções ou remove peças de facções hostis a ele, ele pontua pontos de vitória.<br><br><style=RSH>Setup</style><br><br>∙ Compre 3 cartas.<br>∙ Escolha um personagem.<br>∙ Escolha uma floresta para seu peão.<br>∙ Compre 3 tarefas.
+rules.slip=Deslizar é a única maneira de entrar em uma floresta!
+rules.vagaturn2=<style=RSH><sprite index=65>Dia</style><br><br>Você pode realizar várias ações ao exaurir itens.<br><br><style=""RB"">Mover:</style> Exaura uma <sprite name="boot"> para fazer um movimento.<br><style=""RB"">Batalhar:</style> Exaura uma <sprite name="sword"> para iniciar uma batalha.<br><style=""RB"">Ataque:</style> Exaura uma <sprite name="crossbow"> para remover um guerreiro em sua clareira. Se um jogador não tiver guerreiros lá, você pode, em vez disso, remover uma construção ou marcador daquele jogador.<br><style=""RB"">Explorar:</style> Exaura uma <sprite name="torch"> para pegar um item de uma ruína em sua clareira e pontuar 1 ponto de vitória. <br><style=""RB"">Ajuda:</style> Exaura qualquer item e entregue uma carta da sua mão correspondente à sua clareira para qualquer jogador na sua clareira. Em seguida, pegue um item, se houver, da caixa de Itens Criados daquele jogador.<br><style=""RB"">Tarefas:</style> Realize uma tarefa cujo naipe corresponda à sua clareira ao exaurir os dois itens listados na tarefa. Em seguida, você pode comprar duas cartas do baralho, ou pode pontuar um ponto de vitória por tarefa desse naipe que você tenha concluído, incluindo esta. Finalmente, compre uma nova carta de tarefa. <br><style=""RB"">Criar:</style> Exaura <sprite name="hammer"> em número igual ao custo de criação mostrado na carta. Todos os seus <sprite name="hammer"> correspondem ao naipe da sua clareira.<br><style=""RB"">Reparar:</style> Exaura um <sprite name="hammer"> para reparar um item danificado.<br><style=""RB"">Ação Especial:</style> Exaura uma <sprite name="torch"> para realizar a ação especial do seu personagem.<br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Se você estiver em uma floresta, repare todos os seus itens danificados.<br><br>Em seguida, compre uma carta, mais uma carta por <sprite name="coinstack"> em sua trilha de <sprite name="coinstack">. Se você tiver mais de cinco cartas em sua mão, descarte até ficar com cinco.<br><br>Finalmente, se você tiver mais itens em sua Mochila do que seu limite de itens — seis, mais dois por <sprite name="bag"> em sua trilha de <sprite name="bag"> — você deve remover itens da Mochila até atingir seu limite de itens.
 rules.vagabonusdraw=Ao contrário de outras facções, o Malandro não descobre bônus de compra, mas em vez disso recebe bônus de compra de <sprite name="coinstack">. Esse item só concede um bônus de compra se não estiver danificado nem exaurido.
 rules.vagarelationships=<style=RSH>Relacionamentos</style><br><br>Seu gráfico de Relacionamentos representa quão amigáveis ou hostis as outras facções estão em relação a você.<br>Você pode melhorar um relacionamento com uma facção entregando cartas a ela com a ação Ajudar. Durante o mesmo turno, você deve realizar a ação Ajudar o número de vezes indicado entre o espaço de relacionamento atual e o próximo. Quando você melhora um relacionamento, pontua os pontos de vitória indicados no novo espaço.<br><br>Se você remover um guerreiro, o dono dele se torna Hostil. A partir de agora, você pontua um ponto de vitória cada vez que remover uma peça deles em batalha durante o seu turno, além de quaisquer pontos que pontue por remover construções e marcadores. No entanto, você deve exaurir outra <sprite name="boot"> sempre que se mover para uma clareira com guerreiros Hostis.<br><br>Se o relacionamento de uma facção for melhorado três vezes, você agora é confiável pelos guerreiros daquela facção. Essa facção agora é Aliada. <br><br><style=RB>Ajudando Aliados</style><br>Cada vez que você ajudar uma facção Aliada, pontue 2 pontos de vitória. <br><br><style=RB>Movendo-se com Aliados</style><br>Sempre que você se mover durante o Dia, pode forçar guerreiros de uma facção Aliada a se mover com você para outra clareira. Guerreiros Aliados seguem as regras normais de movimento de sua facção e não recebem o benefício da sua habilidade especial Ágil. Eles são tratados como se o dono deles tivesse escolhido movê-los para efeitos como Revolta. <br><br><style=RB>Atacando com Aliados</style><br>Sempre que você iniciar uma batalha, pode tratar os guerreiros Aliados de uma facção na clareira de batalha como seus. O máximo de acertos que você pode rolar é igual ao número de guerreiros daquele Aliado lá, mais seu total de <sprite name="sword"> não danificados. Você não pode usar guerreiros de outro jogador ao atacar aquele jogador. <br><br><style=RB>Recebendo Acertos com Aliados</style><br>Em uma batalha onde você trata guerreiros Aliados como seus, você pode receber acertos ao remover guerreiros Aliados. No entanto, se você receber mais acertos ao remover guerreiros Aliados do que ao danificar itens durante a mesma batalha, aquela facção Aliada se torna hostil.
 title.dominance=Cartas de Domínio
@@ -2778,76 +3245,76 @@ rules.clearingdiagram.building=Espaços de Construção
 rules.marqsupply=<style=RSH>Suprimentos</style><br><br>∙Guerreiros x25<br>∙Serrarias x6<br>∙Oficinas x6<br>∙Recrutadores x6<br>∙Marcadores de Madeira x8<br>∙Torre da Guarda x1
 rules.eyriesupply=<style=RSH>Suprimentos</style><br><br>∙Guerreiros x20<br>∙Ninhos das Rapinas x7
 rules.allisupply=<style=RSH>Suprimentos</style><br><br><margin=3em>∙Guerreiros / Oficiais x10 (reserva compartilhada)<br>∙Bases x3 (uma de cada naipe)<br>∙Marcadores de Simpatia x10</margin=3em><br><br>
-rules.alliturn1=<style=RSH>Habilidades</style><br><br>A Aliança é especialista em Guerra de Guerrilha. Como defensores em batalhas, eles causam golpes iguais ao valor do dado mais alto, e o atacante causará golpes iguais ao valor do dado mais baixo.<br><br><style=RSH>Apoiadores, Simpatia e Indignação</style><br><br>Para agir como a Aliança, você frequentemente gasta apoiadores — cartas na sua área de Apoiadores. Os apoiadores são separados de sua mão de cartas, e você só pode gastá-los pelo seu naipe. Você não pode ter mais de cinco apoiadores sem uma base.<br><br>Os apoiadores geralmente são usados para colocar marcadores de simpatia. Colocar simpatia é a principal forma de pontuar, e a simpatia pode lhe render mais apoiadores através da Indignação.<br>Sempre que outro jogador remove um marcador de simpatia ou move qualquer guerreiro para uma clareira com um marcador de simpatia, ele deve adicionar uma carta de sua mão correspondente a essa clareira à sua pilha de Apoiadores. Se ele não tiver uma carta correspondente, ele deve mostrar a mão para você, e então você compra uma carta do baralho e a adiciona à sua pilha de Apoiadores.<br><br><style=RSH><sprite index=66>Alvorada</style><br><br>Você pode realizar revoltas quantas vezes quiser e, em seguida, espalhar simpatia quantas vezes quiser.<br><br><style=RB>Revolta</style>: Gaste dois Apoiadores correspondentes a uma clareira simpática no naipe de uma base não construída. Remova todas as peças inimigas dali e coloque a base correspondente. Em seguida, coloque guerreiros iguais ao número de clareiras simpáticas do mesmo naipe da clareira da revolta, incluindo a própria clareira da revolta. Por fim, ganhe um oficial.
-rules.vagaturn1=</margin=3em><br><br><style=RSH>Batalhando como o Malandro<br></style><br><br>Como você não tem guerreiros, você segue algumas regras diferentes em batalhas.<br><br><margin=3em>∙O peão do Malandro não é um guerreiro, portanto, você não pode governar e não é afetado por efeitos que se referem a guerreiros. Você pode batalhar onde seu peão estiver.<br>∙O número máximo de golpes que você pode causar ao rolar é igual ao total de <sprite name="sword"> não danificadas que você possui, estejam elas exaustas ou não.<br>∙Você sofre golpes danificando itens de sua escolha. Se você não tiver itens não danificados, ignora golpes adicionais.<br>∙Você está indefeso, sofrendo um golpe extra, se não tiver <sprite name="sword"> não danificadas.<br></margin=3em></margin=3em><br><br><style=RSH>Habilidades<br></style><br><br>Sendo um Viajante Solitário, o Malandro não pode governar uma clareira ou impedir outro jogador de governá-la, mas ele é Ágil, podendo se mover independentemente de quem governa a clareira.<br><br>O Malandro tem apenas uma peça: o peão do Malandro. Este peão pode se mover e batalhar como um guerreiro, mas não é um guerreiro.<br><br>Sempre que um jogador inimigo usar um efeito que remova todas as peças inimigas de uma clareira (como as revoltas da Aliança, cartas Favor dos Ratos) que contenha o Malandro, ele danifica três itens.<br><br><style=RSH>Itens</style><br><br>Para se mover e agir de forma eficiente como o Malandro, você precisa gerenciar seus itens, expandindo sua seleção ao explorar as ruínas da Floresta e fornecer ajuda a outras facções.<br>Você pode exaurir um item não danificado para realizar uma ação. Esse item não estará disponível até ser restaurado durante a Alvorada.<br><br>Enquanto não danificados, <sprite name="bag">, <sprite name="coinstack"> e <sprite name="teapot"> são armazenados em suas próprias trilhas, enquanto todos os outros itens são armazenados em sua Bolsa. Você só pode carregar uma quantidade limitada de itens na Bolsa e terá que descartar itens até o limite da Bolsa durante o Anoitecer. <br><br>Se você exaurir um <sprite name="bag">, <sprite name="coinstack"> ou <sprite name="teapot"> ele é movido para sua Bolsa.<br><br><style=RSH><sprite index=66>Alvorada</style><br><br>Restaure três itens, mais dois itens adicionais por <sprite name="teapot"> não danificado na sua trilha de <sprite name="teapot">.<br>Em seguida, você pode deslizar uma vez, movendo-se para uma clareira ou floresta adjacente sem exaurir nenhum item <sprite name="boot">.
+rules.alliturn1=<style=RSH>Habilidades</style><br><br>A Aliança é especialista em táticas de Guerrilha. Como defensores em batalhas, eles causam golpes iguais ao valor do dado mais alto, e o atacante causará golpes iguais ao valor do dado mais baixo.<br><br><style=RSH>Apoiadores, Simpatia e Ultraje</style><br><br>Para agir como a Aliança, você frequentemente gasta apoiadores — cartas na sua área de Apoiadores. Os apoiadores são separados de sua mão de cartas, e você só pode gastá-los pelo seu naipe. Você não pode ter mais de cinco apoiadores sem uma base.<br><br>Os apoiadores geralmente são usados para colocar marcadores de simpatia. Colocar simpatia é a principal forma de pontuar, e a simpatia pode lhe render mais apoiadores através do Ultraje.<br>Sempre que outro jogador remove um marcador de simpatia ou move qualquer guerreiro para uma clareira com um marcador de simpatia, ele deve adicionar uma carta de sua mão correspondente a essa clareira à sua pilha de Apoiadores. Se ele não tiver uma carta correspondente, ele deve mostrar a mão para você, e então você compra uma carta do baralho e a adiciona à sua pilha de Apoiadores.<br><br><style=RSH><sprite index=66>Amanhecer</style><br><br>Você pode realizar revoltas quantas vezes quiser e, em seguida, espalhar simpatia quantas vezes quiser.<br><br><style=RB>Revolta</style>: Gaste dois Apoiadores correspondentes a uma clareira simpática no naipe de uma base não construída. Remova todas as peças inimigas dali e coloque a base correspondente. Em seguida, coloque guerreiros iguais ao número de clareiras simpáticas do mesmo naipe da clareira da revolta, incluindo a própria clareira da revolta. Por fim, ganhe um oficial.
+rules.vagaturn1=</margin=3em><br><br><style=RSH>Batalhando como o Malandro<br></style><br><br>Como você não tem guerreiros, você segue algumas regras diferentes em batalhas.<br><br><margin=3em>∙O peão do Malandro não é um guerreiro, portanto, você não pode governar e não é afetado por efeitos que se referem a guerreiros. Você pode batalhar onde seu peão estiver.<br>∙O número máximo de golpes que você pode causar ao rolar é igual ao total de <sprite name="sword"> não danificadas que você possui, estejam elas exauridas ou não.<br>∙Você sofre golpes danificando itens de sua escolha. Se você não tiver itens não danificados, ignora golpes adicionais.<br>∙Você está indefeso, sofrendo um golpe extra, se não tiver <sprite name="sword"> não danificadas.<br></margin=3em></margin=3em><br><br><style=RSH>Habilidades<br></style><br><br>Sendo um Andarilho Solitário, o Malandro não pode governar uma clareira ou impedir outro jogador de governá-la, mas ele é Ágil, podendo se mover independentemente de quem governa a clareira.<br><br>O Malandro tem apenas uma peça: o peão do Malandro. Este peão pode se mover e batalhar como um guerreiro, mas não é um guerreiro.<br><br>Sempre que um jogador inimigo usar um efeito que remova todas as peças inimigas de uma clareira (como as revoltas da Aliança, cartas Proteção dos Ratos) que contenha o Malandro, ele danifica três itens.<br><br><style=RSH>Itens</style><br><br>Para se mover e agir de forma eficiente como o Malandro, você precisa gerenciar seus itens, expandindo sua seleção ao explorar as ruínas da Floresta e fornecer ajuda a outras facções.<br>Você pode exaurir um item não danificado para realizar uma ação. Esse item não estará disponível até ser reanimado durante o Amanhecer.<br><br>Enquanto não danificados, <sprite name="bag">, <sprite name="coinstack"> e <sprite name="teapot"> são armazenados em suas próprias trilhas, enquanto todos os outros itens são armazenados em sua Mochila. Você só pode carregar uma quantidade limitada de itens na Mochila e terá que descartar itens até o limite da Mochila durante o Anoitecer. <br><br>Se você exaurir um <sprite name="bag">, <sprite name="coinstack"> ou <sprite name="teapot"> ele é movido para sua Mochila.<br><br><style=RSH><sprite index=66>Amanhecer</style><br><br>Reanime três itens, mais dois itens adicionais por <sprite name="teapot"> não danificado na sua trilha de <sprite name="teapot">.<br>Em seguida, você pode deslizar uma vez, movendo-se para uma clareira ou floresta adjacente sem exaurir nenhum item <sprite name="boot">.
 rules.craftintro=A maioria das cartas tem um segundo uso — você pode criar a carta para ganhar seu efeito, mostrado na parte inferior.<br>Para criar uma carta, você deve ativar as peças de criação nas clareiras indicadas no requisito de criação da carta.\nVocê só pode ativar cada peça de criação uma vez por turno. Cada facção tem uma peça de criação diferente, como segue:<br><br><margin=3em>∙Marqueses cria com oficinas.<br>∙Rapinas criam com ninhos<br>∙Aliança cria com simpatia<br>∙Malandro cria com martelos</margin=3em>
 rules.cardimmediate=Efeitos Imediatos (caixa de texto amarela)<br>Se a carta conceder um efeito imediato, ele será resolvido e, em seguida, a carta será descartada.\nSempre que você criar um item disponível no suprimento, pontue os pontos de vitória listados na carta!<br>Se o suprimento não tiver o item correspondente para pegar, você não poderá criar a carta.
 rules.cardpersist=Efeitos Persistentes (caixa de texto azul)<br>Cartas com efeitos persistentes são separadas para uso posterior. Você não pode criar uma carta com efeito persistente se já tiver uma de mesmo nome.
 rules.cardambush=Emboscadas (caixa de texto vermelha)<br>Cartas de emboscada só podem ser jogadas em batalhas. Antes da rolagem de dados, o defensor pode jogar uma carta de emboscada cujo naipe corresponda à clareira da batalha para causar dois golpes imediatamente.<br>No entanto, se o defensor jogar uma carta de emboscada, o atacante pode frustrar a emboscada, cancelando seu efeito ao jogar também uma carta de emboscada correspondente.<br>Os golpes de emboscada não são limitados pelo número de guerreiros na clareira da batalha. Se uma carta de emboscada remover todos os guerreiros do atacante, a batalha termina imediatamente.
 rules.leaders=Líderes
 rules.characters=Personagens
-rules.clocworkoverview=Visão Geral dos Bots
-rules.clockworkbody=<style=RSH>Cartas de Ordem</style><br>Em seu turno, um bot compra e revela uma carta, chamada carta de ordem, para determinar algumas ações que ele executará. O termo ordenado significa “correspondente ao naipe da carta de ordem atual.”<br><br><style=RSH>Criar</style><br>Se a carta de ordem do bot mostrar um item disponível, o bot o cria. Sempre que um bot cria um item, ele ignora os pontos de vitória listados e, em vez disso, pontua apenas um ponto de vitória. Bots não podem criar cartas com efeitos persistentes.<br><br><style=RSH>Desempates de Clareira</style><br>Se um bot precisar escolher entre clareiras para direcionar uma ação, ele segue todas as regras listadas pela ação. Se não puder direcionar uma clareira com base nessas regras, ele direciona a clareira de maior prioridade, conforme mostrado pelos marcadores de prioridade colocados no mapa, dentre as clareiras que ele teria direcionado com base nas regras. A clareira de maior prioridade é marcada como “1” e a de menor prioridade como “12.”<br><br><style=RSH>Desempates de Facção</style><br>Se um bot precisar escolher entre facções para direcionar uma ação, ele segue todas as regras listadas pela ação. Se não puder direcionar uma facção com base nessas regras, ele direciona a facção com maior prioridade de configuração, conforme segue da maior para a menor: Marqueses, Dinastia das Rapinas, Aliança da Floresta, Malandro.<br><br><style=RSH>Sofrendo Golpes</style><br>Ao sofrer golpes, um bot remove todos os seus marcadores da clareira da batalha antes de remover qualquer uma de suas construções ali. Se ele tiver múltiplos tipos de construções que poderia remover ali, ele escolhe aleatoriamente qual remover.<br><br><style=RSH>Ordem das Ações</style><br>Se um bot executaria múltiplas ações com diferentes alvos que poderiam produzir resultados diferentes com base na ordem dessas ações, o bot as executa na ordem da maior para a menor prioridade de alvo. Ao se mover, ele avalia a ordem de prioridade das clareiras de origem (não dos destinos).<br><br><style=RSH>Habilidades</style><br>Cada bot tem as seguintes duas habilidades:<br>    <b>Pobre Destreza Manual:</b> Os bots não possuem mão de cartas. Bots não podem descartar cartas. Se um jogador humano pegaria uma carta de um bot, esse humano compra uma carta em vez disso. Se um humano daria uma carta a um bot, descarte essa carta, e esse bot pontua 1 ponto de vitória.<br>    <b>Odeia Surpresas:</b> Cartas de emboscada não podem ser jogadas contra bots.<br><br><style=RSH>Cartas de Domínio</style><br>Bots não podem jogar cartas de domínio para alterar sua condição de vitória.<br><br><style=RSH>Modo Cooperativo</style><br>Para vencer, os jogadores não-bot devem pontuar 30 pontos de vitória antes que qualquer bot pontue 30 pontos de vitória. Bots não tratam peças de outros bots como peças inimigas ao direcionar uma clareira para agir e não se atacam em batalha. (No entanto, um bot ainda pode remover peças de outros bots como dano colateral com efeitos como revoltas, etc.) Os humanos ainda se tratam como inimigos (então eles podem remover construções e marcadores para pontuar, etc.).<br><br>As cartas de domínio são removidas durante o jogo cooperativo.
-rules.clockworkoverviewbody=Os “Bots” de Relógio fornecem uma alternativa determinística à IA padrão. Eles são recomendados para jogadores que buscam um desafio adicional, pois podem ser modificados com níveis de dificuldade adicionais e cartas de traços. Ao jogar com menos de 3 jogadores não-bot, as cartas de domínio são removidas do baralho.<br><br><style=RSH>Traços</style><br>Cada bot tem quatro cartas de traço opcionais que podem ser selecionadas durante a configuração. Os traços modificam as regras dos bots e geralmente aumentam sua dificuldade.<br><br><style=RSH>Dificuldade</style><br>Cada bot tem quatro opções de nível de dificuldade: Fácil, Normal, Desafiador e Pesadelo.
+rules.clocworkoverview=Visão Geral dos Autômatos
+rules.clockworkbody=<style=RSH>Cartas de Ordem</style><br>Em seu turno, um bot compra e revela uma carta, chamada carta de ordem, para determinar algumas ações que ele executará. O termo ordenado significa “correspondente ao naipe da carta de ordem atual.”<br><br><style=RSH>Criar</style><br>Se a carta de ordem do bot mostrar um item disponível, o bot o cria. Sempre que um bot cria um item, ele ignora os pontos de vitória listados e, em vez disso, pontua apenas um ponto de vitória. Bots não podem criar cartas com efeitos persistentes.<br><br><style=RSH>Desempates de Clareira</style><br>Se um bot precisar escolher entre clareiras para direcionar uma ação, ele segue todas as regras listadas pela ação. Se não puder direcionar uma clareira com base nessas regras, ele direciona a clareira de maior prioridade, conforme mostrado pelos marcadores de prioridade colocados no mapa, dentre as clareiras que ele teria direcionado com base nas regras. A clareira de maior prioridade é marcada como “1” e a de menor prioridade como “12.”<br><br><style=RSH>Desempates de Facção</style><br>Se um bot precisar escolher entre facções para direcionar uma ação, ele segue todas as regras listadas pela ação. Se não puder direcionar uma facção com base nessas regras, ele direciona a facção com maior prioridade de preparação, conforme segue da maior para a menor: Marqueses, Dinastia das Rapinas, Aliança da Floresta, Malandro.<br><br><style=RSH>Sofrendo Golpes</style><br>Ao sofrer golpes, um bot remove todos os seus marcadores da clareira da batalha antes de remover qualquer uma de suas construções ali. Se ele tiver múltiplos tipos de construções que poderia remover ali, ele escolhe aleatoriamente qual remover.<br><br><style=RSH>Ordem das Ações</style><br>Se um bot executaria múltiplas ações com diferentes alvos que poderiam produzir resultados diferentes com base na ordem dessas ações, o bot as executa na ordem da maior para a menor prioridade de alvo. Ao se mover, ele avalia a ordem de prioridade das clareiras de origem (não dos destinos).<br><br><style=RSH>Habilidades</style><br>Cada bot tem as seguintes duas habilidades:<br>    <b>Pobre Destreza Manual:</b> Os bots não possuem mão de cartas. Bots não podem descartar cartas. Se um jogador humano pegaria uma carta de um bot, esse humano compra uma carta em vez disso. Se um humano daria uma carta a um bot, descarte essa carta, e esse bot pontua 1 ponto de vitória.<br>    <b>Odeia Surpresas:</b> Cartas de emboscada não podem ser jogadas contra bots.<br><br><style=RSH>Cartas de Domínio</style><br>Bots não podem jogar cartas de domínio para alterar sua condição de vitória.<br><br><style=RSH>Modo Cooperativo</style><br>Para vencer, os jogadores não-bot devem pontuar 30 pontos de vitória antes que qualquer bot pontue 30 pontos de vitória. Bots não tratam peças de outros bots como peças inimigas ao direcionar uma clareira para agir e não se atacam em batalha. (No entanto, um bot ainda pode remover peças de outros bots como dano colateral com efeitos como revoltas, etc.) Os humanos ainda se tratam como inimigos (então eles podem remover construções e marcadores para pontuar, etc.).<br><br>As cartas de domínio são removidas durante o jogo cooperativo.
+rules.clockworkoverviewbody=Os “Bots” Autômatos fornecem uma alternativa determinística à IA padrão. Eles são recomendados para jogadores que buscam um desafio adicional, pois podem ser modificados com níveis de dificuldade adicionais e cartas de traços. Ao jogar com menos de 3 jogadores não-bot, as cartas de domínio são removidas do baralho.<br><br><style=RSH>Traços</style><br>Cada bot tem quatro cartas de traço opcionais que podem ser selecionadas durante a preparação. Os traços modificam as regras dos bots e geralmente aumentam sua dificuldade.<br><br><style=RSH>Dificuldade</style><br>Cada bot tem quatro opções de nível de dificuldade: Fácil, Normal, Desafiador e Pesadelo.
 title.mechanicalmarquise=Marquês Mecânico
 title.difficulties=Dificuldades
 title.turnorder=Ordem de Turno
 title.traits=Traços
 rules.mechmarqoverview=Este é o mais simples dos bots e pode ser usado para completar o número de jogadores em dezenas de configurações. Embora este bot seja direto, não se acomode. Pelo menos um jogador precisará mantê-lo sob controle!
-rules.mechmarqtraits=<style=RSH>Blitz</style><br>Após mover, encontre a clareira que você governa com a maior prioridade e sem peças inimigas. Mova todos os guerreiros, exceto um, dessa clareira. Em seguida, inicie uma batalha na clareira de destino.<br><br><style=RSH>Fortificado</style><br>Suas construções precisam de dois golpes para serem removidas. Sofrer um único golpe em uma construção não tem efeito.<br><br><style=RSH>Vontade de Ferro</style><br>Sempre que você recrutar durante o Dia Escalado, coloque o dobro de guerreiros.<br><BR><style=RSH>Hospitais</style><br>No final de uma batalha como defensor, se dois ou mais guerreiros Marqueses forem removidos na batalha, coloque dois guerreiros na clareira com o token da torre da guarda.
+rules.mechmarqtraits=<style=RSH>Blitz</style><br>Após mover, encontre a clareira que você governa com a maior prioridade e sem peças inimigas. Mova todos os guerreiros, exceto um, dessa clareira. Em seguida, inicie uma batalha na clareira de destino.<br><br><style=RSH>Fortificado</style><br>Suas construções precisam de dois golpes para serem removidas. Sofrer um único golpe em uma construção não tem efeito.<br><br><style=RSH>Vontade de Ferro</style><br>Sempre que você recrutar durante o Dia Expandido, coloque o dobro de guerreiros.<br><BR><style=RSH>Hospitais</style><br>No final de uma batalha como defensor, se dois ou mais guerreiros Marqueses forem removidos na batalha, coloque dois guerreiros na clareira com o token da torre da guarda.
 rules.mechmarqdifficulties=<style=RSH>Fácil</style><br>Sempre que você recrutar, coloque apenas dois guerreiros.<br><br><style=RSH>Normal</style><br>Nada é alterado.<br><br><style=RSH>Desafiador</style><br>Sempre que você recrutar, coloque também dois guerreiros na clareira ordenada que você governa com a maior prioridade.<br><br><style=RSH>Pesadelo</style><br>Sempre que você recrutar, coloque também dois guerreiros na clareira ordenada que você governa com a maior prioridade. No final do Anoitecer, pontue um ponto de vitória.
 rules.mechmarqsetup=<b>1º:</b> Coloque a Torre da Guarda. Coloque o token da torre da guarda em uma clareira de canto aleatória.<br><br><b>2º:</b> Coloque um guerreiro em cada clareira, exceto na clareira no canto diagonalmente oposto à clareira com o token da torre da guarda. Coloque um guerreiro extra na clareira com o token da torre da guarda.<br><br><b>3º:</b> Coloque as Construções Iniciais. Coloque aleatoriamente 1 serraria, 1 oficina e 1 recrutador entre a clareira com o token da torre da guarda e aquelas clareiras adjacentes, com no máximo uma construção em cada clareira.
-rules.mechmarqturnorder=<style=RSH><sprite index=66>Alvorada</style><br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º Criar:</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><style=RSH><sprite index=65>Dia</style><br>Se a carta de ordem for uma carta <sprite name="birdicon">, resolva o Dia Escalado em vez disso.<br><br><b>1º: Batalha</b><br>Inicie uma batalha em cada clareira ordenada. O defensor é o jogador com mais peças na clareira de batalha, depois o jogador com mais <style="vptext">PV</style> em caso de empate.<br><br><b>2º: Recrutar</b><br>Coloque quatro guerreiros entre as clareiras ordenadas que você governa, distribuídos igualmente. Se você governar três dessas clareiras, coloque o quarto guerreiro na clareira de maior prioridade.<br><br><b>3º: Erguer</b><br>Coloque uma construção na clareira que você governa com mais guerreiros Marqueses. Coloque uma serraria se a carta de ordem for uma carta <sprite name="foxicon">, uma oficina se for uma carta <sprite name="rabbiticon"> ou um recrutador se for uma carta <sprite name="mouseicon">.<br><br><b>4º: Mover</b><br>Mova todos os guerreiros, exceto três, de cada clareira ordenada para a clareira adjacente com mais peças inimigas.<br><br><b>5º: Expandir</b><br>Se você não colocou uma construção neste turno e tiver cinco ou menos construções no mapa, descarte a carta de ordem atual, compre e revele uma nova carta de ordem (mas não crie seu item) e retorne ao início do Dia.<br><br><style=RSH>Dia Escalado</style><br><br><b>1º: Batalha</b><br>Inicie uma batalha em cada clareira. O defensor é o jogador com mais peças na clareira de batalha, depois o jogador com mais <style="vptext">PV</style> em caso de empate.<br><br><b>2º: Recrutar</b><br>Coloque dois guerreiros em cada uma das duas clareiras que você governa com a menor prioridade. Se você governar apenas uma clareira, coloque todos os quatro guerreiros lá.<br><br><b>3º: Erguer</b><br>Coloque uma construção do tipo com mais peças no mapa na clareira que você governa com mais guerreiros Marqueses. Em caso de empate, escolha serrarias, depois recrutadores e, por último, oficinas.<br><br><b>4º: Mover:</b><br>Mova todos os guerreiros, exceto três, de cada clareira para a clareira adjacente com mais peças inimigas. Em seguida, inicie batalhas em cada clareira para onde você se moveu.<br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Pontue os pontos de vitória listados no espaço vazio mais à direita da sua trilha de Construções ordenadas. Se a carta de ordem for uma carta <sprite name="birdicon">, use a trilha que concederia mais pontos de vitória. (Diferentemente dos Marqueses, você não pontua ao erguer construções.)
+rules.mechmarqturnorder=<style=RSH><sprite index=66>Amanhecer</style><br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º Criar:</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><style=RSH><sprite index=65>Dia</style><br>Se a carta de ordem for uma carta <sprite name="birdicon">, resolva o Dia Expandido em vez disso.<br><br><b>1º: Batalha</b><br>Inicie uma batalha em cada clareira ordenada. O defensor é o jogador com mais peças na clareira de batalha, depois o jogador com mais <style="vptext">PV</style> em caso de empate.<br><br><b>2º: Recrutar</b><br>Coloque quatro guerreiros entre as clareiras ordenadas que você governa, distribuídos igualmente. Se você governar três dessas clareiras, coloque o quarto guerreiro na clareira de maior prioridade.<br><br><b>3º: Erguer</b><br>Coloque uma construção na clareira que você governa com mais guerreiros Marqueses. Coloque uma serraria se a carta de ordem for uma carta <sprite name="foxicon">, uma oficina se for uma carta <sprite name="rabbiticon"> ou um recrutador se for uma carta <sprite name="mouseicon">.<br><br><b>4º: Mover</b><br>Mova todos os guerreiros, exceto três, de cada clareira ordenada para a clareira adjacente com mais peças inimigas.<br><br><b>5º: Expandir</b><br>Se você não colocou uma construção neste turno e tiver cinco ou menos construções no mapa, descarte a carta de ordem atual, compre e revele uma nova carta de ordem (mas não crie seu item) e retorne ao início do Dia.<br><br><style=RSH>Dia Expandido</style><br><br><b>1º: Batalha</b><br>Inicie uma batalha em cada clareira. O defensor é o jogador com mais peças na clareira de batalha, depois o jogador com mais <style="vptext">PV</style> em caso de empate.<br><br><b>2º: Recrutar</b><br>Coloque dois guerreiros em cada uma das duas clareiras que você governa com a menor prioridade. Se você governar apenas uma clareira, coloque todos os quatro guerreiros lá.<br><br><b>3º: Erguer</b><br>Coloque uma construção do tipo com mais peças no mapa na clareira que você governa com mais guerreiros Marqueses. Em caso de empate, escolha serrarias, depois recrutadores e, por último, oficinas.<br><br><b>4º: Mover:</b><br>Mova todos os guerreiros, exceto três, de cada clareira para a clareira adjacente com mais peças inimigas. Em seguida, inicie batalhas em cada clareira para onde você se moveu.<br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Pontue os pontos de vitória listados no espaço vazio mais à direita da sua trilha de Construções ordenadas. Se a carta de ordem for uma carta <sprite name="birdicon">, use a trilha que concederia mais pontos de vitória. (Diferentemente dos Marqueses, você não pontua ao erguer construções.)
 title.abilities=Habilidades
-rules.electriceyrietraits=<style=RSH>Implacável</style><br>Após resolver o Decreto, remova todas as construções e marcadores indefesos em qualquer clareira com guerreiros da Dinastia das Rapinas.<br><br><style=RSH>Investida</style><br>No final do Dia, coloque dois guerreiros na clareira de maior prioridade sem peças da Dinastia das Rapinas.<br><br><style=RSH>Nobreza</style><br>Agora você entra em tumulto se não puder colocar um Ninho das Rapinas ou um guerreiro. Sempre que você entrar em tumulto, não perde pontos de vitória. Em vez disso, você pontua um ponto de vitória por carta de pássaro no Decreto.<br><br><style=RSH>Imposto de Guerra</style><br>Sempre que você remover uma construção ou marcador inimigo, o dono deles perde um ponto de vitória.
+rules.electriceyrietraits=<style=RSH>Implacável</style><br>Após resolver o Decreto, remova todas as construções e marcadores indefesos em qualquer clareira com guerreiros da Dinastia das Rapinas.<br><br><style=RSH>Investida</style><br>No final do Dia, coloque dois guerreiros na clareira de maior prioridade sem peças da Dinastia das Rapinas.<br><br><style=RSH>Nobreza</style><br>Agora você entra em tumulto se não puder colocar um Ninho ou um guerreiro. Sempre que você entrar em tumulto, não perde pontos de vitória. Em vez disso, você pontua um ponto de vitória por carta de pássaro no Decreto.<br><br><style=RSH>Imposto de Guerra</style><br>Sempre que você remover uma construção ou marcador inimigo, o dono deles perde um ponto de vitória.
 rules.electriceyriedifficulties=<style=RSH>Fácil</style><br>Durante a preparação, adicione apenas uma carta à coluna de pássaro do Decreto.<br><br><style=RSH>Normal</style><br>Nada é alterado.<br><br><style=RSH>Desafiador</style><br>Durante a preparação, pegue uma carta de Emboscada de pássaro do baralho e adicione-a à coluna de pássaro do Decreto.<br><br><style=RSH>Pesadelo</style><br>Durante a preparação, pegue uma carta de Emboscada de pássaro do baralho e adicione-a à coluna de pássaro do Decreto.<br><br>No final do Anoitecer, pontue um ponto de vitória.
-rules.electriceyrieabilities=<b>Senhores da Floresta:</b> A Dinastia das Rapinas Elétrica governa uma clareira quando está empatada com a maior quantidade combinada de guerreiros e construções lá. Eles não governam clareiras vazias.
-rules.electriceyriesetup=<b>1º:</b> Coloque 1 Ninho das Rapinas e 6 guerreiros na clareira de canto diagonalmente oposta à clareira com o token da torre da guarda. Se os Marqueses não estiverem jogando, coloque essas peças em uma clareira de canto aleatória.<br><br><b>2º:</b> Adicione duas cartas de naipe <sprite name="birdicon"> ao Decreto.
-rules.electriceyrieturnorder=<style=RSH><sprite index=66>Alvorada</style><br><br>A sua Alvorada tem quatro etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><b>3º: Adicionar ao Decreto</b><br>Adicione a carta de ordem ao Decreto na coluna correspondente ao naipe da carta.<br><br><b>4º: Um Novo Ninho</b><br>Se você não tiver Ninhos das Rapinas no mapa, coloque um Ninho das Rapinas e quatro guerreiros na clareira ordenada de maior prioridade onde todas essas peças possam ser colocadas.<br><br><style=RSH><sprite index=65>Dia</style><br><br><b>Resolver o Decreto:</b> Recrute para todas as quatro colunas do Decreto da esquerda para a direita. Em seguida, mova para todas as quatro colunas da esquerda para a direita. Depois, batalhe para todas as quatro colunas da esquerda para a direita.<br><br><b>Recrutar:</b> Coloque guerreiros, igual ao número de cartas nesta coluna, em uma clareira com um Ninho das Rapinas cujo naipe corresponda ao desta coluna.<br>    <b>Primeiro Empate para Clareira Alvo:</b> Tal clareira com mais peças inimigas.<br>    <b>Segundo Empate para Clareira Alvo:</b> Tal clareira com menos guerreiros da Dinastia das Rapinas.<br>    <b>Terceiro Empate para Clareira Alvo:</b> Tal clareira de menor prioridade.<br><br><b>Mover:</b> Mova da clareira que você governa cujo naipe corresponda ao desta coluna e que tenha mais guerreiros da Dinastia das Rapinas. Mova para uma clareira adjacente sem Ninho das Rapinas – se todas as clareiras adjacentes tiverem um Ninho das Rapinas, mova para uma clareira adjacente com um Ninho das Rapinas, seguindo os critérios de desempate abaixo. Deixe guerreiros na clareira de origem de modo que haja exatamente o suficiente para governá-la ou igual ao número de cartas nesta coluna, o que for maior.<br>    <b>Primeiro Empate para Clareira de Destino:</b> Tal clareira com menos peças inimigas.<br>    <b>Segundo Empate para Clareira de Destino:</b> Tal clareira de menor prioridade.<br><br><b>Batalha:</b> Inicie uma batalha em uma clareira cujo naipe corresponda ao desta coluna. O defensor é o jogador com mais construções lá (mesmo que zero). Se esta coluna tiver mais cartas do que cada outra coluna, você causa um golpe extra.<br>    <b>Primeiro Empate para Clareira Alvo:</b> Tal clareira sem Ninho das Rapinas.<br>    <b>Segundo Empate para Clareira Alvo:</b> Tal clareira com mais construções indefesas.<br>    <b>Terceiro Empate para Clareira Alvo:</b> Tal clareira de menor prioridade.<br>    <b>Primeiro Empate para Defensor Alvo:</b> Tal jogador com mais peças lá.<br>    <b>Segundo Empate para Defensor Alvo:</b> Tal jogador com mais pontos de vitória.<br><br><b>Erguer:</b> Coloque um Ninho das Rapinas em uma clareira que você governa sem Ninho das Rapinas. (Se houver várias, escolha a clareira de maior prioridade.) Se você não puder colocar um Ninho das Rapinas por qualquer motivo, você imediatamente entra em tumulto.<br><br><style=RSH><sprite index=64>Anoitecer</style><br>Pontue os pontos de vitória listados no espaço vazio mais à direita da sua trilha de Ninhos das Rapinas.<br><br><b>Tumulto</b><br>Se você for instruído a colocar um Ninho das Rapinas e não puder por qualquer motivo, você entra em tumulto, como segue:<br><b>1º: Humilhar.</b> Perda de <style=vpone>1</style> por carta de pássaro no Decreto.<br><b>2º: Expurgar.</b> Descarte todas as cartas do Decreto.
+rules.electriceyrieabilities=<b>Lordes da Floresta:</b> A Dinastia das Rapinas Elétrica governa uma clareira quando está empatada com a maior quantidade combinada de guerreiros e construções lá. Eles não governam clareiras vazias.
+rules.electriceyriesetup=<b>1º:</b> Coloque 1 ninho e 6 guerreiros na clareira de canto diagonalmente oposta à clareira com o token da torre da guarda. Se os Marqueses não estiverem jogando, coloque essas peças em uma clareira de canto aleatória.<br><br><b>2º:</b> Adicione duas cartas de naipe <sprite name="birdicon"> ao Decreto.
+rules.electriceyrieturnorder=<style=RSH><sprite index=66>Amanhecer</style><br><br>O seu Amanhecer tem quatro etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><b>3º: Adicionar ao Decreto</b><br>Adicione a carta de ordem ao Decreto na coluna correspondente ao naipe da carta.<br><br><b>4º: Um Novo Ninho</b><br>Se você não tiver Ninhos no mapa, coloque um Ninho e quatro guerreiros na clareira ordenada de maior prioridade onde todas essas peças possam ser colocadas.<br><br><style=RSH><sprite index=65>Dia</style><br><br><b>Resolver o Decreto:</b> Recrute para todas as quatro colunas do Decreto da esquerda para a direita. Em seguida, mova para todas as quatro colunas da esquerda para a direita. Depois, batalhe para todas as quatro colunas da esquerda para a direita.<br><br><b>Recrutar:</b> Coloque guerreiros, igual ao número de cartas nesta coluna, em uma clareira com um Ninho cujo naipe corresponda ao desta coluna.<br>    <b>Primeiro Empate para Clareira Alvo:</b> Tal clareira com mais peças inimigas.<br>    <b>Segundo Empate para Clareira Alvo:</b> Tal clareira com menos guerreiros da Dinastia das Rapinas.<br>    <b>Terceiro Empate para Clareira Alvo:</b> Tal clareira de menor prioridade.<br><br><b>Mover:</b> Mova da clareira que você governa cujo naipe corresponda ao desta coluna e que tenha mais guerreiros da Dinastia das Rapinas. Mova para uma clareira adjacente sem Ninho – se todas as clareiras adjacentes tiverem um Ninho, mova para uma clareira adjacente com um Ninho, seguindo os critérios de desempate abaixo. Deixe guerreiros na clareira de origem de modo que haja exatamente o suficiente para governá-la ou igual ao número de cartas nesta coluna, o que for maior.<br>    <b>Primeiro Empate para Clareira de Destino:</b> Tal clareira com menos peças inimigas.<br>    <b>Segundo Empate para Clareira de Destino:</b> Tal clareira de menor prioridade.<br><br><b>Batalha:</b> Inicie uma batalha em uma clareira cujo naipe corresponda ao desta coluna. O defensor é o jogador com mais construções lá (mesmo que zero). Se esta coluna tiver mais cartas do que cada outra coluna, você causa um golpe extra.<br>    <b>Primeiro Empate para Clareira Alvo:</b> Tal clareira sem Ninho.<br>    <b>Segundo Empate para Clareira Alvo:</b> Tal clareira com mais construções indefesas.<br>    <b>Terceiro Empate para Clareira Alvo:</b> Tal clareira de menor prioridade.<br>    <b>Primeiro Empate para Defensor Alvo:</b> Tal jogador com mais peças lá.<br>    <b>Segundo Empate para Defensor Alvo:</b> Tal jogador com mais pontos de vitória.<br><br><b>Construir:</b> Coloque um Ninho em uma clareira que você governa sem Ninho. (Se houver várias, escolha a clareira de maior prioridade.) Se você não puder colocar um Ninho por qualquer motivo, você imediatamente entra em tumulto.<br><br><style=RSH><sprite index=64>Anoitecer</style><br>Pontue os pontos de vitória listados no espaço vazio mais à direita da sua trilha de Ninhos.<br><br><b>Tumulto</b><br>Se você for instruído a colocar um Ninho e não puder por qualquer motivo, você entra em tumulto, como segue:<br><b>1º: Humilhar.</b> Perda de <style=vpone>1</style> por carta de pássaro no Decreto.<br><b>2º: Expurgar.</b> Descarte todas as cartas do Decreto.
 rules.autoallioverview=A Aliança Automatizada é especialmente zelosa e irá se revoltar com frequência. Lembre-se dos alvos em potencial deles para evitar surpresas desagradáveis. Uma vez que eles estabeleçam uma base, o momento é crítico. Não os deixe consolidar seus guerreiros ou você estará em apuros!
-rules.autoallitraits=<style=RSH>Veteranos</style><br>Ganhe a habilidade Guerra de Guerrilha da Aliança da Floresta. (Em batalha como defensor, você usa o resultado mais alto e o atacante usa o mais baixo.)<br><br><style=RSH>Popularidade</style><br>Os inimigos não pontuam pontos de vitória ao remover marcadores de simpatia.<br><br><style=RSH>Informantes</style><br>Marcadores de simpatia indefesos se beneficiam de Emboscadas Automatizadas.<br><br><style=RSH>Incêndio</style><br>No final do Anoitecer, Espalhe Simpatia. Não pontue pontos ao colocar este marcador de simpatia.
+rules.autoallitraits=<style=RSH>Veteranos</style><br>Ganhe a habilidade Guerrilha da Aliança da Floresta. (Em batalha como defensor, você usa o resultado mais alto e o atacante usa o mais baixo.)<br><br><style=RSH>Popularidade</style><br>Os inimigos não pontuam pontos de vitória ao remover marcadores de simpatia.<br><br><style=RSH>Informantes</style><br>Marcadores de simpatia indefesos se beneficiam de Emboscadas Automatizadas.<br><br><style=RSH>Incêndio</style><br>No final do Anoitecer, Espalhe Simpatia. Não pontue pontos ao colocar este marcador de simpatia.
 rules.autoallidifficulties=<style=RSH>Fácil</style><br>Você só Organiza se uma clareira tiver quatro ou mais guerreiros da Aliança.<br><br><style=RSH>Normal</style><br>Nada é alterado.<br><br><style=RSH>Desafiador</style><br>Você Organiza se uma clareira tiver dois ou mais guerreiros da Aliança.<br><br><style=RSH>Pesadelo</style><br>Você Organiza se uma clareira tiver dois ou mais guerreiros da Aliança.<br>No final do Anoitecer, pontue um ponto de vitória.
-rules.autoalliabilities=<b>Emboscada Automatizada:</b> Em batalha como defensor com pelo menos um guerreiro da Aliança, a Aliança causa um golpe extra.<br><br><b>Indignação Automatizada:</b> Sempre que um humano remover um marcador de simpatia ou mover qualquer guerreiro para uma clareira simpática, esse jogador deve descartar uma carta correspondente. Se não puder, a Aliança pontua um ponto de vitória. (Isso não aciona a Habilidade de Destreza Manual Fraca.)<br><br><b>Repressão:</b> Sempre que uma base da Aliança for removida, devolva todos os marcadores de simpatia das clareiras correspondentes ao naipe da base removida.<br><br><b>Lei Marcial:</b> Se a Aliança colocar um marcador de simpatia em uma clareira com três ou mais guerreiros pertencentes ao mesmo inimigo, a Aliança pontua um ponto de vitória a menos, até o mínimo de zero.
-rules.autoalliturnorder=<style=RSH><sprite index=66>Alvorada</style><br><br>Sua Alvorada tem quatro etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><b>3º: Revolta</b><br>Se a carta de ordem não for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas que corresponda a uma base em seu estoque e, em seguida, coloque a base ordenada lá.<br><br><b>4º: Comiseração Pública</b><br>Se você não se revoltar nesta Alvorada, espalhe simpatia com base no número de marcadores de simpatia no mapa, conforme segue. Se tiver de zero a quatro, espalhe simpatia duas vezes; se tiver cinco ou mais, espalhe simpatia uma vez. (Você espalhará simpatia novamente no Dia.)<br><br><br><style=RSH><sprite index=65>Dia</style><br><br>Seu Dia tem duas etapas na seguinte ordem.<br><br><b>1º: Espalhar Simpatia</b><br>Coloque um marcador de simpatia em uma clareira ordenada não simpática com menos guerreiros inimigos adjacente a qualquer clareira simpática. Pontue os pontos de vitória conforme mostrado na sua trilha de simpatia.<br><br><b>Sem Clareiras:</b> Se não houver clareiras possíveis para alvejar, coloque um marcador de simpatia na clareira com menos peças inimigas.<br><br><b>Não Pode Espalhar:</b> Se você não puder colocar um marcador de simpatia (porque sua trilha de Simpatia está vazia ou porque não há clareira onde você possa colocar um marcador de simpatia), pontue 5 pontos de vitória.<br><br><b>2º: Revolta Surpresa</b><br>Se a carta de ordem for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática com mais peças inimigas que corresponda a uma base em seu estoque, então coloque a base correspondente lá. (Se houver múltiplas opções, revolte na clareira de maior prioridade.)<br><br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Seu Anoitecer tem três etapas na seguinte ordem:<br><br><b>1º: Organizar</b><br>Em cada clareira com uma base e três ou mais guerreiros da Aliança, remova todos os guerreiros da Aliança dessa clareira e, em seguida, espalhe simpatia.<br><br><b>2º: Recrutar</b><br>Coloque um guerreiro em cada clareira com uma base.<br><br><b>3º: Descartar Ordem</b><br>Descarte a carta de ordem atual.
+rules.autoalliabilities=<b>Emboscada Automatizada:</b> Em batalha como defensor com pelo menos um guerreiro da Aliança, a Aliança causa um golpe extra.<br><br><b>Ultraje Automatizado:</b> Sempre que um humano remover um marcador de simpatia ou mover qualquer guerreiro para uma clareira simpática, esse jogador deve descartar uma carta correspondente. Se não puder, a Aliança pontua um ponto de vitória. (Isso não aciona a Habilidade de Pouca Destreza Manual)<br><br><b>Repressão:</b> Sempre que uma base da Aliança for removida, devolva todos os marcadores de simpatia das clareiras correspondentes ao naipe da base removida.<br><br><b>Lei Marcial:</b> Se a Aliança colocar um marcador de simpatia em uma clareira com três ou mais guerreiros pertencentes ao mesmo inimigo, a Aliança pontua um ponto de vitória a menos, até o mínimo de zero.
+rules.autoalliturnorder=<style=RSH><sprite index=66>Amanhecer</style><br><br>Seu Amanhecer tem quatro etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><b>3º: Revolta</b><br>Se a carta de ordem não for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas que corresponda a uma base em seu estoque e, em seguida, coloque a base ordenada lá.<br><br><b>4º: Comiseração Pública</b><br>Se você não se revoltar neste Amanhecer, espalhe simpatia com base no número de marcadores de simpatia no mapa, conforme segue. Se tiver de zero a quatro, espalhe simpatia duas vezes; se tiver cinco ou mais, espalhe simpatia uma vez. (Você espalhará simpatia novamente no Dia.)<br><br><br><style=RSH><sprite index=65>Dia</style><br><br>Seu Dia tem duas etapas na seguinte ordem.<br><br><b>1º: Espalhar Simpatia</b><br>Coloque um marcador de simpatia em uma clareira ordenada não simpática com menos guerreiros inimigos adjacente a qualquer clareira simpática. Pontue os pontos de vitória conforme mostrado na sua trilha de simpatia.<br><br><b>Sem Clareiras:</b> Se não houver clareiras possíveis para alvejar, coloque um marcador de simpatia na clareira com menos peças inimigas.<br><br><b>Não Pode Espalhar:</b> Se você não puder colocar um marcador de simpatia (porque sua trilha de Simpatia está vazia ou porque não há clareira onde você possa colocar um marcador de simpatia), pontue 5 pontos de vitória.<br><br><b>2º: Revolta Surpresa</b><br>Se a carta de ordem for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática com mais peças inimigas que corresponda a uma base em seu estoque, então coloque a base correspondente lá. (Se houver múltiplas opções, revolte na clareira de maior prioridade.)<br><br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Seu Anoitecer tem três etapas na seguinte ordem:<br><br><b>1º: Organizar</b><br>Em cada clareira com uma base e três ou mais guerreiros da Aliança, remova todos os guerreiros da Aliança dessa clareira e, em seguida, espalhe simpatia.<br><br><b>2º: Recrutar</b><br>Coloque um guerreiro em cada clareira com uma base.<br><br><b>3º: Descartar Ordem</b><br>Descarte a carta de ordem atual.
 rules.autoallistoprevolt=<b>O que pode impedir uma Revolta?</b> <br><br>As revoltas podem falhar por três razões: Primeiro, se a carta de ordem for um pássaro. Segundo, se a base ordenada já estiver no mapa. Terceiro, se nenhuma clareira simpática corresponder a uma base que não está no mapa. Como as criaturas da Floresta gostam de uma boa insurreição, essas falhas desencadeiam pena pública.
 rules.vagabotoverview=O Automalandro é um amigo ou inimigo caprichoso. Como um jogador humano, ele recompensará aqueles que criarem itens. Mas cuidado, ele pode se tornar um inimigo perigoso quando obtiver itens suficientes para aumentar seus golpes máximos.
-rules.vagabottraits=<style=RSH>Atirador de Elite</style><br>No início da batalha como atacante, cause um golpe imediato (pontuando um ponto se remover um guerreiro inimigo).<br><br><style=RSH>Berserker</style><br>Sempre que você Batalhar, mova-se para a clareira mais próxima com mais peças e ataque o jogador com mais peças lá. No Anoitecer, repare mais um item.<br><br><style=RSH>Auxiliador</style><br>Sempre que você Ajudar, pontue um ponto de vitória extra, e o jogador ajudado compra duas cartas em vez de uma.<br><br><style=RSH>Aventureiro</style><br>Você pode Batalhar no máximo uma vez por turno. No final do Dia, repita a Missão quantas vezes for possível.
-rules.vagabotdifficulties=<style=RSH>Fácil</style><br>No Anoitecer, recupere um item a menos.<br><br><style=RSH>Normal</style><br>Nada é alterado. <br><br><style=RSH>Desafiador</style><br>No Anoitecer, recupere um item a mais.<br><br><style=RSH>Pesadelo</style><br>No Anoitecer, recupere um item a mais.<br>No final do Anoitecer, pontue <style=vpone>1</style>.
-rules.vagabotcharacters=<style=RSH>Ladrão</style><br><b>Roubar:</b> Pegue uma carta aleatória do inimigo na sua clareira com mais pontos lá, depois mais peças lá.<br><br><style=RSH>Sucateiro:</style><br><b>Trabalho Diário:</b> Crie a carta do topo da pilha de descarte com um item, pontuando <style=vpone>1</style>. <br>Comece o jogo com um item a menos.<br><br><style=RSH>Patrulheiro:</style><br><b>Esconderijo:</b> Se você tiver três ou mais itens danificados, deslize para uma floresta adjacente aleatória.
-rules.vagabotabilities=<b>Viajante Solitário:</b> O peão do Automalandro não é um guerreiro (portanto, ele não pode dominar uma clareira ou impedir outro jogador de dominá-la). O peão do Automalandro não pode ser removido do mapa.<br><br><b>Remoção Completa:</b> Sempre que um jogador inimigo usar um efeito que remova todas as peças inimigas de uma clareira (como Revoltas da Aliança, cartas de Favor, etc.) com o Automalandro, ele danifica três itens.<br><br><b>Ágil:</b> O Automalandro pode se mover independentemente de quem domina sua clareira de origem ou destino.<br><br><b>Itens:</b> Para realizar ações, o Automalandro deve exaurir itens. Diferentemente do Malandro, o Automalandro trata todos os itens como idênticos (por exemplo, não há diferença entre <sprite name="torch"> e <sprite name="hammer">). Ele exaure itens não danificados para realizar várias ações.<br><br><b>Trilha de Batalha:</b> Ao contrário do Malandro, o Automalandro não usa espadas para determinar os golpes em batalha. Em vez disso, os golpes máximos que ele pode causar começam em um. Enquanto o Automalandro possuir pelo menos seis, nove e doze itens não danificados, um item é colocado em sua Trilha de Batalha. Os espaços de item da sexta e nona posições aumentam os golpes máximos dele em um, e o décimo segundo permite que ele cause um golpe extra como atacante em batalhas. Itens na Trilha de Batalha não podem ser exauridos, mas podem ser danificados.<br><br><b>Recebendo Golpes:</b> Quando o Automalandro recebe golpes, ele danifica itens exauridos ou, se não houver itens exauridos, itens não exauridos. (Itens danificados podem ser movidos da Trilha de Batalha para a Bolsa dele.)
-rules.vagabotsetup=<b>1º:</b> O personagem é selecionado aleatoriamente se não foi atribuído durante a criação do jogo.<br><br><b>2º:</b> O Automalandro começa na floresta adjacente ao maior número de clareiras. Se houver múltiplas florestas assim, decida aleatoriamente entre elas.<br><br><b>3º:</b> Compre uma única carta de missão.<br><br><b>4º:</b> Ganhe 4 itens aleatórios. (O Sucateiro começa com 3 itens em vez de 4.)
-rules.vagabotturnorder=<style=RSH><sprite index=66>Alvorada</style><br><br>A Alvorada do Automalandro tem três etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem para <style=vpone>1</style> se houver um item disponível.<br><br><b>3º: Deslizar</b><br>Se você tiver dois ou menos itens não danificados, mova-se para uma floresta adjacente aleatória e pule o Dia, indo direto para o Anoitecer.<br><br><br><style=RSH><sprite index=65>Dia</style><br><br>A carta de ordem atual determina a sequência de ações que o Automalandro tomará neste turno, conforme a seguir:<br><b>    <sprite name="birdicon">:</b> Explorar, Missão, Ajudar, Batalhar<br><b>    <sprite name="foxicon">:</b> Explorar, Batalhar, Especial<br><b>    <sprite name="rabbiticon">:</b> Batalhar, Reparar, Especial<br><b>    <sprite name="mouseicon">:</b> Missão, Ajudar, Batalhar, Reparar<br><br><b>Explorar:</b> Mova-se para a Ruína mais próxima. Em seguida, exaure um item para pegar um item aleatório da Ruína. (Não pontue pontos de vitória ao explorar.)<br><br><b>Missão:</b> Mova-se para a clareira mais próxima que corresponda à missão atual. Em seguida, exaure dois itens para completar a missão. (Ignore os tipos de itens listados na carta.) Descarte a missão e pontue um ponto de vitória. (Ignore o efeito de texto da carta.) Em seguida, compre uma nova missão.<br><br><b>Ajudar:</b> Escolha o jogador em sua clareira que tenha pelo menos uma peça lá, pelo menos um item criado, e a menor quantidade de pontos de vitória entre esses jogadores. Exaure tantos itens quanto possível, até o número de itens que ele criou. Pegue essa quantidade de itens do jogador alvo e pontue essa mesma quantidade de pontos de vitória. Em seguida, o jogador alvo compra essa mesma quantidade de cartas. (Você pode ajudar outros bots. Por causa da Falta de Destreza Manual deles, bots ajudados simplesmente pontuam um ponto de vitória.)<br><br><b>Batalhar:</b> Mova-se para a clareira mais próxima com pelo menos uma peça do jogador com mais pontos de vitória. Em seguida, exaure um item para iniciar uma batalha contra esse jogador. Se restarem peças dele, exaure dois itens e batalhe novamente, repetindo até que você não tenha itens suficientes para exaurir. Pontue um ponto de vitória por cada guerreiro inimigo que você remover. (Não pontue se você for o defensor. Ainda assim, você pontua por remover marcadores e construções.)<br>    <b>Primeiro Desempate para Clareira de Destino:</b> Tal clareira onde o defensor alvo tenha mais construções e marcadores.<br>    <b>Segundo Desempate para Clareira de Destino:</b> Tal clareira onde o defensor alvo tenha menos guerreiros.<br><br><b>Reparar:</b> Se você tiver pelo menos um item danificado, exaure um item para reparar um item danificado. Se o item danificado estava exaurido, ele permanece assim.<br><br><b>Especial:</b> Exaure um item para realizar a ação especial do seu personagem. Se a ação especial do seu personagem não tiver efeito ou for impossível, pule essa ação.<br>Quando o Automalandro for solicitado a realizar uma ação na clareira mais próxima, ele a realiza em sua clareira atual, se possível. Se não for possível, ele se move para uma clareira onde possa realizar a ação, exaurindo um item por movimento, de forma a exaurir o menor número possível de itens. Ele se move mesmo se não tiver itens não exauridos suficientes para realizar a ação após o movimento.<br><br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>O Anoitecer do Automalandro tem três etapas na seguinte ordem:<br><br><b>1º: Refrescar:</b><br>Se você tiver pelo menos um item danificado, refresque quatro itens não danificados. Se você não tiver itens danificados, refresque seis itens não danificados.<br><br><b>2º: Reparar:</b><br>Se você estiver em uma floresta, repare todos os itens. Se você não estiver em uma floresta, repare um item. Repare itens não exauridos antes de itens exauridos.<br><br><b>3º: Descartar Ordem:</b><br>Descarte a carta de ordem atual.
+rules.vagabottraits=<style=RSH>Atirador de Elite</style><br>No início da batalha como atacante, cause um golpe imediato (pontuando um ponto se remover um guerreiro inimigo).<br><br><style=RSH>Berserker</style><br>Sempre que você Batalhar, mova-se para a clareira mais próxima com mais peças e ataque o jogador com mais peças lá. No Anoitecer, repare mais um item.<br><br><style=RSH>Auxiliador</style><br>Sempre que você Ajudar, pontue um ponto de vitória extra, e o jogador ajudado compra duas cartas em vez de uma.<br><br><style=RSH>Aventureiro</style><br>Você pode Batalhar no máximo uma vez por turno. No final do Dia, repita a Tarefa quantas vezes for possível.
+rules.vagabotdifficulties=<style=RSH>Fácil</style><br>No Anoitecer, reanime um item a menos.<br><br><style=RSH>Normal</style><br>Nada é alterado. <br><br><style=RSH>Desafiador</style><br>No Anoitecer, reanime um item a mais.<br><br><style=RSH>Pesadelo</style><br>No Anoitecer, reanime um item a mais.<br>No final do Anoitecer, pontue <style=vpone>1</style>.
+rules.vagabotcharacters=<style=RSH>Ladrão</style><br><b>Roubar:</b> Pegue uma carta aleatória do inimigo na sua clareira com mais pontos lá, depois mais peças lá.<br><br><style=RSH>Funileiro:</style><br><b>Dia de Trabalho:</b> Crie a carta do topo da pilha de descarte com um item, pontuando <style=vpone>1</style>. <br>Comece o jogo com um item a menos.<br><br><style=RSH>Andarilho:</style><br><b>Esconderijo:</b> Se você tiver três ou mais itens danificados, deslize para uma floresta adjacente aleatória.
+rules.vagabotabilities=<b>Andarilho Solitário:</b> O peão do Automalandro não é um guerreiro (portanto, ele não pode dominar uma clareira ou impedir outro jogador de dominá-la). O peão do Automalandro não pode ser removido do mapa.<br><br><b>Remoção Completa:</b> Sempre que um jogador inimigo usar um efeito que remova todas as peças inimigas de uma clareira (como Revoltas da Aliança, cartas de Favor, etc.) com o Automalandro, ele danifica três itens.<br><br><b>Ágil:</b> O Automalandro pode se mover independentemente de quem domina sua clareira de origem ou destino.<br><br><b>Itens:</b> Para realizar ações, o Automalandro deve exaurir itens. Diferentemente do Malandro, o Automalandro trata todos os itens como idênticos (por exemplo, não há diferença entre <sprite name="torch"> e <sprite name="hammer">). Ele exaure itens não danificados para realizar várias ações.<br><br><b>Trilha de Batalha:</b> Ao contrário do Malandro, o Automalandro não usa espadas para determinar os golpes em batalha. Em vez disso, os golpes máximos que ele pode causar começam em um. Enquanto o Automalandro possuir pelo menos seis, nove e doze itens não danificados, um item é colocado em sua Trilha de Batalha. Os espaços de item da sexta e nona posições aumentam os golpes máximos dele em um, e o décimo segundo permite que ele cause um golpe extra como atacante em batalhas. Itens na Trilha de Batalha não podem ser exauridos, mas podem ser danificados.<br><br><b>Recebendo Golpes:</b> Quando o Automalandro recebe golpes, ele danifica itens exauridos ou, se não houver itens exauridos, itens não exauridos. (Itens danificados podem ser movidos da Trilha de Batalha para a Mochila dele.)
+rules.vagabotsetup=<b>1º:</b> O personagem é selecionado aleatoriamente se não foi atribuído durante a criação do jogo.<br><br><b>2º:</b> O Automalandro começa na floresta adjacente ao maior número de clareiras. Se houver múltiplas florestas assim, decida aleatoriamente entre elas.<br><br><b>3º:</b> Compre uma única carta de tarefa.<br><br><b>4º:</b> Ganhe 4 itens aleatórios. (O Funileiro começa com 3 itens em vez de 4.)
+rules.vagabotturnorder=<style=RSH><sprite index=66>Amanhecer</style><br><br>O Amanhecer do Automalandro tem três etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem para <style=vpone>1</style> se houver um item disponível.<br><br><b>3º: Deslizar</b><br>Se você tiver dois ou menos itens não danificados, mova-se para uma floresta adjacente aleatória e pule o Dia, indo direto para o Anoitecer.<br><br><br><style=RSH><sprite index=65>Dia</style><br><br>A carta de ordem atual determina a sequência de ações que o Automalandro tomará neste turno, conforme a seguir:<br><b>    <sprite name="birdicon">:</b> Explorar, Tarefas, Ajuda, Batalhar<br><b>    <sprite name="foxicon">:</b> Explorar, Batalhar, Ação Especial<br><b>    <sprite name="rabbiticon">:</b> Batalhar, Reparar, Ação Especial<br><b>    <sprite name="mouseicon">:</b> Tarefas, Ajuda, Batalhar, Reparar<br><br><b>Explorar:</b> Mova-se para a Ruína mais próxima. Em seguida, exaura um item para pegar um item aleatório da Ruína. (Não pontue pontos de vitória ao explorar.)<br><br><b>Tarefas:</b> Mova-se para a clareira mais próxima que corresponda à tarefa atual. Em seguida, exaura dois itens para completar a tarefa. (Ignore os tipos de itens listados na carta.) Descarte a tarefa e pontue um ponto de vitória. (Ignore o efeito de texto da carta.) Em seguida, compre uma nova tarefa.<br><br><b>Ajuda:</b> Escolha o jogador em sua clareira que tenha pelo menos uma peça lá, pelo menos um item criado, e a menor quantidade de pontos de vitória entre esses jogadores. Exaura tantos itens quanto possível, até o número de itens que ele criou. Pegue essa quantidade de itens do jogador alvo e pontue essa mesma quantidade de pontos de vitória. Em seguida, o jogador alvo compra essa mesma quantidade de cartas. (Você pode ajudar outros bots. Por causa da Falta de Destreza Manual deles, bots ajudados simplesmente pontuam um ponto de vitória.)<br><br><b>Batalhar:</b> Mova-se para a clareira mais próxima com pelo menos uma peça do jogador com mais pontos de vitória. Em seguida, exaura um item para iniciar uma batalha contra esse jogador. Se restarem peças dele, exaura dois itens e batalhe novamente, repetindo até que você não tenha itens suficientes para exaurir. Pontue um ponto de vitória por cada guerreiro inimigo que você remover. (Não pontue se você for o defensor. Ainda assim, você pontua por remover marcadores e construções.)<br>    <b>Primeiro Desempate para Clareira de Destino:</b> Tal clareira onde o defensor alvo tenha mais construções e marcadores.<br>    <b>Segundo Desempate para Clareira de Destino:</b> Tal clareira onde o defensor alvo tenha menos guerreiros.<br><br><b>Reparar:</b> Se você tiver pelo menos um item danificado, exaura um item para reparar um item danificado. Se o item danificado estava exaurido, ele permanece assim.<br><br><b>Ação Especial:</b> Exaura um item para realizar a ação especial do seu personagem. Se a ação especial do seu personagem não tiver efeito ou for impossível, pule essa ação.<br>Quando o Automalandro for solicitado a realizar uma ação na clareira mais próxima, ele a realiza em sua clareira atual, se possível. Se não for possível, ele se move para uma clareira onde possa realizar a ação, exaurindo um item por movimento, de forma a exaurir o menor número possível de itens. Ele se move mesmo se não tiver itens não exauridos suficientes para realizar a ação após o movimento.<br><br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>O Anoitecer do Automalandro tem três etapas na seguinte ordem:<br><br><b>1º: Refrescar:</b><br>Se você tiver pelo menos um item danificado, reanime quatro itens não danificados. Se você não tiver itens danificados, reanime seis itens não danificados.<br><br><b>2º: Reparar:</b><br>Se você estiver em uma floresta, repare todos os itens. Se você não estiver em uma floresta, repare um item. Repare itens não exauridos antes de itens exauridos.<br><br><b>3º: Descartar Ordem:</b><br>Descarte a carta de ordem atual.
 title.coop=Jogo Cooperativo
-rules.coop=Para vencer, os jogadores humanos/IA devem pontuar 30 pontos de vitória antes que qualquer bot Mecânico pontue 30 pontos de vitória. Bots não tratam outras peças de bots como peças inimigas ao selecionar uma clareira para agir, e não se atacam mutuamente em batalha. No entanto, um bot ainda pode remover peças de outro bot como dano colateral com efeitos como revoltas. Os jogadores humanos/IA ainda se tratam como inimigos (portanto, podem remover construções e marcadores para pontuar, etc.).<br><br>Cartas de Domínio são removidas durante o jogo cooperativo.
-rules.electriceyrieoverview=O Dinastia Elétrica inspirará temor até nos jogadores mais valentes. Como as Dinastias das Rapinas, esse bot pode aumentar agressivamente seu potencial de ação.
+rules.coop=Para vencer, os jogadores humanos/IA devem pontuar 30 pontos de vitória antes que qualquer bot Autômato pontue 30 pontos de vitória. Bots não tratam outras peças de bots como peças inimigas ao selecionar uma clareira para agir, e não se atacam mutuamente em batalha. No entanto, um bot ainda pode remover peças de outro bot como dano colateral com efeitos como revoltas. Os jogadores humanos/IA ainda se tratam como inimigos (portanto, podem remover construções e marcadores para pontuar, etc.).<br><br>Cartas de Domínio são removidas durante o jogo cooperativo.
+rules.electriceyrieoverview=O Dinastia Elétrica inspirará temor até nos jogadores mais valentes. Como a Dinastia das Rapinas, esse bot pode aumentar agressivamente seu potencial de ação.
 title.autoalli=Aliança Automatizada
 title.electriceyrie=Dinastia Elétrica
 title.vagabot=Automalandro
 title.characters=Personagens
-rules.riverfolk=Quando chegaram notícias de que a Floresta nas margens do grande lago estava mergulhando em uma guerra total, a Companhia Ribeirinha rapidamente enviou seus oficiais para estabelecer operações comerciais. À medida que as outras facções compram serviços, a Companhia Ribeirinha poderá expandir ainda mais seus interesses comerciais ao construir postos de comércio pela floresta. A construção desses postos é uma maneira viável de pontuar, assim como os dividendos que podem ser obtidos a partir de sua riqueza.
+rules.riverfolk=Quando chegaram notícias de que a Floresta nas margens do grande lago estava mergulhando em uma guerra total, a Companhia Ribeirinha rapidamente enviou seus oficiais para estabelecer operações comerciais. À medida que as outras facções compram serviços, a Companhia Ribeirinha poderá expandir ainda mais seus interesses comerciais ao construir entrepostos comerciais pela floresta. A construção desses entrepostos é uma maneira viável de pontuar, assim como os dividendos que podem ser obtidos a partir de sua riqueza.
 rules.riverfolksetup=<style=RSH>Preparação</style><br><br><b>1º:</b> Coloque 4 guerreiros em qualquer clareira ao longo do rio.<br><b>2º:</b> Defina os preços dos serviços.
 rules.riverfolksupply=<style=RSH>Suprimento</style><br><br>∙Guerreiros x15<br>∙Bases x3 (uma de cada naipe)
-rules.riverfolkturn1=<style=RSH>Habilidades</style><br><br><b>Nadadores:</b> Você trata rios como caminhos e pode se mover ao longo dos rios independentemente de quem domine a clareira.<br><br><b>À Venda:</b> Você tem uma mão pública.<br><br><style=RSH>Serviços</style><br><br>A Companhia Ribeirinha é uma facção comercial que oferece serviços a outros jogadores. Os custos dos serviços são definidos durante o Anoitecer.<br><br>Qualquer outro jogador, no início de sua Alvorada, pode comprar um serviço da Companhia Ribeirinha mais um adicional por clareira com um posto de comércio e qualquer uma de suas peças. O comprador paga pelos serviços pegando guerreiros de seu próprio suprimento e adicionando-os à caixa de Pagamentos da Companhia Ribeirinha.<br><br><style=RB>Comprar Carta:</style> O comprador pega uma carta da mão da Companhia Ribeirinha e a adiciona à sua mão.<br><style=RB>Barcos:</style> O comprador trata os rios como caminhos até o final de seu turno.<br><style=RB>Mercenários:</style> Durante o Dia e o Anoitecer deste turno, o comprador trata os guerreiros da Companhia Ribeirinha como se fossem seus, para fins de domínio e batalha (o comprador não pode movê-los, contá-los para domínio ou removê-los, exceto ao receber golpes).<br><br><b>Recebendo Golpes:</b> O comprador deve dividir os golpes recebidos igualmente entre suas peças e os guerreiros da Companhia Ribeirinha, com o comprador recebendo os golpes ímpares.
+rules.riverfolkturn1=<style=RSH>Habilidades</style><br><br><b>Nadadores:</b> Você trata rios como caminhos e pode se mover ao longo dos rios independentemente de quem domine a clareira.<br><br><b>À Venda:</b> Você tem uma mão pública.<br><br><style=RSH>Serviços</style><br><br>A Companhia Ribeirinha é uma facção comercial que oferece serviços a outros jogadores. Os custos dos serviços são definidos durante o Anoitecer.<br><br>Qualquer outro jogador, no início de seu Amanhecer, pode comprar um serviço da Companhia Ribeirinha mais um adicional por clareira com um entreposto comercial e qualquer uma de suas peças. O comprador paga pelos serviços pegando guerreiros de seu próprio suprimento e adicionando-os à caixa de Pagamentos da Companhia Ribeirinha.<br><br><style=RB>Cartas da Mão:</style> O comprador pega uma carta da mão da Companhia Ribeirinha e a adiciona à sua mão.<br><style=RB>Barcos:</style> O comprador trata os rios como caminhos até o final de seu turno.<br><style=RB>Mercenários:</style> Durante o Dia e o Anoitecer deste turno, o comprador trata os guerreiros da Companhia Ribeirinha como se fossem seus, para fins de governar e batalhar (o comprador não pode movê-los, contá-los para domínio ou removê-los, exceto ao receber golpes).<br><br><b>Recebendo Golpes:</b> O comprador deve dividir os golpes recebidos igualmente entre suas peças e os guerreiros da Companhia Ribeirinha, com o comprador recebendo os golpes ímpares.
 rules.riverfolkvagapayment=O Malandro paga pelos serviços exaurindo itens—para cada item exaurido, a Companhia Ribeirinha coloca um de seus guerreiros na caixa de Pagamentos. O Malandro não pode comprar Mercenários.
-rules.riverfolkturn2=<style=RSH><sprite index=66>Alvorada</style><br><br>Se sua caixa de Pagamentos estiver vazia, coloque dois guerreiros nela. Em seguida, se você tiver postos de comércio no mapa, pontue 1 ponto de vitória para cada dois fundos (guerreiros na caixa de Fundos). Por fim, mova todos os guerreiros de suas caixas de Compromissos e Pagamentos para seus fundos.<br><br><style=RSH><sprite index=65>Dia</style><br><br>Você pode realizar ações gastando e comprometendo fundos—guerreiros na sua caixa de Fundos. Quando você gasta um fundo, devolva o guerreiro ao suprimento de seu dono. Quando você compromete um fundo, mova o guerreiro para a caixa de Compromissos.<br><br><style=RB>Mover:</style> Comprometa um fundo para realizar um movimento.<br><style=RB>Batalhar:</style> Comprometa um fundo para iniciar uma batalha.<br><style=RB>Criar Carta:</style> Comprometa fundos para criar uma carta da sua mão usando postos de comércio.<br><style=RB>Exportar:</style> Comprometa fundos para criar uma carta da sua mão usando postos de comércio. Em vez de ganhar o efeito de criação listado na carta, descarte a carta e coloque um guerreiro na caixa de Pagamentos.<br><style=RB>Comprar Carta:</style> Comprometa um fundo para comprar uma carta.<br><style=RB>Recrutar:</style> Gaste um fundo para colocar um guerreiro em qualquer clareira com rio.<br><style=RB>Estabelecer Posto de Comércio com Guarnição:</style> Gaste dois fundos para colocar um posto de comércio e um guerreiro em uma clareira. Você deve gastar fundos da facção que domina a clareira escolhida. Cada clareira pode ter apenas um posto de comércio.
-rules.riverfolktradedisruption=Interrupção Comercial: Sempre que um posto de comércio for removido, você perde metade de seus fundos. O posto de comércio removido não retorna ao seu suprimento.<br><br>Postos de Comércio removidos ainda contribuem para seu poder de criação.
+rules.riverfolkturn2=<style=RSH><sprite index=66>Amanhecer</style><br><br>Se sua caixa de Pagamentos estiver vazia, coloque dois guerreiros nela. Em seguida, se você tiver entrepostos comerciais no mapa, pontue 1 ponto de vitória para cada dois fundos (guerreiros na caixa de Fundos). Por fim, mova todos os guerreiros de suas caixas de Comprometidos e Pagamentos para seus fundos.<br><br><style=RSH><sprite index=65>Dia</style><br><br>Você pode realizar ações gastando e comprometendo fundos—guerreiros na sua caixa de Fundos. Quando você gasta um fundo, devolva o guerreiro ao suprimento de seu dono. Quando você compromete um fundo, mova o guerreiro para a caixa de Comprometidos.<br><br><style=RB>Mover:</style> Comprometa um fundo para realizar um movimento.<br><style=RB>Batalhar:</style> Comprometa um fundo para iniciar uma batalha.<br><style=RB>Criar:</style> Comprometa fundos para criar uma carta da sua mão usando entrepostos comerciais.<br><style=RB>Exportar:</style> Comprometa fundos para criar uma carta da sua mão usando entrepostos comerciais. Em vez de ganhar o efeito de criação listado na carta, descarte a carta e coloque um guerreiro na caixa de Pagamentos.<br><style=RB>Comprar:</style> Comprometa um fundo para comprar uma carta.<br><style=RB>Recrutar:</style> Gaste um fundo para colocar um guerreiro em qualquer clareira com rio.<br><style=RB>Estabeleça um Entreposto Comercial com Guarnição:</style> Gaste dois fundos para colocar um entreposto comercial e um guerreiro em uma clareira. Você deve gastar fundos da facção que domina a clareira escolhida. Cada clareira pode ter apenas um entreposto comercial.
+rules.riverfolktradedisruption=Perturbação do Comércio: Sempre que um entreposto comercial for removido, você perde metade de seus fundos. O entreposto comercial removido não retorna ao seu suprimento.<br><br>Entrepostos Comerciais removidos ainda contribuem para seu poder de criação.
 rules.riverfolkturn3=<style=RSH><sprite index=64>Anoitecer</style><br><br>Se você tiver mais de cinco cartas na mão, descarte até ficar com cinco. Em seguida, você pode definir os custos de seus três serviços.
-rules.lizardsetup=<style=RSH>Configuração</style><br><br><style=RB>Passo 1: Posicionar Guerreiros</style><br><br>Na clareira de canto oposta à torre da guarda dos Marqueses ou ao ninho inicial da Dinastia das Rapinas, posicione 4 guerreiros e 1 jardim correspondente ao naipe da clareira; se ambos os Marqueses e a Dinastia das Rapinas estiverem em jogo, escolha um dos outros dois cantos. Em seguida, adicione um guerreiro a cada clareira adjacente.<br><br><style=RB>Passo 2: Escolher Proscrito</style><br><br>Escolha um naipe para se tornar o Proscrito.
+rules.lizardsetup=<style=RSH>Preparação</style><br><br><style=RB>Passo 1: Posicionar Guerreiros</style><br><br>Na clareira de canto oposta à torre da guarda dos Marqueses ou ao ninho inicial da Dinastia das Rapinas, posicione 4 guerreiros e 1 jardim correspondente ao naipe da clareira; se ambos os Marqueses e a Dinastia das Rapinas estiverem em jogo, escolha um dos outros dois cantos. Em seguida, adicione um guerreiro a cada clareira adjacente.<br><br><style=RB>Passo 2: Escolher Pária</style><br><br>Escolha um naipe para se tornar o Pária.
 rules.lizardsupply=<style=RSH>Suprimento</style><br><br>∙Guerreiros x25<br>∙Jardins x15 (5 de cada naipe)
-rules.lizardlostsouls=Almas Perdidas: Quando o Culto dos Lagartos está em jogo, todas as cartas dos jogadores são colocadas na pilha de Almas Perdidas do Culto em vez da pilha de descarte. No início do turno do Culto, o naipe mais comum nas Almas Perdidas define o Proscrito, ou seja, o naipe das clareiras onde o Culto pode realizar conspirações com seus acólitos naquele turno.
-rules.lizardturn1=<style=RSH>Habilidades</style><br><br><b>Vingança:</b> Seus guerreiros removidos ao se defender em batalha se tornam acólitos.<br><b>Ódio pelos Pássaros:</b> Cartas de pássaro não são curingas ao realizar rituais!<br><b>Peregrinos:</b> Você domina qualquer clareira onde tenha um jardim. Essa habilidade especial supera até mesmo os Senhores da Floresta das Rapinas.<br><b>Temam os Fiéis:</b> Sempre que um jardim for removido, descarte uma carta aleatória da sua mão.
-rules.lizardturn2=<style=RSH><sprite index=66>Alvorada</style><br><br>Se um naipe na pilha de Almas Perdidas tiver mais cartas que qualquer outro, esse naipe se torna o Proscrito. Se esse naipe já for o Proscrito, ele se torna o Proscrito Odiado. Em seguida, mova todas as cartas da pilha de Almas Perdidas para a pilha de descarte.<br><br>Por fim, você pode gastar acólitos para realizar conspirações. Se o Proscrito for Odiado, todas as conspirações custam um acólito a menos.<br><br><style=RB>Cruzada:</style> Gaste dois acólitos para batalhar em uma clareira Proscrita ou mover-se de uma clareira Proscrita e, se desejar, batalhar na clareira de destino.<br><style=RB>Converter:</style> Gaste dois acólitos para remover um guerreiro inimigo de uma clareira Proscrita e, em seguida, colocar um guerreiro seu lá.<br><style=RB>Sanctificar:</style> Gaste três acólitos para remover uma construção inimiga de uma clareira Proscrita e, em seguida, colocar um jardim lá.
-rules.lizardturn3=<style=RSH><sprite index=65>Dia</style><br><br>Revele qualquer número de cartas da sua mão e realize um ritual por carta, como segue. Você não pode usar as cartas reveladas para nenhum outro propósito durante o Dia.<br><br><style=RB>Erguer:</style> Revele uma carta correspondente a uma clareira que você domina para colocar um jardim lá.<br><style=RB>Recrutar:</style> Revele uma carta para colocar um guerreiro em uma clareira correspondente.<br><style=RB>Sacrificar:</style> Revele uma carta de pássaro para transformar um guerreiro de seu suprimento em um Acólito.<br><style=RB>Pontuar:</style> Gaste a carta revelada (descartando-a na pilha de Almas Perdidas) para pontuar os pontos de vitória listados na coluna de Jardins do espaço vazio mais à direita correspondente à carta gasta. Você pode realizar o ritual Pontuar apenas uma vez por naipe a cada turno.
-rules.lizardturn4=<style=RSH><sprite index=64>Anoitecer</style><br><br><style=RB>1º:</style> Retorne todas as cartas reveladas para sua mão.<br><style=RB>2º:</style> Crie cartas ativando jardins que correspondam ao naipe do Proscrito.<br><style=RB>3º:</style> Compre uma carta mais uma por bônus de compra descoberto. Se você tiver mais de cinco cartas na mão, descarte até ficar com cinco.
-rules.twovagabonds=Com a adição da Expansão Companhia Ribeirinha, agora os jogos podem ter dois Malandros.<br><br>A preparação é modificada da seguinte forma ao jogar com dois Malandros:<br><margin=3em><br>∙Cada ruína contém dois itens. Esses itens são randomizados de um conjunto de 2 espadas, 2 bolsas, 2 botas e 2 martelos. Quando um Malandro explora uma ruína com dois itens, ele olha ambos e pega um à sua escolha. Um Malandro não pode pegar um item de Ruína que corresponda ao tipo de um item de Ruína que ele já tenha no seu tabuleiro de facção. Se ele explorar, mas não pegar um item, ele não pontua, mas a tocha ainda é exaurida.<br><br>∙Um jogador Malandro aleatório faz a preparação primeiro. O segundo jogador Malandro deve escolher um personagem diferente do primeiro.<br><br>∙Os Malandros compartilham a mesma mão de missões disponíveis. Se um Malandro completar uma missão, ela não estará mais disponível para o outro.</margin=3em>
+rules.lizardlostsouls=Almas Perdidas: Quando os Lagartos Cultistas estão em jogo, todas as cartas dos jogadores são colocadas na pilha de Almas Perdidas dos Cultistas em vez da pilha de descarte. No início do turno dos Cultistas, o naipe mais comum nas Almas Perdidas define o Pária, ou seja, o naipe das clareiras onde os Cultistas podem realizar conspirações com seus acólitos naquele turno.
+rules.lizardturn1=<style=RSH>Habilidades</style><br><br><b>Vingança:</b> Seus guerreiros removidos ao se defender em batalha se tornam acólitos.<br><b>Ódio aos Pássaros:</b> Cartas de pássaro não são curingas ao realizar rituais!<br><b>Peregrino:</b> Você domina qualquer clareira onde tenha um jardim. Essa habilidade especial supera até mesmo os Lordes da Floresta das Rapinas.<br><b>Temam os Fiéis:</b> Sempre que um jardim for removido, descarte uma carta aleatória da sua mão.
+rules.lizardturn2=<style=RSH><sprite index=66>Amanhecer</style><br><br>Se um naipe na pilha de Almas Perdidas tiver mais cartas que qualquer outro, esse naipe se torna o Pária. Se esse naipe já for o Pária, ele se torna o Odiado. Em seguida, mova todas as cartas da pilha de Almas Perdidas para a pilha de descarte.<br><br>Por fim, você pode gastar acólitos para realizar conspirações. Se o Pária for Odiado, todas as conspirações custam um acólito a menos.<br><br><style=RB>Cruzada:</style> Gaste dois acólitos para batalhar em uma clareira Pária ou mover-se de uma clareira Pária e, se desejar, batalhar na clareira de destino.<br><style=RB>Conversão:</style> Gaste dois acólitos para remover um guerreiro inimigo de uma clareira Pária e, em seguida, colocar um guerreiro seu lá.<br><style=RB>Santificação:</style> Gaste três acólitos para remover uma construção inimiga de uma clareira Pária e, em seguida, colocar um jardim lá.
+rules.lizardturn3=<style=RSH><sprite index=65>Dia</style><br><br>Revele qualquer número de cartas da sua mão e realize um ritual por carta, como segue. Você não pode usar as cartas reveladas para nenhum outro propósito durante o Dia.<br><br><style=RB>Construir:</style> Revele uma carta correspondente a uma clareira que você domina para colocar um jardim lá.<br><style=RB>Recrutar:</style> Revele uma carta para colocar um guerreiro em uma clareira correspondente.<br><style=RB>Sacrificar:</style> Revele uma carta de pássaro para transformar um guerreiro de seu suprimento em um Acólito.<br><style=RB>Pontuar:</style> Gaste a carta revelada (descartando-a na pilha de Almas Perdidas) para pontuar os pontos de vitória listados na coluna de Jardins do espaço vazio mais à direita correspondente à carta gasta. Você pode realizar o ritual Pontuar apenas uma vez por naipe a cada turno.
+rules.lizardturn4=<style=RSH><sprite index=64>Anoitecer</style><br><br><style=RB>1º:</style> Retorne todas as cartas reveladas para sua mão.<br><style=RB>2º:</style> Crie cartas ativando jardins que correspondam ao naipe do Pária.<br><style=RB>3º:</style> Compre uma carta mais uma por bônus de compra descoberto. Se você tiver mais de cinco cartas na mão, descarte até ficar com cinco.
+rules.twovagabonds=Com a adição da Expansão Ribeirinhos, agora os jogos podem ter dois Malandros.<br><br>A preparação é modificada da seguinte forma ao jogar com dois Malandros:<br><margin=3em><br>∙Cada ruína contém dois itens. Esses itens são randomizados de um conjunto de 2 espadas, 2 bolsas, 2 botas e 2 martelos. Quando um Malandro explora uma ruína com dois itens, ele olha ambos e pega um à sua escolha. Um Malandro não pode pegar um item de Ruína que corresponda ao tipo de um item de Ruína que ele já tenha no seu tabuleiro de facção. Se ele explorar, mas não pegar um item, ele não pontua, mas a tocha ainda é exaurida.<br><br>∙Um jogador Malandro aleatório faz a preparação primeiro. O segundo jogador Malandro deve escolher um personagem diferente do primeiro.<br><br>∙Os Malandros compartilham a mesma mão de tarefas disponíveis. Se um Malandro completar uma tarefa, ela não estará mais disponível para o outro.</margin=3em>
 rule.riverfolk=A Companhia Ribeirinha deseja acumular riqueza vendendo serviços para todos os lados do conflito. Eles pontuam ao estabelecer postos de comércio e acumular fundos.
-rule.lizard=O Culto dos Lagartos deseja espalhar seu evangelho para todas as criaturas da Floresta. Eles pontuam ao construir jardins e completar rituais.
+rule.lizard=Os Lagartos Cultistas desejam espalhar seu evangelho para todas as criaturas da Floresta. Eles pontuam ao construir jardins e completar rituais.
 rules.lizard=O Culto depende da propaganda boca a boca (e bico) para espalhar seu evangelho, e novos enclaves podem surgir em qualquer lugar do mapa. Onde o Culto domina clareiras, eles podem construir jardins, que irão radicalizar ainda mais os animais que vivem lá. Enquanto outras facções gastam cartas para alcançar seus objetivos, o Culto age principalmente revelando cartas e gradualmente formando o conjunto ideal de seguidores. A menos que sejam usadas para pontuar, essas cartas não são gastas e retornam à mão do Culto durante o Anoitecer. No entanto, essa abordagem mais branda torna o movimento e a batalha difíceis, então essas ações só podem ser realizadas pelos membros mais radicalizados do Culto—seus acólitos.
 title.advancedsetup=Preparação Avançada
 rule.advancedsetup1=<style=RSH>Visão Geral</style> <br><br>A Preparação Avançada é uma forma opcional de escolher e preparar as facções. Essas mudanças impactam o equilíbrio das várias facções, oferecem mais variedade nas posições iniciais e permitem que os jogadores tenham maior controle sobre suas mãos iniciais. Para criar um jogo com preparação avançada, um jogador deve possuir 6 ou mais facções.
 rule.advancedsetup2=<style=RSH>Mão Inicial</style> <br><br>Cada jogador compra 5 cartas antes de escolher as facções e escolhe 2 para devolver ao baralho após fazer suas escolhas de preparação.
-rule.advancedsetup3=<style=RSH>Mudanças no Draft</style> <br><br>Começando pelo último jogador na ordem de turno e seguindo no sentido anti-horário, cada jogador escolhe uma facção disponível e realiza imediatamente a preparação da facção (antes que outro jogador escolha) a partir de um conjunto de facções possíveis. Esse conjunto é criado usando as restrições abaixo, em vez de valores de alcance.<br><br><b>Criar Conjunto de Facções Possíveis</b><br><br>Primeiro, remova todas as facções que não pertencem ao criador do jogo. Em seguida, randomize todas as facções Militantes e adicione uma ao conjunto de facções possíveis (substitua por uma Insurgente se nenhuma Militante for possuída e/ou estiver disponível devido às escolhas de bots clockwork). Depois, randomize as facções restantes (Militantes E Insurgentes) e adicione uma ao conjunto para cada jogador.<br><br>Travar Última Insurgente. Se a última facção adicionada ao conjunto for uma Insurgente, ela será exibida com um ícone de cadeado. Ela não pode ser escolhida a menos que pelo menos uma facção Militante tenha sido escolhida (assumindo que facções Militantes estejam disponíveis no conjunto de draft, o que pode não ser o caso dependendo da coleção dos jogadores e da inclusão de bots clockwork).<br><br><b>Facções Insurgentes</b><br><br><margin=3em>∙ Aliança da Floresta<br>∙ Malandro<br>∙ Companhia Ribeirinha<br>∙ Culto dos Lagartos<br>∙ Conspiração Corvídea</margin=3em><br><br><b>Facções Militantes</b><br><br><margin=3em>∙ Marqueses<br>∙ Dinastia das Rapinas<br>∙ Ducado Subterrâneo</margin=3em><br><br><b>Dois Jogadores:</b> Em um jogo de 2 jogadores, o conjunto será composto por três facções militantes, se possível.<br><br><b>Malandro:</b> O Malandro recebe um personagem aleatório durante o processo de criação de facção, em vez de o jogador escolher durante a preparação.
-rule.advancedsetup4=<style=RSH>Mudanças na Preparação</style> <br><br><b>Regras de Território</b><br><br>Durante a preparação, os jogadores poderão escolher uma ou mais clareiras como seus territórios de origem. Os jogadores não podem escolher territórios de origem que já tenham sido escolhidos como território de origem de inimigos ou onde não possam colocar todas as peças listadas na preparação.<br><br>Algumas facções podem instruir a escolher territórios de origem que não estejam adjacentes a territórios de origem inimigos ou que tenham duas ou mais clareiras entre eles e territórios inimigos. Se não for possível cumprir o requisito de “duas ou mais clareiras entre”, você poderá escolher um território de origem que não seja adjacente a territórios de origem inimigos. Se não for possível cumprir o requisito de “não adjacente”, você poderá escolher um território de origem adjacente a um território de origem inimigo.<br><br><b>Marqueses</b><br><br>Passo 1: Escolha uma clareira como território de origem para sua serraria.<br><br>Passo 2: Escolha uma clareira como território de origem para sua oficina.<br><br>Passo 3: Escolha uma clareira como território de origem para seu recrutador.<br><br>Passo 4: Coloque a Torre da Guarda em uma de suas clareiras de origem.<br><br>Passo 5: Coloque 2 guerreiros em cada um de seus territórios de origem. Coloque 1 guerreiro em cada outra clareira.<br><br><b>Dinastia das Rapinas</b><br><br>Passo 1: Escolha uma clareira como território de origem para seu Ninho das Rapinas na borda do mapa que tenha 2+ clareiras entre ela e territórios de origem inimigos.<br><br>Passo 2: Receba 6 guerreiros e 1 Ninho das Rapinas na clareira escolhida como território de origem.<br><br>Passo 3: Escolha um líder.<br><br><b>Aliança da Floresta</b><br><br>Começa com 3 apoiadores. Nenhuma outra mudança.<br><br><b>Malandro</b><br><br>Sem mudanças.<br><br><b>Companhia Ribeirinha</b><br><br>Começa com 3 pagamentos. Nenhuma outra mudança.<br><br><b>Culto dos Lagartos</b><br><br>Começa com 2 Acolytes.<br><br>Passo 1: Escolha uma clareira como território de origem que não seja adjacente a territórios de origem inimigos para colocar um Jardim e quatro guerreiros.<br><br>Passo 2: Coloque 3 guerreiros em clareiras adjacentes ao seu território de origem de maneira uniforme.<br><br>Passo 3: Escolha o naipe do Proscrito.<br><br><b>Conspiração Corvídea</b><br><br>Passo 1: Escolha uma clareira como território de origem. Coloque 1 guerreiro e 1 marcador de complô de sua escolha virado para baixo.<br><br>Passo 2: Selecione um naipe para adicionar 1 guerreiro a cada uma de suas clareiras correspondentes.<br><br><b>Ducado Subterrâneo</b><br><br>Passo 1: Escolha uma clareira como território de origem que não seja adjacente a territórios de origem inimigos e coloque 2 guerreiros e um Túnel lá.<br><br>Passo 2: Coloque 5 guerreiros entre clareiras adjacentes ao seu território de origem de maneira uniforme.
+rule.advancedsetup3=<style=RSH>Mudanças no Draft</style> <br><br>Começando pelo último jogador na ordem de turno e seguindo no sentido anti-horário, cada jogador escolhe uma facção disponível e realiza imediatamente a preparação da facção (antes que outro jogador escolha) a partir de um conjunto de facções possíveis. Esse conjunto é criado usando as restrições abaixo, em vez de valores de alcance.<br><br><b>Criar Conjunto de Facções Possíveis</b><br><br>Primeiro, remova todas as facções que não pertencem ao criador do jogo. Em seguida, randomize todas as facções Militantes e adicione uma ao conjunto de facções possíveis (substitua por uma Insurgente se nenhuma Militante for possuída e/ou estiver disponível devido às escolhas de Autômatos). Depois, randomize as facções restantes (Militantes E Insurgentes) e adicione uma ao conjunto para cada jogador.<br><br>Travar Último Insurgente. Se a última facção adicionada ao conjunto for uma Insurgente, ela será exibida com um ícone de cadeado. Ela não pode ser escolhida a menos que pelo menos uma facção Militante tenha sido escolhida (assumindo que facções Militantes estejam disponíveis no conjunto de draft, o que pode não ser o caso dependendo da coleção dos jogadores e da inclusão de Autômatos).<br><br><b>Facções Insurgentes</b><br><br><margin=3em>∙ Aliança da Floresta<br>∙ Malandro<br>∙ Companhia Ribeirinha<br>∙ Lagartos Cultistas<br>∙ Conspiração Corvídea</margin=3em><br><br><b>Facções Militantes</b><br><br><margin=3em>∙ Marqueses<br>∙ Dinastia das Rapinas<br>∙ Ducado Subterrâneo</margin=3em><br><br><b>Dois Jogadores:</b> Em um jogo de 2 jogadores, o conjunto será composto por três facções militantes, se possível.<br><br><b>Malandro:</b> O Malandro recebe um personagem aleatório durante o processo de criação de facção, em vez de o jogador escolher durante a preparação.
+rule.advancedsetup4=<style=RSH>Mudanças na Preparação</style> <br><br><b>Regras de Território</b><br><br>Durante a preparação, os jogadores poderão escolher uma ou mais clareiras como seus territórios de origem. Os jogadores não podem escolher territórios de origem que já tenham sido escolhidos como território de origem de inimigos ou onde não possam colocar todas as peças listadas na preparação.<br><br>Algumas facções podem instruir a escolher territórios de origem que não estejam adjacentes a territórios de origem inimigos ou que tenham duas ou mais clareiras entre eles e territórios inimigos. Se não for possível cumprir o requisito de “duas ou mais clareiras entre”, você poderá escolher um território de origem que não seja adjacente a territórios de origem inimigos. Se não for possível cumprir o requisito de “não adjacente”, você poderá escolher um território de origem adjacente a um território de origem inimigo.<br><br><b>Marqueses</b><br><br>Passo 1: Escolha uma clareira como território de origem para sua serraria.<br><br>Passo 2: Escolha uma clareira como território de origem para sua oficina.<br><br>Passo 3: Escolha uma clareira como território de origem para seu recrutador.<br><br>Passo 4: Coloque a Torre da Guarda em uma de suas clareiras de origem.<br><br>Passo 5: Coloque 2 guerreiros em cada um de seus territórios de origem. Coloque 1 guerreiro em cada outra clareira.<br><br><b>Dinastia das Rapinas</b><br><br>Passo 1: Escolha uma clareira como território de origem para seu Ninho na borda do mapa que tenha 2+ clareiras entre ela e territórios de origem inimigos.<br><br>Passo 2: Receba 6 guerreiros e 1 Ninho na clareira escolhida como território de origem.<br><br>Passo 3: Escolha um líder.<br><br><b>Aliança da Floresta</b><br><br>Começa com 3 apoiadores. Nenhuma outra mudança.<br><br><b>Malandro</b><br><br>Sem mudanças.<br><br><b>Companhia Ribeirinha</b><br><br>Começa com 3 pagamentos. Nenhuma outra mudança.<br><br><b>Lagartos Cultistas</b><br><br>Começa com 2 Acólitos.<br><br>Passo 1: Escolha uma clareira como território de origem que não seja adjacente a territórios de origem inimigos para colocar um Jardim e quatro guerreiros.<br><br>Passo 2: Coloque 3 guerreiros em clareiras adjacentes ao seu território de origem de maneira uniforme.<br><br>Passo 3: Escolha o naipe do Pária.<br><br><b>Conspiração Corvídea</b><br><br>Passo 1: Escolha uma clareira como território de origem. Coloque 1 guerreiro e 1 marcador de trama de sua escolha virado para baixo.<br><br>Passo 2: Selecione um naipe para adicionar 1 guerreiro a cada uma de suas clareiras correspondentes.<br><br><b>Ducado Subterrâneo</b><br><br>Passo 1: Escolha uma clareira como território de origem que não seja adjacente a territórios de origem inimigos e coloque 2 guerreiros e um Túnel lá.<br><br>Passo 2: Coloque 5 guerreiros entre clareiras adjacentes ao seu território de origem de maneira uniforme.
 title.maps=Mapas Variantes
 title.autumnmap=Mapa de Outono
 title.wintermap=Mapa de Inverno
@@ -2861,35 +3328,79 @@ rule.lakemap2=Uma vez por turno, um jogador que fizer um movimento em uma clarei
 title.lakeforest=<b>Adjacência do Lago e da Floresta</b>
 rule.lakemap3=O lago não é uma floresta. Diferentemente dos outros mapas, cada floresta que toca o lago é adjacente às duas florestas mais próximas que também tocam o lago, separadas por uma clareira em vez de um caminho.
 title.mountainmap=<b>Mapa da Montanha</b>
-rule.mountainmap1=Coloque a peça da torre na clareira central, como mostrado acima. Os jogadores podem alternar entre a opção de naipes de clareira aleatórios ou a configuração padrão, como mostrado na imagem acima.
+rule.mountainmap1=Coloque a peça da torre na clareira central, como mostrado acima. Os jogadores podem alternar entre a opção de naipes de clareira aleatórios ou a preparação padrão, como mostrado na imagem acima.
 title.closedpaths=<b>Caminhos Fechados</b>
 rule.mountainmap2=Um caminho coberto por um marcador de caminho fechado é considerado um caminho fechado. Clareiras conectadas por um caminho fechado não são adjacentes. No entanto, caminhos fechados cercam e dividem florestas da mesma forma que caminhos normais. Uma vez por turno, durante o Dia, um jogador pode gastar uma carta para remover um marcador de caminho fechado e pontuar 1 ponto de vitória. O jogador deve ter ao menos uma peça em qualquer clareira conectada ao caminho fechado para removê-lo.
 title.thepass=<b>O Desfiladeiro</b>
 rule.mountainmap3=A clareira com a torre é chamada de Desfiladeiro. No final do Anoitecer de um jogador, se esse jogador governar o Desfiladeiro, ele pontua 1 ponto de vitória.
 rule.corvidintro=Enquanto os grandes poderes lutavam pelo controle da floresta, rumores e sussurros se espalhavam por seus cantos mais sombrios. Prosperando no caos da guerra aberta, a Conspiração Corvídea elabora tramas para financiar suas operações criminosas e aterrorizar seus oponentes, até forçar a submissão da Floresta. Sempre que uma trama é revelada, os Corvídeos pontuam pontos de vitória com base no número de tramas já reveladas no mapa. Por isso, os Corvídeos devem proteger cuidadosamente suas tramas contra ataques e exposição total.
-rule.corvidsetup=<style=RSH>Configuração</style><br><br>Para cada naipe, coloque 1 guerreiro em uma clareira correspondente.
+rule.corvidsetup=<style=RSH>Preparação</style><br><br>Para cada naipe, coloque 1 guerreiro em uma clareira correspondente.
 rule.corvidsupply=<style=RSH>Suprimento</style><br><br>∙ Guerreiros x15<br>∙ Trama de Bomba x2<br>∙ Trama de Armadilha x2<br>∙ Trama de Saque x2<br>∙ Trama de Extorsão x2
 title.plots=<b>Tramas</b>
-rule.corvidplots1=A Conspiração Corvídea possui oito marcadores de trama, dois de cada um dos quatro tipos. Marcadores de trama pontuam quando são revelados durante a Alvorada. Além disso, cada marcador de trama possui um efeito, listado abaixo.
-rule.corvidplots2=<style=RSH>Bomba</style><br>Quando revelado, remova todas as peças inimigas de sua clareira e, em seguida, remova este marcador de trama.<br><br><style=RSH>Armadilha</style><br>Enquanto estiver com a face para cima, peças inimigas não podem ser colocadas ou movidas de sua clareira.<br><br><style=RSH>Extorsão</style><br>Quando revelado, pegue uma carta aleatória de cada jogador inimigo com qualquer peça em sua clareira. Enquanto estiver com a face para cima, você compra uma carta extra durante o Anoitecer.<br><br><style=RSH>Incursão</style><br>Quando removido, coloque um guerreiro em cada clareira adjacente. Ignore este efeito se a incursão foi removida por Exposição (veja abaixo).
+rule.corvidplots1=A Conspiração Corvídea possui oito marcadores de trama, dois de cada um dos quatro tipos. Marcadores de trama pontuam quando são revelados durante o Amanhecer. Além disso, cada marcador de trama possui um efeito, listado abaixo.
+rule.corvidplots2=<style=RSH>Bomba</style><br>Quando revelada, remova todas as peças inimigas de sua clareira e, em seguida, remova este marcador de trama.<br><br><style=RSH>Armadilha</style><br>Enquanto estiver com a face para cima, peças inimigas não podem ser colocadas ou movidas de sua clareira.<br><br><style=RSH>Extorsão</style><br>Quando revelada, pegue uma carta aleatória de cada jogador inimigo com qualquer peça em sua clareira. Enquanto estiver com a face para cima, você compra uma carta extra durante o Anoitecer.<br><br><style=RSH>Ataque</style><br>Quando removido, coloque um guerreiro em cada clareira adjacente. Ignore este efeito se o ataque foi removido por Exposição (veja abaixo).
 rule.corvidplots3=Marcadores de trama podem ser removidos por jogadores inimigos da mesma forma que qualquer outro marcador pode ser. Além disso, jogadores inimigos podem tentar remover marcadores de trama com a face para baixo por meio de <b>Exposição:</b> A qualquer momento antes de comprar cartas durante o Anoitecer, um jogador inimigo com uma peça em uma clareira contendo um marcador de trama com a face para baixo pode mostrar aos Corvídeos uma carta que corresponda à clareira para adivinhar o tipo da trama. Se estiver correto, ele remove o marcador (pontuando um ponto) e ignora o seu efeito. Se estiver incorreto, o marcador permanece com a face para baixo, e ele entrega a carta para os Corvídeos.
-rule.corvidabilities=Para proteger seus marcadores de trama, os Corvídeos precisarão mover seus guerreiros para o fundo do território inimigo. Felizmente, seus guerreiros são <b>Ágeis</b>, o que permite que eles ignorem o controle ao se mover. Além disso, seus <b>Agentes Infiltrados</b> oferecem proteção eficaz. Sempre que os Corvídeos estiverem defendendo em uma batalha em uma clareira com um marcador de trama com a face para baixo, eles causam um golpe extra — mesmo que o marcador de trama esteja indefeso!
-rule.corvidbirdsong=<style=RSH><sprite index=66>Alvorada</style> <br><br>Primeiramente, você pode criar usando marcadores de trama, estejam eles com a face para cima ou para baixo.<br><br>Depois, você pode revelar marcadores de trama em qualquer clareira onde tenha pelo menos um guerreiro. Cada vez que você revelar uma trama, você pontua <sprite name="1VP"> por marcador de trama com a face para cima no mapa, incluindo o que acabou de revelar, e então resolve seu efeito de revelação se for uma bomba ou extorsão.<br><br>Por fim, uma vez por turno, você pode gastar qualquer carta para colocar um guerreiro em cada clareira correspondente. Se você descartar uma carta de pássaro, escolha um naipe de clareiras para colocar os guerreiros.
-rule.corviddaylight=<style=RSH><sprite index=65>Dia</style> <br><br>Você pode realizar até três das seguintes ações. <br><br><style=RB>Tramar:</style> Remova um guerreiro Corvídeo, mais um guerreiro Corvídeo por marcador de trama que você já tenha colocado neste turno, de uma clareira para colocar um marcador de trama com a face para baixo nessa clareira. Cada clareira só pode conter um marcador de trama por vez, e todos os guerreiros removidos para colocar a trama devem vir da clareira onde a trama será colocada. <br><style=RB>Truque:</style> Troque dois marcadores de trama no mapa. Ambos os marcadores de trama devem estar com a face para cima ou com a face para baixo.<br><style=RB>Mover:</style> Realize um movimento.<br><style=RB>Batalhar:</style> Inicie uma batalha.<br><br>Adicionalmente, o jogador pode <b>Esforçar-se</b> para realizar uma ação extra de Dia durante o Anoitecer. Se o fizer, ele não comprará cartas durante o Anoitecer deste turno.
+rule.corvidabilities=Para proteger seus marcadores de trama, os Corvídeos precisarão mover seus guerreiros para o fundo do território inimigo. Felizmente, seus guerreiros são <b>Ágeis</b>, o que permite que eles ignorem o controle ao se mover. Além disso, seus <b>Agentes Escondidos</b> oferecem proteção eficaz. Sempre que os Corvídeos estiverem defendendo em uma batalha em uma clareira com um marcador de trama com a face para baixo, eles causam um golpe extra — mesmo que o marcador de trama esteja indefeso!
+rule.corvidbirdsong=<style=RSH><sprite index=66>Amanhecer</style> <br><br>Primeiramente, você pode criar usando marcadores de trama, estejam eles com a face para cima ou para baixo.<br><br>Depois, você pode revelar marcadores de trama em qualquer clareira onde tenha pelo menos um guerreiro. Cada vez que você revelar uma trama, você pontua <sprite name="1VP"> por marcador de trama com a face para cima no mapa, incluindo o que acabou de revelar, e então resolve seu efeito de revelação se for uma bomba ou extorsão.<br><br>Por fim, uma vez por turno, você pode gastar qualquer carta para colocar um guerreiro em cada clareira correspondente. Se você descartar uma carta de pássaro, escolha um naipe de clareiras para colocar os guerreiros.
+rule.corviddaylight=<style=RSH><sprite index=65>Dia</style> <br><br>Você pode realizar até três das seguintes ações. <br><br><style=RB>Tramar:</style> Remova um guerreiro Corvídeo, mais um guerreiro Corvídeo por marcador de trama que você já tenha colocado neste turno, de uma clareira para colocar um marcador de trama com a face para baixo nessa clareira. Cada clareira só pode conter um marcador de trama por vez, e todos os guerreiros removidos para colocar a trama devem vir da clareira onde a trama será colocada. <br><style=RB>Despistar:</style> Troque dois marcadores de trama no mapa. Ambos os marcadores de trama devem estar com a face para cima ou com a face para baixo.<br><style=RB>Mover:</style> Realize um movimento.<br><style=RB>Batalhar:</style> Inicie uma batalha.<br><br>Adicionalmente, o jogador pode <b>Exceder</b> para realizar uma ação extra de Dia durante o Anoitecer. Se o fizer, ele não comprará cartas durante o Anoitecer deste turno.
 rule.corvidevening=<style=RSH><sprite index=64>Anoitecer</style> <br><br>Compre uma carta, mais uma carta por marcador de extorsão com a face para cima no mapa. Em seguida, descarte até ficar com cinco cartas na mão.
 rule.duchyintro=O Ducado há muito tempo olha com desconfiança para os habitantes da superfície. A vasta riqueza do subsolo parecia mais do que suficiente para satisfazer suas ambições. Agora, no entanto, as reservas estão diminuindo, e o Ducado volta sua atenção para a grande Floresta em busca de expansão. Para ter sucesso, eles precisam convencer ministros a se unirem à sua causa e direcionar a riqueza do Ducado para esse esforço, fornecendo ações extras e formas de pontuar. O Ducado conquista o apoio dos ministros ao revelar cartas que correspondam a clareiras onde o Ducado tem qualquer número de peças, representando seus sucessos ao estabelecer postos avançados nas fronteiras. Por fim, o Ducado precisará construir mercados e cidadelas para justificar sua conquista e obter mais apoio de separatistas da Floresta.
 rule.duchysetup=<style=RSH>Preparação</style><br><br>Coloque 2 guerreiros e 1 túnel na clareira do canto diagonalmente oposto à clareira com o marcador da torre. Se os Marqueses não estiverem jogando, coloque essas peças em uma clareira de canto à sua escolha. Coloque 2 guerreiros em cada clareira adjacente a essa clareira de canto.
-rule.duchysupply=<style=RSH>Suprimento</style><br><br>∙Guerreiros x20<br>∙Cidadelas x3<br>∙Mercados x3<br>∙Túneis x3<br>∙Coroas de Escudeiro x3<br>∙Coroas de Nobre x3<br>∙Coroas de Lorde x3<br>∙Coroas de Ministro x9
-rule.duchyabilities=O Ducado recruta seus guerreiros em uma clareira especial chamada <b>A Toca</b>. Essa clareira está fora do mapa e não possui espaços para construções, mas é adjacente a todas as clareiras com um marcador de túnel. Devido à sua construção peculiar, somente guerreiros do Ducado podem entrar na Toca.<br><br>Os olhos do Duque estão focados na campanha pela Floresta. Quando qualquer número de construções do Ducado é removido, o Ducado deve pagar o <b>Preço do Fracasso</b>, descartando uma carta aleatória e devolvendo seu ministro influenciado de maior patente para a pilha de Ministros Não Influenciados.
-rule.duchyBirdsong=<style=RSH><sprite index=66>Alvorada</style> <br><br>Coloque um guerreiro, mais um guerreiro para cada ícone de guerreiro descoberto na trilha das Cidadelas, na Toca.
-rule.duchydaylight=<style=RSH><sprite index=65>Dia</style> <br><br>Primeiro, realize até duas das seguintes ações:<br><br><style=RB>Erguer:</style> Revele uma carta para colocar um mercado ou cidadela em uma clareira correspondente que você governe. <br><style=RB>Recrutar:</style> Coloque um guerreiro na Toca.<br><style=RB>Mover:</style> Realize um movimento.<br><style=RB>Batalhar:</style> Inicie uma batalha.<br><style=RB>Cavar:</style> Gaste uma carta para colocar um marcador de túnel em uma clareira correspondente sem túnel e, em seguida, mova até quatro guerreiros da Toca para essa clareira. Se todos os túneis já estiverem no mapa, você pode remover um túnel no início desta ação.<br><br>Após realizar essas ações, você pode agir com qualquer um de seus ministros influenciados em qualquer ordem:<br><br><b>Topeira-Forrageira:</b> Revele qualquer carta para colocar uma cidadela ou mercado em qualquer clareira (correspondente ou não) que você governe.<br><b>Capitão:</b> Inicie uma batalha.<br><b>Marechal:</b> Realize um movimento.<br><b>Brigadeiro:</b> Realize até dois movimentos ou inicie até duas batalhas.<br><b>Banqueiro:</b> Gaste qualquer número de cartas (até mesmo uma) do mesmo naipe para pontuar pontos de vitória em igual número.<br><b>Prefeito:</b> Realize a ação de qualquer nobre ou escudeiro influenciado.<br><b>Duquesa da Lama:</b> Pontue 2 pontos de vitória se todos os três túneis estiverem no mapa.<br><b>Barão da Terra:</b> Pontue <sprite name="1VP"> por mercado no mapa.<br><b>Conde da Pedra:</b> Pontue <sprite name="1VP"> por cidadela no mapa.<br><br>Por fim, você pode influenciar um ministro não influenciado. Para isso, você deve revelar um número de cartas com base na patente do ministro—um escudeiro precisa de duas cartas, um nobre precisa de três, e um lorde precisa de quatro. No entanto, você só pode revelar cartas que correspondam a clareiras onde você tenha qualquer peça, e cada uma dessas clareiras permite revelar apenas uma carta. Além disso, você perde uma de suas três coroas iniciais dessa patente de Ministros e não poderá influenciar mais desse tipo após gastar essas três coroas. <br><br>Por fim, pontue pontos de vitória iguais à patente do ministro (Escudeiro: <sprite name="1VP">, Nobre: <sprite name="2VP">, Lorde: <sprite name="3VP">).
+rule.duchysupply=<style=RSH>Suprimento</style><br><br>∙Guerreiros x20<br>∙Cidadelas x3<br>∙Mercados x3<br>∙Túneis x3<br>∙Coroas de Comum x3<br>∙Coroas de Nobre x3<br>∙Coroas de Lorde x3<br>∙Coroas de Ministro x9
+rule.duchyabilities=O Ducado recruta seus guerreiros em uma clareira especial chamada <b>A Toca</b>. Essa clareira está fora do mapa e não possui espaços para construções, mas é adjacente a todas as clareiras com um marcador de túnel. Devido à sua construção peculiar, somente guerreiros do Ducado podem entrar na Toca.<br><br>Os olhos do Duque estão focados na campanha pela Floresta. Quando qualquer número de construções do Ducado é removido, o Ducado deve pagar o <b>Preço da Derrota</b>, descartando uma carta aleatória e devolvendo seu ministro influenciado de maior patente para a pilha de Ministros Não Influenciados.
+rule.duchyBirdsong=<style=RSH><sprite index=66>Amanhecer</style> <br><br>Coloque um guerreiro, mais um guerreiro para cada ícone de guerreiro descoberto na trilha das Cidadelas, na Toca.
+rule.duchydaylight=<style=RSH><sprite index=65>Dia</style> <br><br>Primeiro, realize até duas das seguintes ações:<br><br><style=RB>Construir:</style> Revele uma carta para colocar um mercado ou cidadela em uma clareira correspondente que você governe. <br><style=RB>Recrutar:</style> Coloque um guerreiro na Toca.<br><style=RB>Mover:</style> Realize um movimento.<br><style=RB>Batalhar:</style> Inicie uma batalha.<br><style=RB>Escavar:</style> Gaste uma carta para colocar um marcador de túnel em uma clareira correspondente sem túnel e, em seguida, mova até quatro guerreiros da Toca para essa clareira. Se todos os túneis já estiverem no mapa, você pode remover um túnel no início desta ação.<br><br>Após realizar essas ações, você pode agir com qualquer um de seus ministros influenciados em qualquer ordem:<br><br><b>Capataz:</b> Revele qualquer carta para colocar uma cidadela ou mercado em qualquer clareira (correspondente ou não) que você governe.<br><b>Capitão:</b> Inicie uma batalha.<br><b>Marechal:</b> Realize um movimento.<br><b>Brigadeiro:</b> Realize até dois movimentos ou inicie até duas batalhas.<br><b>Banqueiro:</b> Gaste qualquer número de cartas (até mesmo uma) do mesmo naipe para pontuar pontos de vitória em igual número.<br><b>Prefeito:</b> Realize a ação de qualquer nobre ou comum influenciado.<br><b>Duquesa da Lama:</b> Pontue 2 pontos de vitória se todos os três túneis estiverem no mapa.<br><b>Barão da Terra:</b> Pontue <sprite name="1VP"> por mercado no mapa.<br><b>Conde da Pedra:</b> Pontue <sprite name="1VP"> por cidadela no mapa.<br><br>Por fim, você pode influenciar um ministro não influenciado. Para isso, você deve revelar um número de cartas com base na patente do ministro—um comum precisa de duas cartas, um nobre precisa de três, e um lorde precisa de quatro. No entanto, você só pode revelar cartas que correspondam a clareiras onde você tenha qualquer peça, e cada uma dessas clareiras permite revelar apenas uma carta. Além disso, você perde uma de suas três coroas iniciais dessa patente de Ministros e não poderá influenciar mais desse tipo após gastar essas três coroas. <br><br>Por fim, pontue pontos de vitória iguais à patente do ministro (Comum: <sprite name="1VP">, Nobre: <sprite name="2VP">, Lorde: <sprite name="3VP">).
 rule.duchyevening=<style=RSH><sprite index=64>Anoitecer</style> <br><br>Descarte todas as cartas de pássaro que você revelou neste turno e devolva todas as outras cartas reveladas para sua mão. Em seguida, você pode criar ativando cidadelas e mercados—eles são tratados da mesma forma aqui. Depois, compre uma carta mais uma carta por cada bônus de compra descoberto. Por fim, descarte até ficar com cinco cartas na mão.
 rule.corvidconspiracy=A Conspiração Corvídea elabora tramas para financiar suas operações criminosas e aterrorizar seus oponentes até que possam subjugar a Floresta. Os Corvídeos pontuam pontos de vitória com base em quantas tramas estão reveladas no mapa.
 rule.undergroundduchy=O Ducado Subterrâneo lidera seu ataque a partir do subsolo usando túneis para se mobilizar pelo mapa, convencendo ministros a se juntarem à sua causa. O Ducado ergue mercados e cidadelas para justificar sua conquista e ganhar mais apoio de separatistas da Floresta.
-title.lordofthehundreds=Senhor das Centenas
-rule.lordofthehundreds.intro1=<i>Afirmando ser a única verdadeira voz da Floresta, o Senhor das Centenas consolida seu poder esmagando toda dissidência. Durante seu Anoitecer, ele pontua com base em quantas clareiras ele</i> <b>oprime</b>—<i>clareiras que governa e que não possuem peças inimigas. Seu exército numeroso é liderado pelo</i> <b>senhor da guerra</b><i>, um guerreiro-demagogo cuja mudança de</i> <b>humor</b> <i>oferece vantagens temporárias.
-rule.lordofthehundreds.intro2=Ao acumular itens em seu imponente</i> <b>Tesouro</b><i>, os Centenas aumentam seu</i> <b>Comando</b> <i>e sua</i> <b>Proeza</b><i>, permitindo que realizem mais ações e atraiam mais guerreiros para o senhor da guerra. Se isso não for suficiente, eles podem incitar</i> <b>multidões</b> <i>empunhando tochas para incendiar a Floresta.</i>
-rule.lordofthehundreds.setup1=<b>Passo 1: Posicionar Guerreiros</b><br>Coloque seu senhor da guerra, 4 guerreiros e 1 fortaleza em uma clareira de canto que outro jogador não tenha escolhido como clareira inicial.
+rules.keepers.1=Os Guardiões de Ferro são uma ordem de cavaleiros exilados que retornaram para recuperar <b>relíquias</b> perdidas em conflitos passados.
+rules.keepers.2=Primeiro, eles devem <b>escavar</b> relíquias das florestas, depois mover as relíquias para suas <b>estações</b>, onde finalmente podem <b>recuperá-las</b> para marcar pontos. Mas eles devem planejar cuidadosamente, já que contam com seu <b>Séquito</b> de moradores da Floresta, que podem desaparecer — ou pior — enquanto ajudam os Guardiões a vasculhar e recuperar as relíquias que procuram.
+rules.keepers.setup.1=<style=RSH>Setup</style><br><br><b>Etapa 1: Adicionar relíquias às florestas</b><br>As 12 relíquias são embaralhadas e uma é adicionada aleatoriamente virada para baixo a cada floresta.<br>Seu tipo será mostrado quando estiver virada para baixo, mas não seu valor.
+rules.keepers.relics=<style=RSH>4x Relíquias de Tábua</style><br> Valores de 1, 2, 3, 3<br><br><style=RSH>4x Relíquias de Figura</style><br> Valores de 1, 2, 3, 3<br><br><style=RSH>4x Relíquias de Jóias</style><br> Valores de 1, 2, 3, 3
+rules.keepers.setup.2=<b>Etapa 2: Posicione os Guerreiros</b><br><br>Coloque 4 guerreiros em uma clareira de canto que outro jogador não escolheu como clareira inicial e, em seguida, coloque 4 guerreiros em uma clareira adjacente na borda do mapa.
+rules.keepers.setup.3=<b>Etapa 3: Distribua as Relíquias restantes</b><br><br>Todas as relíquias restantes não jogadas durante a etapa 1 serão adicionadas viradas para baixo, da maneira mais uniforme possível, entre florestas não adjacentes às suas clareiras iniciais.
+rules.keepers.setup.4=<b>Etapa 4: Seguidores Fiéis</b><br><br>Uma carta de Seguidor Fiel é adicionada em cada uma das colunas de seu Séquito.
+rules.keepers.supply=<style=RSH>Suprimento</style><br><br>∙Guerreiros x15<br>∙Estações x3 (frente e verso)
+rules.keepers.birdsong.1=<style=RSH><sprite index=66>Amanhecer</style> <br><br><b>Primeiro, Acampe.</b> Em qualquer número de clareiras, você pode substituir um guerreiro Guardião por uma estação. Suas estações têm dois lados, e você pode colocar a estação em qualquer um dos lados.
+rules.keepers.birdsong.2=Cada estação mostra que tipo de relíquia você pode recuperar nela. Por exemplo, esta estação permite que você recupere figuras ou jóias, dependendo de qual lado você coloca virado para cima. Existem três tipos de relíquias: figuras, jóias e tábuas.
+rules.keepers.birdsong.3=Você não pode acampar na mesma clareira várias vezes em um turno.
+rules.keepers.birdsong.4=Você pode acampar em uma clareira que já tenha uma estação de um turno anterior!
+rules.keepers.birdsong.5=Se você não tiver guerreiros ou estações no mapa, você pode colocar um guerreiro e uma estação em qualquer clareira da borda.
+rules.keepers.birdsong.6=<b>Segundo, Levante Acampamento.</b> Levantar Acampamento é essencialmente o oposto de Acampar. Em qualquer número de clareiras, você pode substituir uma estação por um guerreiro Guardião. Da mesma forma, você não pode Levantar Acampamento na mesma clareira várias vezes em um turno.
+rules.keepers.birdsong.7=<b>Terceiro, Recrute.</b> Você pode gastar uma carta quantas vezes quiser para colocar dois guerreiros em uma estação correspondente.
+rules.keepers.birdsong.8=Sim, você pode colocar seis, oito ou até dez guerreiros em uma única estação se tiver cartas para isso!
+rules.keepers.daylight.1=<style=RSH><sprite index=65>Dia</style> <br><br><b>Primeiro, Criar.</b> Esta é uma ação padrão de Criar que usa suas estações, independentemente do tipo.<br><br><b>Segundo, Ative o Séquito.</b> Você pode realizar uma ação por carta em seu Séquito, localizada ao longo do topo do seu tabuleiro de facção, da esquerda para a direita. Realize a ação listada pelo espaço de ação da carta em uma clareira que corresponda ao naipe da carta.
+rules.keepers.daylight.2=O Séquito funciona como os Decretos das Rapinas, mas você pode pular ações sem penalidade.
+rules.keepers.daylight.3=<b>Mover:</b> O espaço de ação esquerdo permite que você se mova da clareira correspondente.
+rules.keepers.daylight.4=<b>Batalhe e Escave:</b> O espaço de ação do meio permite que você lute e depois escave. Se você realizar esta ação, você deve batalhar na clareira em que está agindo, a menos que não haja peças inimigas com as quais você possa lutar lá. Então você pode escavar na mesma clareira. Veja como a escavação funciona... Se você governar a clareira e tiver um guerreiro Guardião lá, você pode mover uma relíquia de qualquer floresta adjacente para a clareira e então virar a relíquia para revelar seu valor.
+rules.keepers.daylight.5=Cada tipo de relíquia tem quatro fichas com os mesmos valores — 1, 2, 3 e 3. Cada relíquia começa em seu lado sem valor. Quando escavada, ela vira para mostrar seu valor.
+rules.keepers.daylight.6=Depois de ter escavado uma relíquia, conte quantas clareiras você governa adjacentes à floresta da qual escavou — basicamente, todas as clareiras que estão tocando a floresta. Se você governar menos dessas clareiras do que o valor da relíquia, você deve descartar a carta em seu Séquito que você usou para escavar.
+rules.keepers.daylight.7=<b>Mover ou Recuperar:</b> O slot de ação da direita permite que você mova ou recupere relíquias de uma clareira correspondente, à sua escolha. Veja como a recuperação funciona... Uma de cada vez, você pode pegar qualquer número de relíquias da clareira em que está agindo. No entanto, você só pode pegar uma relíquia se a clareira tiver uma estação do mesmo tipo: figura, tábua ou jóia. Quando você pega uma relíquia, coloque-a no seu tabuleiro de facção no espaço de Relíquias vazio mais à esquerda do seu tipo. Então, conte quantas clareiras você governa que correspondem ao naipe da clareira em que está agindo, incluindo essa clareira. Se você governar menos dessas clareiras do que o valor da relíquia, você deve descartar a carta em seu Séquito que você usou para recuperá-la e, em seguida, encerrar a ação. Quando você recupera uma relíquia, você ganha pontos iguais ao seu valor e ganha mais dois pontos se ela preencher uma coluna de Relíquias.
+rules.keepers.evening.1=<style=RSH><sprite index=64>Anoitecer</style> <br><br><b>Primeiro, Deixe a Terra.</b> Em cada clareira que tenha quatro ou mais guerreiros Guardiões, você deve remover um guerreiro Guardião.<br><br><b>Segundo, Receba o Séquito.</b> Você pode adicionar qualquer número de cartas da sua mão a qualquer espaço de ação no seu Séquito. No entanto, seu Séquito não pode segurar mais de dez cartas por vez.
+rules.keepers.evening.2=Se você não adicionar nenhuma carta, você pode mudar exatamente uma carta do seu Séquito para qualquer outro slot de ação do Séquito.<br><br><b>Terceiro, Compre e Descarte.</b> Você compra uma carta, mais uma carta para cada estação do mapa. Então, se você tiver mais de cinco cartas, você descarta até cinco cartas.
+rules.hundreds.1=Afirmando ser a única voz verdadeira da Floresta, o Senhor das Centenas consolida o poder esmagando toda dissidência.
+rules.hundreds.2=No Anoitecer, eles marcam pontos com base em quantas clareiras eles <b>oprimem</b> — clareiras que eles governam e que não têm nenhuma peça inimiga. Seu exército enxameante é liderado pelo <b>Senhor da Guerra</b>, um guerreiro-demagogo cujo <b>humor</b> mutável fornece vantagens temporárias.
+rules.hundreds.3=Ao empilhar itens em seu imponente <b>Tesouro</b>, as Centenas crescem em <b>Comando</b> e <b>Proeza</b>, o que os permite realizar mais ações e atrair mais guerreiros para seu Senhor da Guerra. Se isso não for suficiente, eles podem incitar <b>turbas</b> empunhando tochas para arrasar a Floresta.
+rules.hundreds.setup.1=<style=RSH>Setup</style><br><br><b>Etapa 1: Posicione os guerreiros</b><br><br>Coloque seu Senhor da Guerra, quatro guerreiros e um forte em uma clareira de canto que não seja a clareira de canto inicial de outro jogador e, se possível, seja diagonalmente oposta a uma clareira de canto inicial.
+rules.hundreds.setup.2=<b>Etapa 2: Posicione os itens</b><br><br>Os 4 itens são distribuídos entre as ruínas, caso isso ainda não tenha sido feito (normalmente pelo Malandro estar no jogo).
+rules.hundreds.setup.3=<b>Etapa 3: Humor Inicial</b><br><br>Comece com o humor Teimoso no espaço de humor. (Isso significa que no seu primeiro turno, você escolherá qualquer humor, exceto Teimoso.)
+rules.hundreds.supply=<style=RSH>Suprimento</style><br><br>∙Guerreiros x20<br>∙Fortes x6<br>∙Turbas x5
+rules.hundreds.birdsong.1=<style=RSH><sprite index=66>Amanhecer</style> <br><br><b>Primeiro, Arrase.</b> Em cada clareira com um marcador de turba, remova todos os edifícios e marcadores inimigos. Se houver uma ruína lá, pegue um item dela e adicione-o ao seu Tesouro. <br><br>Sempre que você ganha um item, ele é colocado no espaço vazio mais à esquerda do seu Tesouro que mostra esse tipo de item. Botas, bolsas e moedas aumentam seu Comando, enquanto martelos, chá, espadas e a besta aumentam sua Proeza.
+rules.hundreds.birdsong.2=Depois de resolver todas as suas turbas, role o dado de turba uma vez — não importa quantas turbas estejam no mapa! Coloque um marcador de turba em uma clareira que combine com o naipe que você rolou no dado de turba. Esta clareira deve ser adjacente a uma clareira que já tenha uma turba, e uma clareira não pode ter várias turbas.
+rules.hundreds.birdsong.3=<b>Segundo, Recrute.</b> Coloque guerreiros em número igual à sua Proeza na clareira com seu Senhor da Guerra. Então, coloque um guerreiro em cada forte.<br><br><b>Terceiro, Convoque.</b> Se seu Senhor da Guerra não estiver no mapa, você precisará de um novo! Substitua qualquer guerreiro das Centenas no mapa pelo seu Senhor da Guerra. Se não puder — por exemplo, se não tiver guerreiros no mapa — então coloque seu Senhor da Guerra em qualquer clareira.
+rules.hundreds.birdsong.4=<b>Quarto, escolha seu humor.</b> Aqui, você deve substituir seu cartão de humor atual por um diferente. Você não pode escolher um humor se tiver o item em seu Tesouro que o cartão de humor mostra no canto superior esquerdo. Um humor, Esbanjador, não mostra um item. Você sempre pode escolhê-lo, desde que não esteja Esbanjador no momento. Se você estiver Esbanjador e tiver todos os tipos de itens em seu Tesouro, você permanecerá Esbanjador.
+rules.hundreds.daylight.1=<style=RSH><sprite index=65>Dia</style> <br><br><b>Primeiro, Criar.</b> Esta é uma ação padrão de Criar que usa seus fortes.<br><br><b>Segundo, Comande as Centenas.</b> Você pode realizar essas ações em qualquer ordem, um número de vezes menor ou igual seu Comando:
+rules.hundreds.daylight.2=∙<b>Mover:</b> Faça um movimento.<br>∙<b>Batalha:</b> Inicie uma batalha.<br>∙<b>Construir:</b> Gaste uma carta para colocar um forte em uma clareira correspondente que você governa.
+rules.hundreds.daylight.3=<b>Terceiro, Avance o Senhor da Guerra.</b> Você pode avançar seu senhor da guerra um número de vezes igual à sua Proeza. Sempre que avançar, você pode se mover, e então você pode batalhar — nenhum dos dois é necessário. O movimento deve incluir seu Senhor da Guerra, mas você também pode mover guerreiros junto com seu Senhor da Guerra, e a batalha deve ser na clareira do seu Senhor da Guerra.
+rules.hundreds.evening.1=<style=RSH><sprite index=64>Anoitecer</style> <br><br><b>Primeiro, Incite.</b> Qualquer número de vezes, você pode gastar uma carta para colocar um marcador de turba em uma clareira correspondente com um guerreiro das Centenas, até mesmo seu Senhor da Guerra. Uma clareira não pode ter várias turbas.
+rules.hundreds.evening.2=Você não precisa colocar turbas adjacentes a clareiras que já tenham uma turba, como você faz quando rola o dado da turba na sua etapa Arrasar.
+rules.hundreds.evening.3=<b>Segundo, Oprima.</b> Você ganha pontos com base em quantas clareiras você governa que têm uma peça das Centenas e nenhuma peça inimiga — nenhum guerreiro, nenhuma ficha, nenhuma construção, nada.
+rules.hundreds.evening.4=<b>Terceiro, Compre e Descarte.</b> Você compra uma carta. Se tiver mais de cinco cartas, descarta até cinco.
+rules.hundreds.evening.5=Se você quiser comprar mais cartas, escolha seu humor Conflitante!
+rules.hundreds.ability.1=<style=RSH>A habilidade Saqueadores</style> <br><br>É assim que sua habilidade Saqueadores funciona. Na batalha como o atacante, você pode escolher saquear o defensor. Você ainda rola, mas não causa nenhum acerto rolado, mas o defensor ainda causa. No final da batalha, se você governar a clareira onde você acabou de lutar, você pode pegar qualquer item da seção de Itens Criados do defensor.
+rules.hundreds.ability.2=Notavelmente, você não pode saquear o Malandro, que não tem uma caixa de Itens Criados.
+rules.keepers.desc=Os Guardiões de Ferro são uma ordem de cavaleiros devotos, exilados da Floresta, que retornaram para recuperar relíquias perdidas em conflitos passados. Eles pontuam recuperando relíquias em suas estações.
+rules.hundreds.desc=O Senhor das Centenas não tolera tolos e não permite dissidência. Durante o Anoitecer, eles marcam pontos com base em quão bem eles oprimem seus inimigos. Quanto mais clareiras eles governarem que tenham uma peça de Centenas e nenhuma peça inimiga, mais pontos eles marcam.
 emote.dominance.marquise=Desloque para a esquerda, ataque pela direita!
 emote.dominance.eyrie=Segurem suas penas. Temos um novo caminho para a vitória pela frente.
 emote.dominance.alliance=Mudança de planos, amigos. Eles nunca saberão o que os atingiu!
@@ -2911,7 +3422,7 @@ tuber.canis.actions.MovePieces.VagabondChooseAlly=Escolha um aliado para mover j
 tuber.canis.actions.MovePieces.SelectSource=Selecione guerreiros para mover.
 tuber.canis.actions.MovePiece.NumberToMove=Escolha o número de guerreiros para mover.
 tuber.canis.actions.MovePieces.SelectDestination=Selecione uma clareira para mover-se.
-tuber.canis.actions.BirdsongActivations=Escolha uma carta com uma ativação de Alvorada para ativar.
+tuber.canis.actions.BirdsongActivations=Escolha uma carta com uma ativação de Amanhecer para ativar.
 tuber.canis.actions.EyrieDynastiesActions.ChooseDecrees=Atribua cartas ao seu decreto.
 tuber.canis.actions.DaylightActivations=Fase de Criação
 tuber.canis.actions.DaylightActivations.NoActions=Nenhuma carta para criar. Pressione o botão de continuar.
@@ -2923,7 +3434,7 @@ tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.Sympa
 tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceDaylightAction=Escolha uma ação.
 tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceEveningAction=Escolha uma ação.
 tuber.canis.actions.tuber.canis.actions.WoodlandAllianceActions.Outrage=Escolha uma carta para adicionar aos apoiadores da Aliança da Floresta.
-tuber.canis.actions.VagabondActions.VagabondBirdsongActionRefresh=Escolha itens para exaurir.
+tuber.canis.actions.VagabondActions.VagabondBirdsongActionRefresh=Escolha itens para reanimar.
 tuber.canis.actions.VagabondActions.VagabondBirdsongActionSlip=Escolha um local para deslizar.
 tuber.canis.actions.VagabondActions.AidActions.ChooseWhoToAid=Escolha um jogador para ajudar.
 tuber.canis.actions.VagabondActions.Draw2=Compre 2 cartas.
@@ -2933,7 +3444,7 @@ tuber.canis.actions.VagabondActions.VagabondDamageActionSelectionsWithAllies=Esc
 tuber.canis.actions.VagabondActions.VagabondDamageActionSelections=Escolha itens para danificar.
 tuber.canis.actions.VagabondActions.DaylightChoice=Realize ações utilizando itens.
 tuber.canis.actions.VagabondActions.AidActions.ChooseItemToTake=Escolha um item para pegar.
-tuber.canis.actions.VagabondActions.DiscardItems=Sua bolsa está sobrecarregada. Escolha itens para descartar.
+tuber.canis.actions.VagabondActions.DiscardItems=Sua mochila está sobrecarregada. Escolha itens para descartar.
 tuber.canis.abilities.StandAndDeliverAbility=Escolha um jogador para roubar uma carta.
 tuber.canis.abilities.ActivateDominanceAbility=Escolha um jogador para formar uma coalizão.
 tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWood=Escolha onde colocar esta madeira.
@@ -2942,10 +3453,10 @@ tuber.canis.actions.MarquiseDeCatActions.FieldHospitalSelection=Descarte uma car
 tuber.canis.actions.CostActions.ExhaustSelectedItem=Escolha um item para exaurir.
 tuber.canis.actions.VagabondActions.AidActions.ChooseCardForAiding=Escolha uma carta para ajudar.
 tuber.canis.abilities.MarquiseDeCatAbilities.ChooseBuilding=Escolha uma construção.
-tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility=Escolha uma clareira para sobrecarregar.
+tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility=Escolha uma clareira para faz Hora Extra.
 tuber.canis.abilities.MarquiseDeCatAbilities.BattleAbility=Escolha um inimigo para batalhar.
 tuber.canis.abilities.MarquiseDeCatAbilities.BuildAbility=Escolha uma clareira para erguer.
-tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.Discard=Escolha uma carta para descartar ao sobrecarregar.
+tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.Discard=Escolha uma carta para descartar ao fazer Hora Extra.
 tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbility=Escolha uma clareira para recrutar um guerreiro.
 tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbilityWithCount=No limite de suprimento. Escolha uma clareira para recrutar um guerreiro. ([X] restantes)
 tuber.canis.abilities.MarquiseDeCatAbilities.SpendBirdForAction=Escolha uma carta de pássaro para gastar.
@@ -2955,13 +3466,13 @@ tuber.canis.abilities.VagabondAbilities.TinkerAbility=Escolha uma carta do monte
 tuber.canis.abilities.VagabondAbilities.VagabondAidAbility=Escolha um jogador para ajudar.
 tuber.canis.abilities.VagabondAbilities.VagabondBattleAbility=Escolha um inimigo para batalhar.
 tuber.canis.abilities.VagabondAbilities.VagabondMoveAbility=Selecione um local de onde mover-se.
-tuber.canis.abilities.VagabondAbilities.VagabondQuestAbility=Escolha uma missão para completar.
+tuber.canis.abilities.VagabondAbilities.VagabondQuestAbility=Escolha uma tarefa para completar.
 tuber.canis.abilities.VagabondAbilities.VagabondRepairAbility=Escolha um item danificado para reparar.
 tuber.canis.abilities.VagabondAbilities.VagabondStrikeAbility=Escolha uma peça para destruir.
 tuber.canis.abilities.WoodlandAllianceAbilities.MobilizeAbility=Escolha uma carta para adicionar aos seus Apoiadores.
 tuber.canis.abilities.WoodlandAllianceAbilities.OrganizeAbility=Escolha um guerreiro para substituir por um marcador de simpatia.
 tuber.canis.abilities.WoodlandAllianceAbilities.RevoltAbility=Escolha uma clareira para iniciar uma revolta.
-tuber.canis.abilities.WoodlandAllianceAbilities.OutrageHand=Mão do inimigo revelada após a última Indignação.
+tuber.canis.abilities.WoodlandAllianceAbilities.OutrageHand=Mão do inimigo revelada após o último Ultraje.
 tuber.canis.abilities.WoodlandAllianceAbilities.SpreadSympathyAbility=Escolha uma clareira para espalhar simpatia.
 tuber.canis.abilities.WoodlandAllianceAbilities.SingleTrainAbility=Escolha uma carta para descartar e treinar um oficial.
 tuber.canis.abilities.WoodlandAllianceAbilities.TrainAbility=Escolha [X] cartas para descartar e treinar um oficial.
@@ -2977,23 +3488,23 @@ tuber.canis.entities.PlayableClasses.ChoosePiecesToRemove=Escolha as baixas da b
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Recruit=Escolha uma clareira para recrutar guerreiros.
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Move=Escolha uma clareira para se mover.
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Battle=Escolha um inimigo para batalhar.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Build=Escolha uma clareira para erguer um ninho.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Recruit=Nenhuma clareira para recrutar que corresponda ao decreto.<br>Continue para entrar em Colapso.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Move=Nenhum guerreiro em clareiras correspondentes ao decreto para mover. Continue para entrar em Colapso.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Battle=Nenhuma clareira para batalhar que corresponda ao decreto.<br>Continue para entrar em Colapso.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Build=Nenhuma clareira para erguer que corresponda ao decreto.<br>Continue para entrar em Colapso.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Build=Escolha uma clareira para construir um ninho.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Recruit=Nenhuma clareira para recrutar que corresponda ao decreto.<br>Continue para entrar em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Move=Nenhum guerreiro em clareiras correspondentes ao decreto para mover. Continue para entrar em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Battle=Nenhuma clareira para batalhar que corresponda ao decreto.<br>Continue para entrar em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Build=Nenhuma clareira para construir que corresponda ao decreto.<br>Continue para entrar em Tumulto.
 nonPrompt.vagabondDamage=O Malandro está selecionando [X] itens para danificar.
 nonPrompt.vagabondDamageWithAllies=O Malandro está selecionando [X] itens ou aliados para danificar.
 nonPrompt.removeItems=O Malandro está selecionando [X] itens para descartar.
 nonPrompt.decreeResolve_Recruit=O decreto das Rapinas diz que devem recrutar em <line-height=120%>\n[Suits].
 nonPrompt.decreeResolve_Move=O decreto das Rapinas diz que devem mover-se de <line-height=120%>\n[Suits].
 nonPrompt.decreeResolve_Battle=O decreto das Rapinas diz que devem batalhar em <line-height=120%>\n[Suits].
-nonPrompt.decreeResolve_Build=O decreto das Rapinas diz que devem erguer em <line-height=120%>\n[Suits].
+nonPrompt.decreeResolve_Build=O decreto das Rapinas diz que devem construir em <line-height=120%>\n[Suits].
 tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatSetup.ChooseStarting.opponent=Os Marqueses estão escolhendo onde colocar sua torre da guarda.
 tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Sawmill.opponent=Os Marqueses estão escolhendo uma clareira para sua serraria.
 tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Workshop.opponent=Os Marqueses estão escolhendo uma clareira para sua oficina.
 tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Recruiter.opponent=Os Marqueses estão escolhendo uma clareira para seu recrutador.
-tuber.canis.actions.MarquiseDeCatActions.RemoveWoodForBuilding=Selecione [X] madeiras para pagar o custo de construção ([Y]/[X]).
+tuber.canis.actions.MarquiseDeCatActions.RemoveWoodForBuilding=Escolha a madeira para gastar. ([X])
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesSetup.ChooseLeader.opponent=As Rapinas estão escolhendo um líder.
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesSetup.ChooseStarting.opponent=As Rapinas estão escolhendo uma clareira para seu ninho.
 tuber.canis.actions.VagabondActions.VagabondSetup.ChooseVagabond.opponent=O Malandro está escolhendo seu personagem.
@@ -3019,10 +3530,10 @@ tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.Sympa
 tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceDaylightAction.opponent=[player] está considerando opções...
 tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceEveningAction.opponent=[player] está considerando opções...
 tuber.canis.actions.tuber.canis.actions.WoodlandAllianceActions.Outrage.opponent=O jogador está escolhendo uma carta para adicionar aos Apoiadores da Aliança.
-tuber.canis.actions.VagabondActions.VagabondBirdsongActionRefresh.opponent=O Malandro está escolhendo itens para exaurir.
+tuber.canis.actions.VagabondActions.VagabondBirdsongActionRefresh.opponent=O Malandro está escolhendo itens para reanimar.
 tuber.canis.actions.VagabondActions.VagabondBirdsongActionSlip.opponent=O Malandro está escolhendo uma localização para deslizar.
 tuber.canis.actions.VagabondActions.AidActions.ChooseWhoToAid.opponent=O Malandro está escolhendo um jogador para ajudar.
-tuber.canis.actions.VagabondActions.ChooseQuestOption.opponent=O Malandro está escolhendo a recompensa de uma missão.
+tuber.canis.actions.VagabondActions.ChooseQuestOption.opponent=O Malandro está escolhendo a recompensa de uma tarefa.
 tuber.canis.actions.VagabondActions.VagabondDamageActionSelectionsWithAllies.opponent=O Malandro está escolhendo baixas.
 tuber.canis.actions.VagabondActions.VagabondDamageActionSelections.opponent=O Malandro está escolhendo itens para destruir.
 tuber.canis.actions.VagabondActions.DaylightChoice.opponent=[player] está considerando opções...
@@ -3035,10 +3546,10 @@ tuber.canis.actions.MarquiseDeCatActions.FieldHospitalSelection.opponent=Os Marq
 tuber.canis.actions.CostActions.ExhaustSelectedItem.opponent=[player] está escolhendo um item para exaurir.
 tuber.canis.actions.VagabondActions.AidActions.ChooseCardForAiding.opponent=O Malandro está ajudando.
 tuber.canis.abilities.MarquiseDeCatAbilities.ChooseBuilding.opponent=Os Marqueses estão escolhendo um tipo de construção.
-tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.opponent=Os Marqueses estão escolhendo uma clareira para sobrecarregar.
+tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.opponent=Os Marqueses estão escolhendo uma clareira para fazer Hora Extra.
 tuber.canis.abilities.MarquiseDeCatAbilities.BattleAbility.opponent=Os Marqueses estão escolhendo uma clareira para iniciar uma batalha.
 tuber.canis.abilities.MarquiseDeCatAbilities.BuildAbility.opponent=Os Marqueses estão escolhendo uma clareira para erguer uma construção.
-tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.Discard.opponent=Os Marqueses estão escolhendo uma carta para descartar e sobrecarregar.
+tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.Discard.opponent=Os Marqueses estão escolhendo uma carta para descartar e fazer Hora Extra.
 tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbility.opponent=Os Marqueses estão escolhendo uma clareira para recrutar um guerreiro.
 tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbilityWithCount.opponent=Os Marqueses estão escolhendo uma clareira para recrutar um guerreiro.
 tuber.canis.abilities.MarquiseDeCatAbilities.SpendBirdForAction.opponent=Os Marqueses estão escolhendo uma carta de pássaro para gastar em uma ação extra.
@@ -3048,7 +3559,7 @@ tuber.canis.abilities.VagabondAbilities.TinkerAbility.opponent=O Malandro está 
 tuber.canis.abilities.VagabondAbilities.VagabondAidAbility.opponent=O Malandro está escolhendo um jogador para ajudar.
 tuber.canis.abilities.VagabondAbilities.VagabondBattleAbility.opponent=O Malandro está escolhendo quem atacar.
 tuber.canis.abilities.VagabondAbilities.VagabondMoveAbility.opponent=O Malandro está se movendo.
-tuber.canis.abilities.VagabondAbilities.VagabondQuestAbility.opponent=O Malandro está escolhendo uma missão para completar.
+tuber.canis.abilities.VagabondAbilities.VagabondQuestAbility.opponent=O Malandro está escolhendo uma tarefa para completar.
 tuber.canis.abilities.VagabondAbilities.VagabondRepairAbility.opponent=O Malandro está escolhendo um item para reparar.
 tuber.canis.abilities.VagabondAbilities.VagabondStrikeAbility.opponent=O Malandro está escolhendo o que atacar.
 tuber.canis.abilities.WoodlandAllianceAbilities.MobilizeAbility.opponent=A Aliança da Floresta está escolhendo uma carta para adicionar aos seus Apoiadores.
@@ -3057,33 +3568,33 @@ tuber.canis.abilities.WoodlandAllianceAbilities.RevoltAbility.opponent=A Alianç
 tuber.canis.abilities.WoodlandAllianceAbilities.SpreadSympathyAbility.opponent=A Aliança da Floresta está escolhendo uma clareira para espalhar simpatia.
 tuber.canis.abilities.WoodlandAllianceAbilities.TrainAbility.opponent=A Aliança da Floresta está treinando um oficial.
 tuber.canis.abilities.WoodlandAllianceAbilities.WoodlandAllianceRecruitAbility.opponent=A Aliança da Floresta está escolhendo uma clareira para recrutar um guerreiro.
-tuber.canis.abilities.BetterBurrowBankAbility.opponent=A Aliança da Floresta está escolhendo um jogador para comprar uma carta com o Banco das Tocas.
+tuber.canis.abilities.BetterBurrowBankAbility.opponent=A Aliança da Floresta está escolhendo um jogador para comprar uma carta com o Banco Bom Bocado.
 tuber.canis.abilities.ClaimDominanceAbility.opponent=[player] está escolhendo uma carta para trocar por uma carta de domínio na loja.
 tuber.canis.abilities.CobblerAbility.opponent=[player] está usando o Sapateiro para mover.
-tuber.canis.abilities.CodeBreakersAbility.opponent=[player] está usando Decifradores de Códigos para olhar a mão de um jogador.
-tuber.canis.abilities.CommandWarrenAbility.opponent=[player] está usando o Covil do Comando para batalhar.
+tuber.canis.abilities.CodeBreakersAbility.opponent=[player] está usando Decodificadores para olhar a mão de um jogador.
+tuber.canis.abilities.CommandWarrenAbility.opponent=[player] está usando o Comando para batalhar.
 tuber.canis.abilities.CraftAbility.opponent=[player] está escolhendo uma carta para criar.
-tuber.canis.abilities.StandAndDeliverAbility.opponent=[player] está escolhendo um jogador para roubar uma carta com Parar e Entregar.
-tuber.canis.abilities.TaxCollectorAbility.opponent=[player] está escolhendo um guerreiro para sacrificar por uma carta com o Coletor de Impostos.
+tuber.canis.abilities.StandAndDeliverAbility.opponent=[player] está escolhendo um jogador para roubar uma carta com Mãos ao Alto!
+tuber.canis.abilities.TaxCollectorAbility.opponent=[player] está escolhendo um guerreiro para sacrificar por uma carta com o Coletor de Taxas.
 tuber.canis.entities.PlayableClasses.ChoosePiecesToRemove.opponent=[player] está escolhendo baixas.
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Recruit.opponent=A Dinastia das Rapinas está escolhendo uma clareira para recrutar guerreiros.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Move.opponent=A Dinastia das Rapinas está escolhendo uma clareira para marchar.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Move.opponent=A Dinastia das Rapinas está escolhendo uma clareira para mover.
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Battle.opponent=A Dinastia das Rapinas está escolhendo uma clareira para iniciar uma batalha.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Build.opponent=A Dinastia das Rapinas está escolhendo uma clareira para erguer um ninho.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Recruit.opponent=A Dinastia das Rapinas está entrando em Turbulência.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Move.opponent=A Dinastia das Rapinas está entrando em Turbulência.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Battle.opponent=A Dinastia das Rapinas está entrando em Turbulência.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Build.opponent=A Dinastia das Rapinas está entrando em Turbulência.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Build.opponent=A Dinastia das Rapinas está escolhendo uma clareira para construir um ninho.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Recruit.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Move.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Battle.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Build.opponent=A Dinastia das Rapinas está entrando em Tumulto.
 tuber.canis.actions.usecraftedcards=Ativar cartas criadas?
 tuber.canis.actions.usecraftedcards.opponent=[player] está considerando opções...
 tuber.canis.abilities.ClaimDominanceAbility.PickDominanceCard=Escolha uma carta de domínio para reivindicar.
 tuber.canis.abilities.ClaimDominanceAbility.PickDominanceCard.opponent=[player] está escolhendo uma carta de domínio.
 tuber.canis.actions.BattleActions.ChooseAmbushCards.CancelDefenderAmbush=Usar uma Emboscada para cancelar uma Emboscada inimiga correspondente?
 tuber.canis.actions.BattleActions.ChooseAmbushCards.CancelDefenderAmbush.opponent=[player] está considerando opções...
-build.turmoil.noRoosts=Não há mais ninhos em seu suprimento para erguer. <br> Continue para entrar em Turbulência.
-build.turmoil.noBuildableSpots=Não é possível erguer um Ninho em uma clareira [X] <br> porque não há espaços de construção disponíveis <br> nas clareiras que você controla nesse naipe. <br> Continue para entrar em Turbulência.
-build.turmoil.noControl=Não é possível erguer um Ninho em uma clareira [X] <br> porque você não governa nenhuma clareira nesse naipe. <br> Continue para entrar em Turbulência.
-recruit.trumoil.notEnoughWarriors=Não há mais guerreiros na reserva para recrutar. Continue para entrar em Turbulência.
+build.turmoil.noRoosts=Não há mais ninhos em seu suprimento para construir. <br> Continue para entrar em Tumulto.
+build.turmoil.noBuildableSpots=Não é possível construir um Ninho em uma clareira [X] <br> porque não há espaços de construção disponíveis <br> nas clareiras que você controla nesse naipe. <br> Continue para entrar em Tumulto.
+build.turmoil.noControl=Não é possível construir um Ninho em uma clareira [X] <br> porque você não governa nenhuma clareira nesse naipe. <br> Continue para entrar em Tumulto.
+recruit.trumoil.notEnoughWarriors=Não há mais guerreiros na reserva para recrutar. Continue para entrar em Tumulto.
 tuber.canis.actions.endTurnConfirmation.MarquiseDeCat=Ainda há ações do dia disponíveis. Tem certeza de que deseja avançar para o anoitecer?
 tuber.canis.actions.endTurnConfirmation.WoodlandAlliance=Ainda há ações disponíveis. Tem certeza de que deseja encerrar seu turno?
 lobby.resign.confirmation=Tem certeza de que deseja desistir deste jogo?
@@ -3091,10 +3602,10 @@ lobby.gamecompleted={0} foi concluído.
 tutorial.completedbody=O tutorial foi concluído. Coloque seus conhecimentos à prova no modo Desafio?
 tutorial.completedheader=Tutorial concluído!
 tuber.canis.entities.discardpile=PILHA DE DESCARTE
-recruit.trumoil.notEnoughWarriors.opponent=A Dinastia das Rapinas está entrando em Turbulência.
-build.turmoil.noRoosts.opponent=A Dinastia das Rapinas está entrando em Turbulência.
-build.turmoil.noBuildableSpots.opponent=A Dinastia das Rapinas está entrando em Turbulência.
-build.turmoil.noControl.opponent=A Dinastia das Rapinas está entrando em Turbulência.
+recruit.trumoil.notEnoughWarriors.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+build.turmoil.noRoosts.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+build.turmoil.noBuildableSpots.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+build.turmoil.noControl.opponent=A Dinastia das Rapinas está entrando em Tumulto.
 tuber.canis.actions.EyrieDynastiesActions.RestoreEyrieChoice=Escolha uma clareira para colocar um ninho e 3 guerreiros.
 tuber.canis.actions.EyrieDynastiesActions.RestoreEyrieChoice.opponent=A Dinastia das Rapinas está escolhendo uma clareira para colocar um ninho e 3 guerreiros.
 tuber.canis.actions.tuber.canis.actions.automateactions.outrage=Escolha uma carta para adicionar aos apoiadores da Aliança Automatizada.
@@ -3105,12 +3616,12 @@ mechanicalmarquise.score.buildings={0} Construções
 direbytes.header=Notícias do Lobo Terrível
 direbytes.none=Sem Notícias do Lobo Terrível
 tuber.canis.undo.endturnconfirmation=Pressione o botão continuar para encerrar o turno.
-tuber.canis.undo.marquiseDeCatSetupUndo=Pressione o botão continuar para concluir a configuração.
-tuber.canis.undo.vagabondSetupUndo=Pressione o botão continuar para concluir a configuração.
+tuber.canis.undo.marquiseDeCatSetupUndo=Pressione o botão continuar para concluir a preparação.
+tuber.canis.undo.vagabondSetupUndo=Pressione o botão continuar para concluir a preparação.
 direbytes.link=Link
 tuber.canis.undo.endturnconfirmation.opponent=Aguardando o oponente passar o turno.
-tuber.canis.undo.marquiseDeCatSetupUndo.opponent=Aguardando os Marqueses confirmarem a configuração.
-tuber.canis.undo.vagabondSetupUndo.opponent=Aguardando o Malandro confirmar a configuração.
+tuber.canis.undo.marquiseDeCatSetupUndo.opponent=Aguardando os Marqueses confirmarem a preparação.
+tuber.canis.undo.vagabondSetupUndo.opponent=Aguardando o Malandro confirmar a preparação.
 prompts.productunlock.cosmetic.title={0}
 prompts.productunlock.cosmetic.description={0} foi desbloqueado para sua conta.
 tuber.canis.actions.DrawThenDiscard.NoActions=Não há mais cartas para descartar. Pressione o botão continuar.
@@ -3155,21 +3666,22 @@ prompt.advancedsetup.corvidconspiracy.plot=Coloque um plano oculto em sua clarei
 prompt.advancedsetup.corvidconspiracy.plot.opponent=[player] está escolhendo um plano para sua clareira de origem.
 prompt.advancedsetup.undergroundduchy.homeland=Escolha uma clareira de origem que não seja adjacente às clareiras de origem inimigas e coloque 2 guerreiros e um Túnel lá.
 prompt.advancedsetup.undergroundduchy.homeland.opponent=[player] está escolhendo uma clareira de origem.
-tuber.canis.actions.CharmOffensiveInformants=Substituir compra de Carta Ofensiva Encantada por Informantes ou continuar.
+tuber.canis.actions.CharmOffensiveInformants=Substituir compra de Carta Charme Ofensivo por Informantes ou continuar.
+tuber.canis.actions.CharmOffensiveInformants.opponent=[player] está considerando as opções.
 prompt.challenges.sectionheader.standard=Padrão
 prompt.controllersupport.enable=Detectamos uma entrada de controle. Deseja habilitar o suporte para gamepad?
-store.product.clockwork.name=A Expansão Mecânica
+store.product.clockwork.name=A Expansão Autômata
 store.product.clockwork.description=Quatro facções automatizadas traiçoeiras oferecem uma alternativa desafiadora e personalizável à IA. O novo modo cooperativo permite que os jogadores formem equipes para enfrentar poderosos oponentes automatizados!
 store.product.clockwork.shortdescription=Quatro facções automatizadas e modo cooperativo!
-store.product.clockwork.storedescription=Tique...taque...tique...taque...<br><br>A batalha pela floresta selvagem entra em ação com a Expansão Mecânica!<br><br>Quatro facções inimigas automatizadas e traiçoeiras trazem novos desafios ao Root em uma alternativa personalizável à IA do jogo! Você consegue superar a ameaça mecânica e garantir seu direito de governar a floresta?<br><br>Introduz o Modo Cooperativo! Forme equipes para enfrentar poderosos oponentes automatizados!<br><br> Marquês Mecânico 2.0<br>Este é o mais simples dos bots e pode ser usado para completar a contagem de jogadores em dezenas de configurações. Embora este bot seja direto, não se acomode. Pelo menos um jogador precisará mantê-lo sob controle!<br><br>Rapinas Elétricas<br>As Rapinas Elétricas vão inspirar medo até mesmo nos jogadores mais resistentes. Assim como a Dinastia das Rapinas, esse bot pode aumentar rapidamente seu potencial de ações.<br><br>Aliança Automatizada<br>A Aliança Automatizada é especialmente zelosa e se revoltará com frequência. Fique atento aos alvos em potencial para evitar surpresas desagradáveis. Uma vez que eles estabelecem uma base, o tempo é crucial. Não deixe que consolidem seus guerreiros ou você terá problemas!<br><br>Automalandro<br>O Automalandro pode ser um amigo ou inimigo imprevisível. Assim como um jogador humano, ele recompensará aqueles que criarem itens. Mas cuidado, ele pode se tornar um inimigo perigoso quando conseguir itens suficientes para aumentar seu dano máximo.
+store.product.clockwork.storedescription=Tique...taque...tique...taque...<br><br>A batalha pela floresta selvagem entra em ação com a Expansão Autômata!<br><br>Quatro facções inimigas automatizadas e traiçoeiras trazem novos desafios ao Root em uma alternativa personalizável à IA do jogo! Você consegue superar a ameaça mecânica e garantir seu direito de governar a floresta?<br><br>Introduz o Modo Cooperativo! Forme equipes para enfrentar poderosos oponentes automatizados!<br><br> Marquês Mecânico 2.0<br>Este é o mais simples dos bots e pode ser usado para completar a contagem de jogadores em dezenas de configurações. Embora este bot seja direto, não se acomode. Pelo menos um jogador precisará mantê-lo sob controle!<br><br>Rapinas Elétricas<br>As Rapinas Elétricas vão inspirar medo até mesmo nos jogadores mais resistentes. Assim como a Dinastia das Rapinas, esse bot pode aumentar rapidamente seu potencial de ações.<br><br>Aliança Automatizada<br>A Aliança Automatizada é especialmente zelosa e se revoltará com frequência. Fique atento aos alvos em potencial para evitar surpresas desagradáveis. Uma vez que eles estabelecem uma base, o tempo é crucial. Não deixe que consolidem seus guerreiros ou você terá problemas!<br><br>Automalandro<br>O Automalandro pode ser um amigo ou inimigo imprevisível. Assim como um jogador humano, ele recompensará aqueles que criarem itens. Mas cuidado, ele pode se tornar um inimigo perigoso quando conseguir itens suficientes para aumentar seu dano máximo.
 store.verificationFailed=A integridade do DLC não pôde ser verificada. Reinicie com uma conexão à internet para validar.
 store.restorePurchases=Restaurar Compras
 store.restorePurchasesError.default=Ocorreu um erro. Verifique sua conexão com a internet e tente novamente.
 store.product.wintermap.name=O Mapa de Inverno
-store.product.riverfolk.name=A Expansão Riverfolk
-store.product.riverfolk.description=Duas novas facções entram na briga! A Companhia Ribeirinha e o Culto dos Lagartos trazem novas estratégias à batalha pelo domínio da floresta. <br><br>Três novos Malandros - o Patife, o Vagante e o Árbitro - ajudam você a vencer com astúcia!
+store.product.riverfolk.name=A Expansão Ribeirinhos
+store.product.riverfolk.description=Duas novas facções entram na briga! A Companhia Ribeirinha e os Lagartos Cultistas trazem novas estratégias à batalha pelo domínio da floresta. <br><br>Três novos Malandros - o Patife, o Vagabundo e o Árbitro - ajudam você a vencer com astúcia!
 store.product.riverfolk.shortdescription=A Companhia Ribeirinha chega ao Root! Duas novas facções entram na briga!
-store.product.riverfolk.storedescription=Duas novas facções e variantes do Malandro trazem novos desafios ao Root! <br><br>Companhia Ribeirinha<br>A Companhia Ribeirinha está aberta para negócios – a floresta pode estar em guerra, mas não há razão para não lucrar! Estabeleça postos de comércio e conquiste sua vitória! <br><br>Culto dos Lagartos<br>Espalhe o evangelho escamoso do Culto dos Lagartos! Cultive seus jardins para radicalizar novos acólitos e revele o verdadeiro poder de seu proselitismo! <br><br>Novas Variantes do Malandro!<br>Três novos Malandros espreitam a floresta para ajudá-lo a vencer com astúcia! O Patife incendeia a floresta em vez de deixá-la nas mãos de outros; o Vagante inicia batalhas que outros precisam terminar; e o Árbitro oferece seus serviços... por um preço, é claro! <br><br>Novos Desafios!<br>Novos cenários para um jogador e tutoriais ajudam você a aprender as artimanhas dos mais recentes guerreiros da floresta!
+store.product.riverfolk.storedescription=Duas novas facções e variantes do Malandro trazem novos desafios ao Root! <br><br>Companhia Ribeirinha<br>A Companhia Ribeirinha está aberta para negócios – a floresta pode estar em guerra, mas não há razão para não lucrar! Estabeleça postos de comércio e conquiste sua vitória! <br><br>Lagartos Cultistas<br>Espalhe o evangelho escamoso dos Lagartos Cultistas! Cultive seus jardins para radicalizar novos acólitos e revele o verdadeiro poder de seu proselitismo! <br><br>Novas Variantes do Malandro!<br>Três novos Malandros espreitam a floresta para ajudá-lo a vencer com astúcia! O Patife incendeia a floresta em vez de deixá-la nas mãos de outros; o Vagabundo inicia batalhas que outros precisam terminar; e o Árbitro oferece seus serviços... por um preço, é claro! <br><br>Novos Desafios!<br>Novos cenários para um jogador e tutoriais ajudam você a aprender as artimanhas dos mais recentes guerreiros da floresta!
 code.redeem.CodeRedeemed=Código Resgatado!
 code.redeem.error.NoDefinition=O código não possui uma definição associada.
 code.redeem.error.CodeNotFound=Código não encontrado.
@@ -3183,25 +3695,26 @@ code.redeem.error.RedemptionEnded=O período de validade do código terminou.
 code.redeem.equip.immediate=Código resgatado! Gostaria de equipar o cosmético agora?
 code.redeem.error.ios=O código não pode ser resgatado no iOS. Por favor, visite nosso site para resgatar o código em...
 code.redeem.error.NoLoggedIn=O código não pode ser resgatado. Faça login ou crie uma conta.
-store.product.cosmetic.eyrie.emigre.name=Skin Premium de Emigrante das Rapinas
+store.product.cosmetic.eyrie.emigre.name=Skin Premium Imigrante Rapina
+store.product.cosmetic.marquise.marquiseinboots.name=Skin Premium Marqueses de Botas
 store.login.warning.description=Se pretende jogar em várias plataformas, faça login em sua conta antes de comprar.
-expansion.exiles.name=O Baralho de Exilados e Partidários
+expansion.exiles.name=O Baralho Exilados e Partisans
 store.purchase.error.invalidregion=Este produto ainda não está disponível em sua região.
-store.product.miniexpansion.name=Exilados & Partidários & Malandros
-store.product.miniexpansion.description=Três novos Malandros estão espreitando pela floresta!<br>Além de um baralho totalmente novo para uma floresta ainda mais selvagem!<br>Contém o Pacote de Malandros e o Baralho de Exilados e Partidários.
-store.product.underworldexpansion.name=A Expansão do Subterrâneo
+store.product.miniexpansion.name=Exilados & Partisans & Malandros
+store.product.miniexpansion.description=Três novos Malandros estão espreitando pela floresta!<br>Além de um baralho totalmente novo para uma floresta ainda mais selvagem!<br>Contém o Pacote de Malandros e o Baralho Exilados e Partisans.
+store.product.underworldexpansion.name=A Expansão Submundo
 store.product.underworldexpansion.description=Conquiste novos campos de batalha enquanto você explora o Subterrâneo de Root!<br>Contém as facções Ducado Subterrâneo e Conspiração Corvídea, além dos mapas da Montanha e do Lago!
-store.product.maraudersexpansion.name=A Expansão dos Saqueadores <br>(Com Contratados de Bônus!)
-store.product.maraudersexpansion.description=Root: A Expansão dos Saqueadores introduz duas novas facções à Floresta⁠—o Senhor das Centenas e os Guardiões de Ferro—junto com sete facções menores que podem ser controladas por qualquer jogador, chamadas de contratados. <br><br>Ideal para menos jogadores, mas ótima com mais!
-store.product.maraudersexpansion.name.short=A Expansão dos Saqueadores
+store.product.marauderexpansion.name=A Expansão Saqueadores
+store.product.marauderexpansion.description=Duas novas facções!<br>Senhor das Centenas – Oprima a Floresta e queime-a até o chão se necessário. Você não sofre dissidência.<br>Guardiões de Ferro – Lidere sua ordem exilada de cavaleiros devotos para a batalha para recuperar relíquias antigas. Para a glória!
+store.product.marauderexpansion.name.short=A Expansão Saqueadores
 Log.Eyrie.Selects.Character=<color=#3a63cb>Dinastia das Rapinas</color> seleciona [name] como seu líder, adicionando um <sprite name="birdicon"> aos decretos [area1] e [area2].
-Log.Eyrie.Selects.Roost=[faction name] ergue seu Ninho das Rapinas inicial em uma clareira de [suit icon].
+Log.Eyrie.Selects.Roost=[faction name] erguem seu Ninho inicial em uma clareira de [suit icon].
 Log.Vagabond.Character=[faction name] escolhe [name] como seu personagem.
 Log.Keep.Choice=[faction name] coloca sua Torre da Guarda em uma clareira de [suit icon].
 Log.SetupBuilding.Choice=[faction name] coloca seu [piece] em uma clareira de [suit icon].
 Log.Start.Game=Início do Jogo
 Log.Start.Turn=Turno de [faction name]
-Log.Birdsong=<sprite name="Birdsong">Alvorada
+Log.Birdsong=<sprite name="Birdsong">Amanhecer
 Log.Daylight=<sprite name="Daylight">Dia
 Log.Evening=<sprite name="Evening">Anoitecer
 Log.initiate.battle=[faction name] inicia uma batalha contra [faction name 2] em uma clareira de [suit icon].
@@ -3225,31 +3738,31 @@ Log.Aid=[faction name] exaure um [item icon] para ajudar [faction name 2] com um
 Log.Aid.Item=[faction name] recebe um [item icon] em troca pela ajuda.
 Log.Slip.Clearing=[faction name] desliza para uma clareira de [suit icon].
 Log.Slip.Forest=[faction name] desliza para uma floresta.
-Log.Quest=[faction name] exaure [item icon] e [item icon 2] para completar a missão [name].
-Log.Quest.Draw.Reward=[faction name] compra 2 cartas como recompensa da missão.
-Log.Quest.Point.Reward=[faction name] pontua [X] <style="vptext">PV</style> como recompensa da missão.
+Log.Quest=[faction name] exaure [item icon] e [item icon 2] para completar a tarefa [name].
+Log.Quest.Draw.Reward=[faction name] compra 2 cartas como recompensa da tarefa.
+Log.Quest.Point.Reward=[faction name] pontua [X] <style="vptext">PV</style> como recompensa da tarefa.
 Log.Relationship.1=[faction name] aumenta sua relação com [faction name 2] para nível 1, ganhando 1 <style="vptext">PV</style>.
 Log.Relationship.2=[faction name] aumenta sua relação com [faction name 2] para nível 2, ganhando 2 <style="vptext">PV</style>.
 Log.Relationship.3=[faction name] aumenta sua relação com [faction name 2] para aliado, ganhando 2 <style="vptext">PV</style>.
 Log.Relationship.Hostile=[faction name] torna-se hostil à [faction name 2].
-Log.Refresh=[faction name] refresca os seguintes itens na Alvorada: [items].
+Log.Refresh=[faction name] reanima os seguintes itens no Amanhecer: [items].
 Log.Explore=[faction name] explora uma ruína em uma clareira de [suit icon]. Eles ganham 1 <style="vptext">PV</style> e obtêm um [item icon].
 Log.Strike=[faction name] ataca um [piece] de [faction name 2] em uma clareira de [suit icon].
 Log.Repair=[faction name] exaure <sprite name="hammer"> para reparar [item icon].
 Log.Evenings.Rest=[faction name] repara todos os itens com Descanso do Anoitecer.
-Log.Satchel.Discard=[faction name] remove os seguintes itens de sua bolsa por estar sobrecarregada: [items].
+Log.Satchel.Discard=[faction name] remove os seguintes itens de sua mochila por estar sobrecarregada: [items].
 Log.Steal=[faction name] usa Roubo, exaurindo <sprite name="torch"> para pegar uma carta aleatória de [faction name 2].
 Log.Hideout=[faction name] usa Esconderijo, exaurindo <sprite name="torch"> para reparar [items]. Isso encerra o dia.
-Log.Day.Labor=[faction name] usa Trabalho Diário, exaurindo <sprite name="torch"> para pegar uma carta da pilha de descarte e colocá-la na mão.
+Log.Day.Labor=[faction name] usa Dia de Trabalho, exaurindo <sprite name="torch"> para pegar uma carta da pilha de descarte e colocá-la na mão.
 Log.Move.Vagabond=[faction name] exaure <sprite name="boot"> para mover-se para uma clareira de [suit icon].
 Log.Vagabond.item.damage.gen=[faction name] danifica os seguintes itens: [items].
 Log.Enter.Coalition=[faction name] entra em uma Coalizão com [faction name 2].
 Log.Move.Buddy=[faction name] move-se com [X] guerreiros de [faction name 2].
-Log.Outrage=[faction name] causa indignação, adicionando uma carta aos apoiadores da <color=#008D3F>Aliança da Floresta</color>.
-Log.Outrage.reveal=[faction name 2] revela sua mão para [faction name] devido à indignação. [faction name] adiciona uma carta do baralho aos seus apoiadores.
-Log.Outrage.reveal.rootbot=[faction name 2] não tem cartas na mão para revelar a [faction name] devido à indignação. [faction name] adiciona uma carta do baralho aos seus apoiadores.
-Log.Outrage.reveal.nocarddrawn=[faction name 2] revela sua mão para [faction name] devido à indignação. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
-Log.Outrage.reveal.rootbot.nocarddrawn=[faction name 2] não tem cartas na mão para revelar a [faction name] devido à indignação. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
+Log.Outrage=[faction name] causa Ultraje, adicionando uma carta aos apoiadores da <color=#008D3F>Aliança da Floresta</color>.
+Log.Outrage.reveal=[faction name 2] revela sua mão para [faction name] devido ao Ultraje. [faction name] adiciona uma carta do baralho aos seus apoiadores.
+Log.Outrage.reveal.rootbot=[faction name 2] não tem cartas na mão para revelar a [faction name] devido ao Ultraje. [faction name] adiciona uma carta do baralho aos seus apoiadores.
+Log.Outrage.reveal.nocarddrawn=[faction name 2] revela sua mão para [faction name] devido ao Ultraje. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
+Log.Outrage.reveal.rootbot.nocarddrawn=[faction name 2] não tem cartas na mão para revelar a [faction name] devido ao Ultraje. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
 Log.Revolt.Intro=[faction name] inicia uma revolta em uma clareira de [suit icon].
 Log.Revolt.destruction=[faction name] perdeu [pieces].
 Log.Revolt.additions=[faction name] ganha um oficial e [X] guerreiros.
@@ -3259,12 +3772,12 @@ Log.Organize=[faction name] usa Organizar para sacrificar um guerreiro por simpa
 Log.Organize.AutomatedAlliance=[faction name] usa Organizar para sacrificar todos os guerreiros em uma clareira de [suit icon] para espalhar simpatia, pontuando [X] <style="vptext">PV</style>.
 Log.Train=[faction name] treina um oficial.
 Log.Lost.base=Como uma base da <color=#008D3F>Aliança da Floresta</color> foi removida, eles perdem [X] oficiais e descartam [X2] apoiadores correspondentes.
-Log.Generate.Wood=[faction name] gerou [X] madeira durante a Alvorada.
-Log.Overwork=[faction name] usou Sobrecarregar para descartar uma carta de [suit icon] por 1 madeira.
-Log.Field.Hospitals=[faction name] usou Hospitais de Campanha para devolver [X] guerreiros caídos à sua Torre da Guarda.
-Log.Hawks=[faction name] descarta uma carta <sprite name="birdicon"> para realizar uma ação extra.
+Log.Generate.Wood=[faction name] geraram [X] madeira durante o Amanhecer.
+Log.Overwork=[faction name] usaram Hora Extra para descartar uma carta de [suit icon] por 1 madeira.
+Log.Field.Hospitals=[faction name] usaram Hospitais de Campanha para devolver [X] guerreiros caídos à sua Torre da Guarda.
+Log.Hawks=[faction name] descartam uma carta <sprite name="birdicon"> para realizar uma ação extra.
 Log.Decree.Assignment=[faction name] atribui [suit icon] ao seu decreto de [name].
-Log.Special.Birdsong.Draw=[faction name] compra uma carta durante a Alvorada porque sua mão estava vazia.
+Log.Special.Birdsong.Draw=[faction name] compra uma carta durante o Amanhecer porque sua mão estava vazia.
 Log.Special.Birdsong.Roost=[faction name] coloca um ninho e 3 guerreiros em uma clareira de [suit icon] porque não tinha ninhos.
 Log.Turmoil.recruit=[faction name] entra em tumulto porque não conseguiu recrutar em uma clareira de [suit icon].
 Log.Turmoil.move=[faction name] entra em tumulto porque não conseguiu se mover em uma clareira de [suit icon].
@@ -3280,19 +3793,19 @@ Log.Commander.hit=[faction name] causa um acerto adicional com a habilidade de C
 Log.Favor.Craft=[faction name] cria [name] para remover todas as peças inimigas em clareiras de [suit icon].
 Log.Dominance=[faction name] joga uma carta de domínio para mudar sua condição de vitória.
 Log.Armorers=[faction name] descarta Armeiros para ignorar acertos rolados.
-Log.Sappers=[faction name] descarta Sapadores para causar um acerto adicional.
+Log.Sappers=[faction name] descarta Armadilheiros para causar um acerto adicional.
 Log.BrutalTactics=[faction name] usa Táticas Brutais para causar um acerto adicional. O defensor pontua 1 <style="vptext">PV</style>.
 Log.RoyalClaim=[faction name] descarta Reivindicação Real para pontuar 1 <style="vptext">PV</style> para cada clareira que governa. Eles pontuam [X] <style="vptext">PV</style>.
-Log.StandandDeliver=[faction name] usa "Entregue ou Sofra!" para pegar uma carta aleatória de [faction name 2]. Esse jogador pontua 1 <style="vptext">PV</style>.
-Log.TaxCollector=[faction name] usa Coletor de Impostos para remover um guerreiro e comprar uma carta.
-Log.CommandWarren=[faction name] usa Comando Warren para iniciar uma batalha contra [faction name 2] em uma clareira de [suit icon].
-Log.BetterBurrowBank=[faction name] usa Banco de Túneis Melhorado para comprar uma carta junto com [faction name 2].
+Log.StandandDeliver=[faction name] usa "Mãos ao Alto!" para pegar uma carta aleatória de [faction name 2]. Esse jogador pontua 1 <style="vptext">PV</style>.
+Log.TaxCollector=[faction name] usa Coletor de Taxas para remover um guerreiro e comprar uma carta.
+Log.CommandWarren=[faction name] usa Comando para iniciar uma batalha contra [faction name 2] em uma clareira de [suit icon].
+Log.BetterBurrowBank=[faction name] usa Banco Bom Bocado para comprar uma carta junto com [faction name 2].
 Log.Cobbler=[faction name] usa Sapateiro para se mover.
-Log.Codebreakers=[faction name] usa Quebradores de Código para olhar a mão de [faction name 2].
+Log.Codebreakers=[faction name] usa Decodificadores para olhar a mão de [faction name 2].
 log.order=[faction name] revela [suit icon] como sua ordem.
 log.given.card=[faction name] descarta a carta que recebeu de [faction name 2] e pontua 1 <style="vptext">PV</style>.
 log.nightmare.score=[faction name] pontua 1 <style="vptext">PV</style> pela dificuldade Pesadelo.
-log.escalated.daylight=Alvorada Escalonada
+log.escalated.daylight=Dia Expandido
 log.expand=A <color=#CC6633>Marquês Mecânico</color> se expande, comprando uma nova ordem e repetindo o Dia.
 log.evening.score=<color=#CC6633>Marquês Mecânico</color> pontua [X] <style="vptext">PV</style> de sua trilha de construções.
 log.trait.blitz=<color=#CC6633>Marquês Mecânico</color> usa seu traço Blitz para se mover e batalhar.
@@ -3305,8 +3818,8 @@ log.setup.electric.eyrie=<color=#3a63cb>Rapinas Elétricas</color> adicionam [X]
 log.battle.extrahit=<color=#3a63cb>Rapinas Elétricas</color> causam um acerto extra por ter mais cartas atribuídas à coluna ordenada de seu decreto do que qualquer outra.
 log.public.pity=<color=#008D3F>Aliança Automatizada</color> usa Comiseração Pública para espalhar simpatia [X] vezes.
 log.crackdown=<color=#008D3F>Aliança Automatizada</color> perde todos os marcadores de simpatia em clareiras que correspondem ao naipe da base destruída devido à Repressão.
-Log.automated.Outrage=[faction name] causa Indignação, descartando uma carta.
-Log.automated.Outrage.vp=[faction name] causa Indignação, mas não tem uma carta correspondente. <color=#008D3F>Aliança Automatizada</color> pontua 1 <style="vptext">PV</style>.
+Log.automated.Outrage=[faction name] causa Ultraje, descartando uma carta.
+Log.automated.Outrage.vp=[faction name] causa Ultraje, mas não tem uma carta correspondente. <color=#008D3F>Aliança Automatizada</color> pontua 1 <style="vptext">PV</style>.
 log.automated.ambush=<color=#008D3F>Aliança Automatizada</color> causa um acerto extra com sua habilidade Emboscada Automatizada.
 log.trait.wildfire=<color=#008D3F>Aliança Automatizada</color> espalha simpatia para uma clareira de [suit icon], mas não pontua com seu traço Incêndio.
 log.generic.exhaust.item=<color=#436979>Automalandro</color> exaure [X] itens.
@@ -3314,15 +3827,15 @@ log.battletrack=<color=#436979>Automalandro</color> adiciona um item à sua tril
 log.trait.marksmen=<color=#436979>Automalandro</color> causa um acerto imediato usando seu traço Atirador.
 log.trait.helper=O <color=#436979>Automalandro</color> pontua 1 <style="vptext">PV</style> com seu traço Ajudante, e o jogador ajudado compra uma carta adicional.
 log.vagabot.steal=<color=#436979>Automalandro</color> exaure um item para usar sua habilidade Roubo, pegando uma carta aleatória de [faction name].
-log.vagabot.daylabor=<color=#436979>Automalandro</color> exaure um item para usar sua habilidade Trabalho Diário, criando [name] do monte de descarte e pontuando 1 <style="vptext">PV</style>.
+log.vagabot.daylabor=<color=#436979>Automalandro</color> exaure um item para usar sua habilidade Dia de Trabalho, criando [name] do monte de descarte e pontuando 1 <style="vptext">PV</style>.
 log.vagabot.hideout=<color=#436979>Automalandro</color> exaure um item para usar sua habilidade Esconderijo, deslizando para uma floresta.
 log.vagabot.explore=<color=#436979>Automalandro</color> move [X] espaços para uma clareira de [suit icon] com uma ruína para explorá-la. Ele exaure [X] itens, pega um [item icon] da ruína e pontua 1 <style="vptext">PV</style>.
-log.vagabot.quest=<color=#436979>Automalandro</color> move [X] espaços para uma clareira de [suit icon] para completar sua missão. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova missão.
-log.vagabot.evening.refresh=<color=#436979>Automalandro</color> refresca: [items]
+log.vagabot.quest=<color=#436979>Automalandro</color> move [X] espaços para uma clareira de [suit icon] para completar sua tarefa. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova tarefa.
+log.vagabot.evening.refresh=<color=#436979>Automalandro</color> reanima: [items]
 log.vagabot.evening.repair=<color=#436979>Automalandro</color> repara: [items]
 log.aiswap.timeout=[name] ficou inativo e foi substituído por uma IA.
 log.aiswap.resign=[name] desistiu e foi substituído por uma IA.
-key.roost=Ninho das Rapinas
+key.roost=Ninho
 Log.vagabot.aid=<color=#436979>Automalandro</color> exaure [X] itens para ajudar [faction name] com [X] cartas do baralho. Automalandro recebe [items] em troca e ganha [X] <style="vptext">PV</style>.
 Log.automated.Sympathy=<color=#008D3F>Aliança Automatizada</color> espalha simpatia para uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
 log.steal.clockwork=<color=#436979>Malandro</color> recebe uma carta do baralho em vez disso.
@@ -3343,7 +3856,7 @@ Log.Move.Buddy.one=[faction name] se move com 1 guerreiro de [faction name 2].
 log.public.pity.one=<color=#008D3F>Aliança Automatizada</color> usa Comiseração Pública para espalhar simpatia 1 vez.
 Log.trait.Hospitals.one=<color=#CC6633>Marquês Mecânico</color> usa seu traço Hospital para devolver 1 guerreiro caído à sua Torre da Guarda.
 Log.Sympathy.one=[faction name] gasta 1 simpatizante para espalhar simpatia para uma clareira de [suit icon], pontuando [X2] <style="vptext">PV</style>.
-log.vagabot.quest.one=<color=#436979>Automalandro</color> move 1 espaço para uma clareira de [suit icon] para completar sua missão. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova missão.
+log.vagabot.quest.one=<color=#436979>Automalandro</color> move 1 espaço para uma clareira de [suit icon] para completar sua tarefa. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova tarefa.
 log.hatch=<color=#3a63cb>Dinastia das Rapinas</color> choca um guerreiro a partir de um ovo em uma clareira de [suit icon].
 log.multi.hatch=<color=#3a63cb>Dinastia das Rapinas</color> choca [X] guerreiros a partir de ovos em uma clareira de [suit icon].
 log.break=[faction name] quebra um ovo por <style="vpnum">1</style> em uma clareira de [suit icon].
@@ -3355,9 +3868,9 @@ log.raid=Uma Emboscada é removida, fazendo com que a Conspiração Corvídea ad
 log.player.won=[faction name] Vence!
 scenario.journeytothenorth.name=Jornada ao Norte
 scenario.journeytothenorth.tier1description=Governe as 4 clareiras mais ao norte para vencer (não é necessário pontuar pontos de vitória).
-scenario.town.name=Cidade do Tinker
-scenario.town.tier1description=O baralho de cartas contém apenas itens e o suprimento é ilimitado. Você começa como o Engenheiro.
-scenario.town.tier2description=O baralho de cartas contém apenas itens e o suprimento é ilimitado. Você começa como o Engenheiro e não pode usar missões. Os oponentes começam com <style="vpnum">5</style>.
+scenario.town.name=Cidade do Funileiro
+scenario.town.tier1description=O baralho de cartas contém apenas itens e o suprimento é ilimitado. Você começa como o Funileiro.
+scenario.town.tier2description=O baralho de cartas contém apenas itens e o suprimento é ilimitado. Você começa como o Funileiro e não pode completar tarefas. Os oponentes começam com <style="vpnum">5</style>.
 scenario.delivery.name=Coletor de Ovos
 scenario.delivery.tier1description=No início do seu turno, ovos aparecem em clareiras aleatórias. Quando você se move para uma clareira com um ovo, ele choca e vira um guerreiro das Rapinas. No início do turno de cada oponente, eles quebram um ovo na clareira onde estão por <style="vpnum">1</style>.
 scenario.delivery.tier2description=No início do seu turno, ovos aparecem em clareiras aleatórias. Quando você se move para uma clareira com um ovo, ele choca e vira um guerreiro das Rapinas. No início do turno de cada oponente, eles quebram um ovo na clareira onde estão por <style="vpnum">1</style>. Você começa com apenas 2 guerreiros.


### PR DESCRIPTION
Tradução revisada e corrigida:

- Extensão Marauders completamente traduzida
- Termos do jogo localizados conforme a tradução oficial do boardgame (MeepleBR)
- Cartas do Baralho Compartilhado traduzidas conforme o baralho oficial (levando em consideração o baralho Exilados & Partisans)
- Todas as facções foram revisadas para mostrar os nomes corretos de habilidades e nomes de ações conforme a tradução oficial
- Mudanças realizadas no Patch 1.33 também foram traduzidas