### PR TITLE
Revisão de bugs e maiores mudanças

### DIFF
--- a/translate/pt-BR/strings_pt_BR.txt
+++ b/translate/pt-BR/strings_pt_BR.txt
@@ -367,16 +367,16 @@ playerinfo.autoalliance.autoambush=Em combate como defensor com qualquer guerrei
 playerinfo.autoalliance.autoambushtitle=Emboscada Automatizada
 playerinfo.autoalliance.autooutrage=Sempre que um humano remover um marcador de simpatia ou mover guerreiros para uma clareira simpática, ele deve descartar uma carta correspondente. Se não puder, você ganha +1 .
 playerinfo.autoalliance.autooutragetitle=Ultraje Automatizado
-playerinfo.autoalliance.Birdsong=1º: Revele uma carta de ordem.<br><br>2º: Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><br>3º: Revolta<br>Remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas e coloque a base ordenada lá. Se a carta de ordem for um <sprite name="birdicon">, faça isso durante o Amanhecer.<br><br>4º: Piedade Pública<br>Se você não se revoltou neste turno, espalhe simpatia duas vezes se tiver quatro ou menos clareiras simpáticas ou espalhe simpatia uma vez se tiver cinco ou mais.
-playerinfo.autoalliance.daylight=1º: Espalhar Simpatia<br>Coloque um marcador de simpatia na clareira ordenada com menos guerreiros inimigos adjacente a qualquer clareira simpática. Se não houver tal clareira, em vez disso, coloque simpatia na clareira com menos peças inimigas. Se não puder colocar um marcador de simpatia, ganhe <style="vpnum">5 .<br><br>2º: Revolta Surpresa<br>Se a carta de ordem for um <sprite name="birdicon">, revolte em uma clareira que corresponda ao naipe de uma base não utilizada.
+playerinfo.autoalliance.Birdsong=1º: Revele uma carta de ordem.<br><br>2º: Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><br>3º: Revolta<br>Remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas e coloque a base ordenada lá. Se a carta de ordem for um <sprite name="birdicon">, faça isso durante o Amanhecer.<br><br>4º: Pena Pública<br>Se você não se revoltou neste turno, espalhe simpatia duas vezes se tiver quatro ou menos clareiras simpáticas ou espalhe simpatia uma vez se tiver cinco ou mais.
+playerinfo.autoalliance.daylight=1º: Distribua Simpatia<br>Coloque um marcador de simpatia na clareira ordenada com menos guerreiros inimigos adjacente a qualquer clareira simpática. Se não houver tal clareira, em vez disso, coloque simpatia na clareira com menos peças inimigas. Se não puder colocar um marcador de simpatia, ganhe <style="vpnum">5 .<br><br>2º: Revolta Surpresa<br>Se a carta de ordem for um <sprite name="birdicon">, revolte em uma clareira que corresponda ao naipe de uma base não utilizada.
 playerinfo.autoalliance.evening=1º: Organizar<br>Em cada clareira com uma base e três ou mais guerreiros da Aliança, remova todos os guerreiros da Aliança lá e espalhe simpatia.<br><br>2º: Recrutar<br>Coloque um guerreiro em cada clareira com uma base.
 playerinfo.autoalliance.title=Aliança Automatizada
 playerinfo.Birdsong=Amanhecer
 playerinfo.craftedcards=Cartas Criadas
 playerinfo.crafteditems=Itens Criados
 playerinfo.daylight=Dia
-playerinfo.electriceyrie.Birdsong=<b>1º:</b> Revele uma carta de ordem.<br><b>2º:</b> Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><b>3º:</b> Adicione a carta de ordem à coluna correspondente do Decreto.
-playerinfo.electriceyrie.daylight=<b>1º:</b> Resolva o Decreto—recrute para cada coluna com pelo menos uma carta da esquerda para a direita, depois mova dessa forma e então combata dessa forma.<br><br>    <b>-Recrutar -</b> Recrute guerreiros, igual ao número de cartas nessa coluna, em uma clareira correspondente com um ninho.<br><br>        -Empates de Clareira - Recrute em tal clareira com mais peças inimigas, depois menos guerreiros Rapinas, depois menor prioridade.<br><br>    <b>-Mover</b> - Mova da clareira correspondente que você governa com mais guerreiros Rapinas. Mova para uma clareira adjacente sem ninho—se todas tiverem ninho, mova para a com menos peças inimigas. Deixe guerreiros suficientes para exatamente governar a clareira de origem ou igual ao número de cartas nesta coluna, o que for maior.<br><br>        -Empates de Destino - Mova para tal clareira com menos peças inimigas, depois menor prioridade.<br><br>    <b>-Combater</b> - Combata em uma clareira correspondente. O defensor é o jogador com mais edifícios. Se esta coluna tiver mais cartas, cause um golpe extra.<br><br>        -Empates de Clareira - Combata em tal clareira sem ninho, depois mais edifícios indefesos, depois menor prioridade.<br><br>        -Empates de Defensor - Combata tal jogador com mais peças lá, depois mais pontos de vitória.<br><br><b>2º:</b> Construa um ninho na clareira que você governa de maior prioridade sem ninho. Se não puder colocar um ninho, você entra em tumulto.
+playerinfo.electriceyrie.Birdsong=<b>1º:</b> Revele uma carta de ordem.<br><b>2º:</b> Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.<br><b>3º:</b> Adicione a carta de ordem à coluna correspondente do Decreto.<br><b>4º:</b> Se você não possui nenhum ninho no mapa, posicione um ninho e 4 guerreiros na clareira ordenada com a maior prioridade e onde todas estas peças possam ser posicionadas.
+playerinfo.electriceyrie.daylight=<b>1º:</b> Resolva o Decreto—recrute para cada coluna com pelo menos uma carta da esquerda para a direita, depois mova dessa forma e então combata dessa forma.<br><br>    <b>-Recrutar -</b> Recrute guerreiros, igual ao número de cartas nessa coluna, em uma clareira correspondente com um ninho.<br><br>        -Empates de Clareira - Recrute em tal clareira com mais peças inimigas, depois menos guerreiros Rapinas, depois menor prioridade.<br><br>    <b>-Mover</b> - Mova da clareira correspondente que você governa com mais guerreiros Rapinas. Mova para uma clareira adjacente sem ninho—se todas tiverem ninho, mova para a com menos peças inimigas. Deixe guerreiros suficientes para exatamente governar a clareira de origem ou igual ao número de cartas nesta coluna, o que for maior.<br><br>        -Empates de Destino - Mova para tal clareira com menos peças inimigas, depois menor prioridade.<br><br>    <b>-Batalha</b> - Combata em uma clareira correspondente. O defensor é o jogador com mais edifícios. Se esta coluna tiver mais cartas, cause um golpe extra.<br><br>        -Empates de Clareira - Combata em tal clareira sem ninho, depois mais edifícios indefesos, depois menor prioridade.<br><br>        -Empates de Defensor - Combata tal jogador com mais peças lá, depois mais pontos de vitória.<br><br><b>2º:</b> Construa um ninho na clareira que você governa de maior prioridade sem ninho. Se não puder colocar um ninho, você entra em tumulto.
 playerinfo.electriceyrie.evening=Pontue os <style="vptext">PVs</style> listados no espaço vazio mais à direita na trilha de Ninhos.
 playerinfo.evening=Anoitecer
 playerinfo.eyriedynasties.Birdsong=1º: Se sua mão estiver vazia, compre uma carta <sprite name="DrawCard">.<br><br>2º: Adicione uma ou duas cartas ao Decreto. Apenas uma carta adicionada pode ser do naipe de pássaro <sprite name="birdicon">.<br><br>3º: Se você não tiver ninhos <sprite name="Roost">, coloque um ninho e três guerreiros na clareira com menos guerreiros.
@@ -423,9 +423,9 @@ playerinfo.marquisedecat.workshopstitle=Oficinas
 playerinfo.mechmarq.Birdsong=1º: Revele uma carta de ordem<br><br>2º: Crie a carta de ordem por <style="vpone">1</style> se houver um item disponível.
 playerinfo.mechmarq.blitz=<size=125%><b>Relâmpago</b></size><br>Depois de se mover, encontre a clareira que você governa de maior prioridade sem peças inimigas. Mova todos os guerreiros, exceto um, dessa clareira. Em seguida, combata na clareira de destino.
 playerinfo.mechmarq.challenging=<size=125%><b>Desafiador</b></size><br> - Sempre que você Recrutar, coloque também dois guerreiros na clareira ordenada de maior prioridade que você governa.
-playerinfo.mechmarq.daylight=Se a carta de ordens for uma carta de <sprite name="birdicon">, resolva a Fase de Dia Expandido em vez disso.<br>1º: Batalha<br>Inicie uma batalha em cada clareira ordenada. O defensor será o jogador com mais peças na clareira de batalha ou, em caso de empate, aquele com mais <style="vptext">PV</style>.<br><br>2º: Recrutar<br>Coloque quatro guerreiros entre as clareiras ordenadas que você governa, distribuídos igualmente. Se você governar três dessas clareiras, coloque o quarto guerreiro na clareira de maior prioridade.<br><br>3º: Erguer<br>Coloque uma construção na clareira que você governa com mais guerreiros dos Marqueses. Coloque uma serraria se a carta de ordens for uma carta de <sprite name="ClearingFox">, uma oficina se for uma carta de <sprite name="ClearingRabbit"> ou um recrutador se for uma carta de <sprite name="ClearingMouse">.<br><br>4º: Mover<br>Mova todos os seus guerreiros, exceto três, de cada clareira ordenada para a clareira adjacente com mais peças inimigas.<br><br>5º: Expandir<br>Se você não colocou uma construção nesta rodada e tiver cinco ou menos construções no mapa, descarte a carta de ordens atual, compre e revele uma nova carta de ordens (mas não crie o item), e retorne ao início da Fase de Dia.
+playerinfo.mechmarq.daylight=Se a carta de ordens for uma carta de <sprite name="birdicon">, resolva a Fase de Dia Expandido em vez disso.<br>1º: Batalha<br>Inicie uma batalha em cada clareira ordenada. O defensor será o jogador com mais peças na clareira de batalha ou, em caso de empate, aquele com mais <style="vptext">PV</style>.<br><br>2º: Recrutamento<br>Coloque quatro guerreiros entre as clareiras ordenadas que você governa, distribuídos igualmente. Se você governar três dessas clareiras, coloque o quarto guerreiro na clareira de maior prioridade.<br><br>3º: Erguer<br>Coloque uma construção na clareira que você governa com mais guerreiros dos Marqueses. Coloque uma serraria se a carta de ordens for uma carta de <sprite name="ClearingFox">, uma oficina se for uma carta de <sprite name="ClearingRabbit"> ou um recrutador se for uma carta de <sprite name="ClearingMouse">.<br><br>4º: Marcha<br>Mova todos os seus guerreiros, exceto três, de cada clareira ordenada para a clareira adjacente com mais peças inimigas.<br><br>5º: Expandir<br>Se você não colocou uma construção nesta rodada e tiver cinco ou menos construções no mapa, descarte a carta de ordens atual, compre e revele uma nova carta de ordens (mas não crie o item), e retorne ao início da Fase de Dia.
 playerinfo.mechmarq.easy=<size=125%><b>Fácil</b></size><br> - Sempre que você Recrutar, em vez disso, coloque apenas dois guerreiros.
-playerinfo.mechmarq.escalateddaylight=1º: Batalha<br>Inicie uma batalha em cada clareira. Os critérios de desempate são os mesmos do combate no Dia padrão.<br><br>2º: Recrutamento<br>Coloque dois guerreiros em cada uma das duas clareiras de menor prioridade que você controla. Se você controlar apenas uma clareira, coloque todos os quatro guerreiros nela.<br><br>3º: Construir<br>Coloque uma construção do tipo com mais peças no mapa na clareira que você controla com mais guerreiros do Marquês. Em caso de empate, priorize serrarias, depois recrutadores e, por último, oficinas.<br><br>4º: Marcha<br>Mova todos, exceto três de seus guerreiros, de cada clareira para a clareira adjacente com mais peças inimigas. Em seguida, inicie uma batalha em cada clareira para onde se moveu.
+playerinfo.mechmarq.escalateddaylight=1º: Batalha<br>Inicie uma batalha em cada clareira. Os critérios de desempate são os mesmos do combate no Dia padrão.<br><br>2º: Recrutamento<br>Coloque dois guerreiros em cada uma das duas clareiras de menor prioridade que você controla. Se você controlar apenas uma clareira, coloque todos os quatro guerreiros nela.<br><br>3º: Erguer<br>Coloque uma construção do tipo com mais peças no mapa na clareira que você controla com mais guerreiros do Marquês. Em caso de empate, priorize serrarias, depois recrutadores e, por último, oficinas.<br><br>4º: Marcha<br>Mova todos, exceto três de seus guerreiros, de cada clareira para a clareira adjacente com mais peças inimigas. Em seguida, inicie uma batalha em cada clareira para onde se moveu.
 playerinfo.mechmarq.escalateddaylighttitle=Dia Expandido
 playerinfo.mechmarq.evening=Receba os pontos de vitória indicados no espaço vazio mais à direita da sua trilha de construções ordenada. Se a carta de ordens for uma carta de pássaro, use a trilha que conceder mais pontos de vitória. (Diferente dos Marqueses, você não ganha pontos de vitória ao posicionar construções.)
 playerinfo.mechmarq.fortified=<size=125%><b>Fortificado</b></size><br>Suas construções precisam de dois golpes para serem removidas. Um único golpe em uma construção não tem efeito.
@@ -508,7 +508,7 @@ playmat.daylabor=Dia de Trabalho!
 playmat.dominanceavailable=Carta de Dominação Disponível!
 playmat.explore=Explorar!
 playmat.fieldhospital=Hospital de Campo!
-playmat.hawksforhire=Rapinas para Contratar!
+playmat.hawksforhire=Pássaros para Contratar!
 playmat.hideout=Esconderijo!
 playmat.leaderdeposed=Líder Deposto!
 playmat.liz.fearofthefaithful=Medo dos Fiéis
@@ -598,13 +598,13 @@ prompt.continuesaved.title=Continuar Jogo
 prompt.coopdescription=Jogue em equipe contra oponentes Autômatos. Para vencer, os jogadores (e IA) devem cada um marcar 30 pontos de vitória antes que qualquer oponente Autômato marque 30 pontos de vitória. Cartas de Dominação são removidas.
 prompt.expand=Expandir
 prompt.leaderboard.name.label=Nome
-prompt.leaderboard.rank.label=Classificação
+prompt.leaderboard.rank.label=Rank
 prompt.leaderboard.score.label=Pontuação
 prompt.login.banned=Sua conta foi banida.
 prompt.minimize=Minimizar
 prompt.time.out.removed=Você foi removido deste jogo por exceder o tempo de turno por dois turnos seguidos.
 prompt.time.out.removed.setup=Você foi removido deste jogo por exceder o tempo de turno durante a preparação.
-prompts.aid.automatedalliance=Ajudando a Aliança Autômata
+prompts.aid.automatedalliance=Ajudando a Aliança Automatizada
 prompts.aid.electriceyrie=Ajudando as Rapinas Elétricas
 prompts.aid.eyriedynasties=Ajudando a Dinastia das Rapinas
 prompts.aid.lizardcult=Ajudando os Lagartos Cultistas
@@ -628,16 +628,16 @@ prompts.gameresults.cooperativewinner=Vitória Cooperativa
 prompts.gameresults.nowinner=Desistiu
 prompts.gameresults.title=Fim de Jogo
 prompts.gameresults.tutorialcomplete=Tutorial Concluído
-prompts.gameresults.winner.automatedalliance=Vitória - Aliança Autômata
+prompts.gameresults.winner.automatedalliance=Vitória - Aliança Automatizada
 prompts.gameresults.winner.electriceyrie=Vitória - Rapinas Elétricas
-prompts.gameresults.winner.eyriedynasties=Vitória - Rapinas
+prompts.gameresults.winner.eyriedynasties=Vitória - Dinastia das Rapinas
 prompts.gameresults.winner.marquisedecat=Vitória - Marqueses
 prompts.gameresults.winner.mechanicalmarquise=Vitória - Marquês Mecânico
 prompts.gameresults.winner.vagabond=Vitória - Malandro
 prompts.gameresults.winner.vagabot=Vitória - Automalandro
-prompts.gameresults.winner.woodlandalliance=Vitória - Aliança
-prompts.gameresults.winner.lordofthehundreds=Vitória - Centenas
-prompts.gameresults.winner.keepersiniron=Vitória - Guardiões
+prompts.gameresults.winner.woodlandalliance=Vitória - Aliança da Floresta
+prompts.gameresults.winner.lordofthehundreds=Vitória - Senhor das Centenas
+prompts.gameresults.winner.keepersiniron=Vitória - Guardiões de Ferro
 prompts.loginfailure.eulanotaccepted=Por favor, aceite o EULA para fazer login.
 prompts.marquisebuild.recruiter=Recrutador
 prompts.marquisebuild.sawmill=Serraria
@@ -810,7 +810,7 @@ shortfactionnames.ElectricEyrie=Rapinas
 shortfactionnames.eyriedynasties=Rapinas
 shortfactionnames.invalid=Facção Aleatória
 shortfactionnames.marquisedecat=Marqueses
-shortfactionnames.MechanicalMarquise=Marqueses
+shortfactionnames.MechanicalMarquise=Marquês
 shortfactionnames.SecondVagabond=Malandro
 shortfactionnames.vagabond=Malandro
 shortfactionnames.Vagabot=Automalandro
@@ -843,7 +843,7 @@ playerinfo.riverfolkcompany.swimmers.title=Nadadores
 playerinfo.riverfolkcompany.swimmers.description=Você trata rios como caminhos e pode se mover ao longo dos rios, independentemente de quem governa.
 playerinfo.riverfolkcompany.tradingpost.removed=Entreposto Comercial Removido: Este posto comercial foi removido do mapa, mas ainda pode ser usado para criar itens.
 playerinfo.riverfolkcompany.Birdsong=1º: Protecionismo - Se a caixa de Pagamentos estiver vazia, coloque dois guerreiros nela.<br><br>2º: Dividendos - Se houver entrepostos comerciais no mapa, marque um ponto de vitória por cada dois fundos. (Você não marca pontos por guerreiros nas caixas de Pagamentos ou Comprometidos.)<br><br>3º: Angariando Fundos - Mova todos os guerreiros do seu tabuleiro de facção para a caixa de Fundos.
-playerinfo.riverfolkcompany.daylight=Comprometa ou gaste fundos para realizar ações<br>
+playerinfo.riverfolkcompany.daylight=Comprometa ou gaste fundos para realizar ações.<br>
 <sprite index=76>Estabeleça um Entreposto Comercial com Guarnição
 playerinfo.riverfolkcompany.evening=1º: Descarte até ter 5 cartas.<br><br>2º: Ajuste os preços dos Serviços.
 prompt.riverfolkcompany.hand.title=Mão da Companhia Ribeirinha
@@ -851,7 +851,7 @@ prompts.buyservices.description=Empreste guerreiros do seu suprimento para compr
 prompts.buyservices.vagabond.description=Exaura itens para comprar serviços.
 prompts.riverfolkscoredividends.label=Marcando Dividendos
 tooltip.playmat.tradepost=<size=125%><b>Entreposto Comercial da Companhia Ribeirinha</b></size><br>• Contribui com o naipe dessa clareira para a criação de itens.<br>• Inimigos nessa clareira podem comprar um serviço adicional.<br>• Você não pode marcar dividendos sem ao menos um entreposto comercial no mapa.<br>• Quando um entreposto comercial é removido, perca metade dos seus fundos, arredondado para cima.<br>• Cada clareira só pode ter um entreposto comercial.
-tooltip.playmat.otterstack=<size=125%><b>Guerreiros da Companhia Ribeirinha</b></size>
+tooltip.playmat.otterstack=<size=125%><b>Guerreiros dos Ribeirinhos</b></size>
 tooltip.ui.riverfolk.publichand=Veja a mão do jogador da Companhia Ribeirinha.
 tooltip.ui.riverfolk.craftingslots=<size=125%><b>Peças de Criação Disponíveis</b></size>
 tooltip.ability.riverfolk.battle=<size=125%><b>Batalhar</b></size>\nComprometa um fundo para batalhar.
@@ -1000,110 +1000,110 @@ scenario.angry.tier1description=Guerreiros inimigos derrotados são adicionados 
 scenario.angry.tier2description=Guerreiros inimigos derrotados são adicionados aos seus comprometidos. Os inimigos não comprarão seus serviços e começam com <style="vpnum">3</style>.
 scenario.shippingempire.tier1description=Você não pode marcar pontos de vitória. Você vence imediatamente ao ter um entreposto comercial em cada clareira de rio.
 tuber.canis.actions.RiverfolkCompanyActions.RiverfolkCompanySetup.ChooseStartingWarriorLocations=Escolha clareiras de rio para seus 4 guerreiros iniciais.
-tuber.canis.actions.RiverfolkCompanyActions.RiverfolkCompanySetup.ChooseStartingWarriorLocations.opponent=A Companhia Ribeirinha está escolhendo clareiras de rio para seus guerreiros iniciais.
+tuber.canis.actions.RiverfolkCompanyActions.RiverfolkCompanySetup.ChooseStartingWarriorLocations.opponent=Companhia Ribeirinha - escolhendo clareiras de rio para seus guerreiros iniciais.
 tuber.canis.actions.RiverfolkCompanyActions.SetRiverfolkServicePrices=Defina os preços de serviço até seu próximo turno.
-tuber.canis.actions.RiverfolkCompanyActions.SetRiverfolkServicePrices.opponent=A Companhia Ribeirinha está definindo preços de serviço.
+tuber.canis.actions.RiverfolkCompanyActions.SetRiverfolkServicePrices.opponent=Companhia Ribeirinha - definindo preços de serviço.
 tuber.canis.undo.riverfolkCompanySetupUndo=Pressione o botão continuar para completar a preparação.
 tuber.canis.undo.riverfolkCompanySetupUndo.opponent=Aguardando a Companhia Ribeirinha confirmar a preparação.
 tuber.canis.actions.RiverfolkCompanyActions.RiverfolkTradePostDestroyed.ChooseFundsToLose=Escolha os fundos a serem perdidos pelo entreposto comercial removido.
 tuber.canis.actions.RiverfolkCompanyActions.RiverfolkTradePostDestroyed.ChooseFundsToLose.opponent=Aguardando a Companhia Ribeirinha remover fundos pelo entreposto comercial removido.
 tuber.canis.actions.RiverfolkCompanyActions.DaylightChoice=Escolha uma ação.
-tuber.canis.actions.RiverfolkCompanyActions.DaylightChoice.opponent=A Companhia Ribeirinha está ponderando a próxima ação.
+tuber.canis.actions.RiverfolkCompanyActions.DaylightChoice.opponent=Companhia Ribeirinha - ponderando a próxima ação.
 tuber.canis.actions.RiverfolkCompanyActions.BuyRiverfolkServices=Escolha quaisquer serviços da Companhia Ribeirinha para comprar.
-tuber.canis.actions.RiverfolkCompanyActions.BuyRiverfolkServices.opponent=[player] está considerando serviços da Companhia Ribeirinha.
+tuber.canis.actions.RiverfolkCompanyActions.BuyRiverfolkServices.opponent=[player] - considerando serviços da Companhia Ribeirinha.
 tuber.canis.actions.RiverfolkCompanyActions.ChooseRiverfolkHandCard=Escolha uma carta da mão da Companhia Ribeirinha para pegar.
-tuber.canis.actions.RiverfolkCompanyActions.ChooseRiverfolkHandCard.opponent=[player] está considerando uma carta da mão da Companhia Ribeirinha para pegar.
+tuber.canis.actions.RiverfolkCompanyActions.ChooseRiverfolkHandCard.opponent=[player] - considerando uma carta da mão da Companhia Ribeirinha para pegar.
 tuber.canis.actions.RiverfolkCompanyActions.CommitFund=Comprometa Fundos.
-tuber.canis.actions.RiverfolkCompanyActions.CommitFund.opponent=A Companhia Ribeirinha está comprometendo fundos.
+tuber.canis.actions.RiverfolkCompanyActions.CommitFund.opponent=Companhia Ribeirinha - comprometendo fundos.
 tuber.canis.actions.RiverfolkCompanyActions.SpendFund=Gaste Fundos.
-tuber.canis.actions.RiverfolkCompanyActions.SpendFund.opponent=A Companhia Ribeirinha está gastando fundos.
+tuber.canis.actions.RiverfolkCompanyActions.SpendFund.opponent=Companhia Ribeirinha - gastando fundos.
 tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkEstablishTradePostAbility=Escolha um local para este entreposto comercial.
-tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkEstablishTradePostAbility.opponent=A Companhia Ribeirinha está posicionando um entreposto comercial.
+tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkEstablishTradePostAbility.opponent=Companhia Ribeirinha - posicionando um entreposto comercial.
 tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkRecruitAbility=Escolha uma clareira de rio para posicionar um guerreiro.
 tuber.canis.abilities.RiverfolkCompanyAbilities.RiverfolkRecruitAbility.opponent=O oponente está escolhendo uma clareira de rio para posicionar um guerreiro.
 tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseStarting=Escolha uma clareira para o seu jardim.
-tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseStarting.opponent=Os Lagartos Cultistas estão escolhendo onde posicionar seu jardim.
+tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseStarting.opponent=Lagartos Cultistas - escolhendo onde posicionar o jardim.
 tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseOutcast=Escolha um naipe inicial para o Pária.
-tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseOutcast.opponent=Os Lagartos Cultistas estão escolhendo um naipe inicial para o Pária.
+tuber.canis.actions.LizardCultActions.LizardCultSetup.ChooseOutcast.opponent=Lagartos Cultistas - escolhendo um naipe inicial para o Pária.
 tuber.canis.undo.lizardCultSetupUndo=Pressione o botão de continuar para finalizar a preparação.
 tuber.canis.undo.lizardCultSetupUndo.opponent=Aguardando os Lagartos Cultistas confirmarem a preparação.
 tuber.canis.abilities.LizardCultAbilities.CultCrusadeBattleAbility=Escolha quem atacar.
-tuber.canis.abilities.LizardCultAbilities.CultCrusadeBattleAbility.opponent=[player] está escolhendo quem atacar.
+tuber.canis.abilities.LizardCultAbilities.CultCrusadeBattleAbility.opponent=[player] - escolhendo quem atacar.
 tuber.canis.actions.LizardCultActions.RevealCardCost=Escolha uma carta para revelar.
-tuber.canis.actions.LizardCultActions.RevealCardCost.opponent=Os Lagartos Cultistas estão escolhendo uma carta para revelar.
+tuber.canis.actions.LizardCultActions.RevealCardCost.opponent=Lagartos Cultistas - escolhendo uma carta para revelar.
 tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction=Escolha uma Conspiração.
 tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.persistant=Escolha uma Conspiração ou carta criada para usar.
-tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.persistant.opponent=Os Lagartos Cultistas estão escolhendo uma Conspiração ou carta criada para usar.
+tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.persistant.opponent=Lagartos Cultistas - escolhendo uma Conspiração ou carta criada para usar.
 tuber.canis.actions.LizardCultActions.LizardCultDaylightAction=Escolha um Ritual.
 tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.NoActions=Nenhum Ritual disponível. Pressione o botão de continuar.
-tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.opponent=Os Lagartos Cultistas estão escolhendo um Ritual.
-tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.NoActions.opponent=Os Lagartos Cultistas estão escolhendo um Ritual.
+tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.opponent=Lagartos Cultistas - escolhendo um Ritual.
+tuber.canis.actions.LizardCultActions.LizardCultDaylightAction.NoActions.opponent=Lagartos Cultistas - escolhendo um Ritual.
 tuber.canis.actions.CraftActivations=Escolha uma carta para criar.
-tuber.canis.actions.CraftActivations.opponent=[player] está considerando opções de criação.
+tuber.canis.actions.CraftActivations.opponent=[player] - considerando opções de criação.
 tuber.canis.actions.CraftActivations.NoActions=Nenhuma carta disponível para criar. Pressione o botão de continuar.
-tuber.canis.actions.CraftActivations.NoActions.opponent=[player] está considerando opções de criação.
-tuber.canis.actions.VagabondActions.EnlistVagabondArbiter=Recrute o Malandro Arbítrio para adicionar [X] intactas <sprite name="sword"> ao seu máximo de golpes (e dê a ele <sprite name="1VP">)?
-tuber.canis.actions.VagabondActions.EnlistVagabondArbiter.opponent=[player] está considerando opções...
+tuber.canis.actions.CraftActivations.NoActions.opponent=[player] - considerando opções de criação.
+tuber.canis.actions.VagabondActions.EnlistVagabondArbiter=Recrutar o Malandro Árbitro para adicionar [X] <sprite name="sword"> intacta(s) ao seu máximo de dano (dando a ele <sprite name="1VP">)?
+tuber.canis.actions.VagabondActions.EnlistVagabondArbiter.opponent=[player] - considerando opções...
 tuber.canis.abilities.VagabondAbilities.ScorchedEarthAbility.SelectClearing=Escolha uma clareira para incendiar com Terra Queimada.
-tuber.canis.abilities.VagabondAbilities.ScorchedEarthAbility.SelectClearing.opponent=O Malandro está escolhendo uma clareira para incendiar com Terra Queimada.
+tuber.canis.abilities.VagabondAbilities.ScorchedEarthAbility.SelectClearing.opponent=Malandro - escolhendo uma clareira para incendiar com Terra Queimada.
 tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectAttacker=Escolha um atacante para Instigar em combate.
-tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectAttacker.opponent=O Malandro está escolhendo um atacante para Instigar em combate.
+tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectAttacker.opponent=Malandro - escolhendo um atacante para Instigar em combate.
 tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectDefender=Escolha um defensor para Instigar em combate.
-tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectDefender.opponent=O Malandro está escolhendo um defensor para Instigar em combate.
+tuber.canis.abilities.VagabondAbilities.InstigateAbility.SelectDefender.opponent=Malandro - escolhendo um defensor para Instigar em combate.
 tooltip.ui.lizardcult.acolytes=<size=125%><b>Acolitos</b></size>\nUsados para realizar conspirações.
 <size=<size=125%><b>Taxa de Compra</b></size>\nCompre esta quantidade de cartas ao Anoitecer. Compre mais cartas ao construir Jardins.=Draw Rate
-tooltip.ability.lizardcult.build=<size=125%><b>Construir</b></size>\nRevele uma carta não corvo para colocar um jardim em uma clareira correspondente que você governe.
+tooltip.ability.lizardcult.build=<size=125%><b>Construir</b></size>\nRevele uma carta que não seja pássaro para colocar um jardim em uma clareira correspondente que você governe.
 tooltip.ability.lizardcult.convert=<size=125%><b>Conversão</b></size>\nRemova um guerreiro inimigo em uma clareira Pária e posicione um guerreiro seu no lugar.
-tooltip.ability.lizardcult.crusade=<size=125%><b>Cruzada (combate)</b></size>\nInicie um combate em qualquer clareira Proscrita.
-tooltip.ability.lizardcult.moveandbattle=<size=125%><b>Cruzada (mover e combater)</b></size>\nMova-se de qualquer clareira Proscrita e inicie um combate na clareira de destino.
-tooltip.ability.lizardcult.recruit=<size=125%><b>Recrutar</b></size>\nRevele uma carta não corvo para colocar um guerreiro em uma clareira correspondente.
-tooltip.ability.lizardcult.sacrifice=<size=125%><b>Sacrificar</b></size>\nRevele uma carta de corvo para converter um guerreiro de sua reserva em um Acólito.
+tooltip.ability.lizardcult.crusade=<size=125%><b>Cruzada (combate)</b></size>\nInicie um combate em qualquer clareira Pária.
+tooltip.ability.lizardcult.moveandbattle=<size=125%><b>Cruzada (mover e combater)</b></size>\nMova-se de qualquer clareira Pária e inicie um combate na clareira de destino.
+tooltip.ability.lizardcult.recruit=<size=125%><b>Recrutar</b></size>\nRevele uma carta que não seja pássaro para colocar um guerreiro em uma clareira correspondente.
+tooltip.ability.lizardcult.sacrifice=<size=125%><b>Sacrificar</b></size>\nRevele uma carta que não seja pássaro para converter um guerreiro de sua reserva em um Acólito.
 tooltip.ability.lizardcult.sanctify=<size=125%><b>Santificação</b></size>\nRemova uma construção inimiga em uma clareira Pária e posicione um jardim no lugar.
 tooltip.ability.lizardcult.score=<size=125%><b>Pontuar</b></size>\nRevele e descarte uma carta para pontuar pontos de vitória com base na sua trilha de jardim.
-tooltip.playmat.lizardstack=<size=125%><b>Guerreiros dos Lagartos Cultistas</b></size>
+tooltip.playmat.lizardstack=<size=125%><b>Guerreiros dos Cultistas</b></size>
 tooltip.playmat.garden=<size=125%><b>Jardim</b></size>\nSempre que um jardim for removido, descarte uma carta aleatória de sua mão.
 aiplayername.riverfolkCompany=Companhia Ribeirinha
 aiplayername.lizardCult=Lagartos Cultistas
 riverfolkWithColor=<color=#397F7F>Companhia Ribeirinha</color>
 cultWithColor=<color=#748421>Lagartos Cultistas</color>
-vagabondWithColorAndCharacter=<color=#436979>[character name] Malandro</color>
-vagabondWithColorAndCharacter2=<color=#436979>[character name 2] Malandro</color>
+vagabondWithColorAndCharacter=<color=#436979>Malandro [character name]</color>
+vagabondWithColorAndCharacter2=<color=#436979>Malandro [character name 2]</color>
 tooltip.ui.lizardcult.hatedoutcast=<size=125%><b>Odiado</b></size>\nDetermina os jardins usados para criar itens e as clareiras com que as conspirações podem interagir. As conspirações custam um acólito a menos enquanto o Pária for Odiado.
 tooltip.ui.lizardcult.outcast=<size=125%><b>Pária</b></size>\nDetermina os jardins usados para criar itens e as clareiras com que as conspirações podem interagir.
-log.riverfolk.protectionism=<color=#397F7F>Companhia Ribeirinha</color> adiciona [X] guerreiros aos pagamentos, já que estava vazia no início do Amanhecer.
-log.riverfolk.dividends=<color=#397F7F>Companhia Ribeirinha</color> ganha [X] pontos de vitória a partir de dividendos.
-log.riverfolk.gather=<color=#397F7F>Companhia Ribeirinha</color> move [X] guerreiros para seus fundos.
-log.riverfolk.move=<color=#397F7F>Companhia Ribeirinha</color> compromete um fundo para mover [X] guerreiros para uma clareira de [suit icon].
-log.riverfolk.move.one=<color=#397F7F>Companhia Ribeirinha</color> compromete um fundo para mover 1 guerreiro para uma clareira de [suit icon].
-log.riverfolk.battle=<color=#397F7F>Companhia Ribeirinha</color> compromete um fundo para iniciar um combate contra [faction name 2] em uma clareira de [suit icon].
-Log.riverfolk.Craft.Persistent=<color=#397F7F>Companhia Ribeirinha</color> compromete [X2] fundos para criar [name].
-Log.riverfolk.Craft.Item=<color=#397F7F>Companhia Ribeirinha</color> compromete [X2] fundos para criar [name], ganhando [item icon] e [X] <style="vptext">PV</style>.
-Log.Riverfolk.Craft.for.Warriors=<color=#397F7F>Companhia Ribeirinha</color> compromete [X] fundos para criar [name] em troca de pagamento em vez do efeito da carta.
-log.riverfolk.draw=<color=#397F7F>Companhia Ribeirinha</color> compromete [X] fundos para comprar uma carta.
-log.riverfolk.recruit=<color=#397F7F>Companhia Ribeirinha</color> gasta um fundo para recrutar um guerreiro em uma clareira de [suit icon].
-log.riverfolk.trade.post=<color=#397F7F>Companhia Ribeirinha</color> gasta [X] fundos para estabelecer um entreposto comercial em uma clareira de [suit icon], ganhando <style=vpnum">2</style>.
-log.riverfolk.set.price=<color=#397F7F>Companhia Ribeirinha</color> define o preço do serviço [service name] para [X].
-log.riverfolk.setup=<color=#397F7F>Companhia Ribeirinha</color> adiciona [X] guerreiros a uma clareira de [suit icon] durante a preparação.
-log.riverfolk.trade.discard=<color=#397F7F>Companhia Ribeirinha</color> perde [X] fundos porque um entreposto comercial foi removido.
-log.buy.service.hand=[faction name] compra o serviço Cartas da Mão da Companhia Ribeirinha por [X], recebendo [suit icon][name].
-log.buy.service.riverboats=[faction name] compra o serviço Barcos da Companhia Ribeirinha por [X].
-log.buy.service.mercenaries=[faction name] compra o serviço Mercenários da Companhia Ribeirinha por [X].
-log.cult.setup.garden=<color=#748421>Lagartos Cultistas</color> posicionam seu jardim inicial e 4 guerreiros em uma clareira de [suit icon]. 1 guerreiro é posicionado em cada clareira adjacente.
+log.riverfolk.protectionism=<color=#397F7F>Companhia Ribeirinha</color> - adicionando [X] guerreiro(s) aos pagamentos, já que estava vazia no início do Amanhecer.
+log.riverfolk.dividends=<color=#397F7F>Companhia Ribeirinha</color> - ganhando [X] PV a partir de dividendos.
+log.riverfolk.gather=<color=#397F7F>Companhia Ribeirinha</color> - movendo [X] guerreiro(s) para seus fundos.
+log.riverfolk.move=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo um fundo para mover [X] guerreiro(s) para uma clareira de [suit icon].
+log.riverfolk.move.one=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo um fundo para mover 1 guerreiro para uma clareira de [suit icon].
+log.riverfolk.battle=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo um fundo para iniciar um combate contra [faction name 2] em uma clareira de [suit icon].
+Log.riverfolk.Craft.Persistent=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo [X2] fundos para criar [name].
+Log.riverfolk.Craft.Item=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo [X2] fundos para criar [name], ganhando [item icon] e [X] <style="vptext">PV</style>.
+Log.Riverfolk.Craft.for.Warriors=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo [X] fundo(s) para criar [name] em troca de pagamento em vez do efeito da carta.
+log.riverfolk.draw=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo [X] fundo(s) para comprar uma carta.
+log.riverfolk.recruit=<color=#397F7F>Companhia Ribeirinha</color> - gastando um fundo para recrutar um guerreiro em uma clareira de [suit icon].
+log.riverfolk.trade.post=<color=#397F7F>Companhia Ribeirinha</color> - gastando [X] fundo(s) para estabelecer um entreposto comercial em uma clareira de [suit icon], ganhando <style=vpnum">2</style>.
+log.riverfolk.set.price=<color=#397F7F>Companhia Ribeirinha</color> - definindo o preço do serviço [service name] para [X].
+log.riverfolk.setup=<color=#397F7F>Companhia Ribeirinha</color> - adicionando [X] guerreiro(s) a uma clareira de [suit icon] durante a preparação.
+log.riverfolk.trade.discard=<color=#397F7F>Companhia Ribeirinha</color> - perdendo [X] fundo(s) porque um entreposto comercial foi removido.
+log.buy.service.hand=[faction name] - comprando o serviço Cartas da Mão da Companhia Ribeirinha por [X], recebendo [suit icon][name].
+log.buy.service.riverboats=[faction name] - comprando o serviço Botes da Companhia Ribeirinha por [X].
+log.buy.service.mercenaries=[faction name] - comprando o serviço Mercenários da Companhia Ribeirinha por [X].
+log.cult.setup.garden=<color=#748421>Lagartos Cultistas</color> - posicionando o jardim inicial e 4 guerreiros em uma clareira de [suit icon]. 1 guerreiro é posicionado em cada clareira adjacente.
 log.cult.outcast=O Pária torna-se [suit icon].
 log.cult.outcast.hated=O Pária de [suit icon] agora é Odiado.
 log.cult.outcast.no.change=O Pária Odiado continua sendo [suit icon].
-log.cult.crusade=<color=#748421>Lagartos Cultistas</color> gastam [X] acólitos para realizar uma Cruzada.
-log.cult.convert=<color=#748421>Lagartos Cultistas</color> gastam [X] acólitos para Converter um guerreiro de [faction name] em uma clareira de [suit icon] para um guerreiro dos Lagartos Cultistas.
-log.cult.sanctify=<color=#748421>Lagartos Cultistas</color> gastam [X] acólitos para Santificar uma construção de [faction name] em uma clareira de [suit icon], substituindo-a por um jardim.
-log.cult.build=<color=#748421>Lagartos Cultistas</color> revelam [name] para construir um jardim em uma clareira de [suit icon].
-log.cult.recruit=<color=#748421>Lagartos Cultistas</color> revelam [name] para recrutar um guerreiro em uma clareira de [suit icon].
-log.cult.score=<color=#748421>Lagartos Cultistas</color> descartam [name] para pontuar jardins de [suit icon] e ganhar [X] pontos de vitória.
-log.cult.sacrifice=<color=#748421>Lagartos Cultistas</color> revelam [name] para ganhar um acólito.
-log.cult.lost.garden=<color=#748421>Lagartos Cultistas</color> descartam a carta aleatória [name] porque um jardim foi removido.
-log.vagabond.explore.failure=[faction name] falha em encontrar um item válido para pegar ao explorar em uma clareira de [suit icon].
-log.vagabond.scorched.earth=[faction name] remove <sprite name="torch"> para usar sua habilidade Terra Queimada em uma clareira de [suit icon]. As seguintes peças são removidas: [piece list]
-log.vagabond.vagrant.ability=<color=#4E6F89>Malandro</color> exaure <sprite name="torch"> para instigar um combate entre [faction name] e [faction name 2] em uma clareira de [suit icon].
-log.vagabond.arbiter.ability=[faction name] recruta a ajuda do Malandro Arbítrio <color=#4E6F89>Malandro</color> no combate, adicionando [X] espadas ao seu máximo de golpes. O Arbítrio ganha [X2] <style="vptext">PV</style> em troca.
+log.cult.crusade=<color=#748421>Lagartos Cultistas</color> - gastando [X] acólito(s) para realizar uma Cruzada.
+log.cult.convert=<color=#748421>Lagartos Cultistas</color> - gastando [X] acólito(s) para Converter um guerreiro de [faction name] em uma clareira de [suit icon] para um guerreiro dos Lagartos Cultistas.
+log.cult.sanctify=<color=#748421>Lagartos Cultistas</color> - gastando [X] acólito(s) para Santificar uma construção de [faction name] em uma clareira de [suit icon], substituindo-a por um jardim.
+log.cult.build=<color=#748421>Lagartos Cultistas</color> - revelando [name] para construir um jardim em uma clareira de [suit icon].
+log.cult.recruit=<color=#748421>Lagartos Cultistas</color> - revelando [name] para recrutar um guerreiro em uma clareira de [suit icon].
+log.cult.score=<color=#748421>Lagartos Cultistas</color> - descartando [name] para pontuar jardins de [suit icon] e ganhar [X] PV.
+log.cult.sacrifice=<color=#748421>Lagartos Cultistas</color> - revelando [name] para ganhar um acólito.
+log.cult.lost.garden=<color=#748421>Lagartos Cultistas</color> - descartando a carta aleatória [name] porque um jardim foi removido.
+log.vagabond.explore.failure=[faction name] - falhando em encontrar um item válido para pegar ao explorar em uma clareira de [suit icon].
+log.vagabond.scorched.earth=[faction name] - removendo <sprite name="torch"> para usar a habilidade Terra Queimada em uma clareira de [suit icon]. As seguintes peças são removidas: [piece list]
+log.vagabond.vagrant.ability=<color=#4E6F89>Malandro</color> - exaurindo <sprite name="torch"> para instigar um combate entre [faction name] e [faction name 2] em uma clareira de [suit icon].
+log.vagabond.arbiter.ability=[faction name] - recrutando a ajuda do <color=#4E6F89>Malandro</color> Árbitro no combate, adicionando [X] espada(s) ao seu máximo de golpes. O Árbitro ganha [X2] <style="vptext">PV</style> em troca.
 tooltip.lizardcult.gardens.description=Jardins do naipe do pária contribuem para criar itens durante o Anoitecer. Sempre que um jardim for removido, descarte uma carta aleatória de sua mão.
 tooltip.ui.hand.reveal.liz=<size=125%><b>Mão dos Lagartos Cultistas</b></size> Veja as cartas dos Lagartos Cultistas que foram reveladas.
 tooltip.ui.lostsouls.liz=Almas Perdidas
@@ -1114,7 +1114,7 @@ ftt.twovagabond.explore=Cada <sprite name="Ruins"><color=#4E6F89>ruína</color> 
 ftt.twovagabond.explore.2=Ao explorar uma <sprite name="Ruins"><color=#4E6F89>ruína</color> com dois itens, você pode escolher os itens que estão lá. No entanto, não é permitido selecionar um item do mesmo tipo de outro item que você já possui e que também foi retirado de uma ruína.
 ftt.service.intro.1=No início do Amanhecer, os jogadores podem comprar serviços da Companhia Ribeirinha. Para comprar um serviço, os jogadores movem guerreiros iguais ao custo do serviço de sua reserva para a área de pagamentos da Companhia Ribeirinha.
 ftt.service.intro.2=Cartas da Mão: Roube uma carta da mão da Companhia Ribeirinha
-ftt.service.intro.3=Barcos: Trate rios como caminhos até o final do turno.
+ftt.service.intro.3=Botes: Trate rios como caminhos até o final do turno.
 ftt.service.intro.4=Mercenários: Durante o Dia e o Anoitecer deste turno, trate os guerreiros da Companhia Ribeirinha como seus para fins de governar e combater. O Malandro não pode usar essa habilidade.
 ftt.service.intro.5=Note que o Malandro paga pelos serviços exaurindo itens no início do Amanhecer antes de reanimar. Para cada item que o Malandro exaurir para fazer isso, a Companhia Ribeirinha posiciona um de seus próprios guerreiros nos Pagamentos.
 tutorial.title.tutorialR01=Escamas Sagradas
@@ -1127,7 +1127,7 @@ playmat.revenge=Vingança!
 stinger.title.fear=Medo dos Fiéis
 playmat.convert=Conversão!
 key.handcard=Cartas da Mão
-key.riverboats=Barcos
+key.riverboats=Botes
 key.mercenaries=Mercenários
 tuber.canis.abilities.LizardCultAbilities.CultBuildAbility=Escolha uma clareira para o seu jardim.
 tuber.canis.abilities.LizardCultAbilities.CultRecruitAbility=Escolha uma clareira para recrutar um guerreiro.
@@ -1138,7 +1138,7 @@ tooltip.fish.mouse=Peixe de Rato
 tooltip.fishmonochrome=
 tooltip.tutorial.hatedoutcast=Odiado
 tooltip.tutorial.mostcommonsuit=Naipe Mais Comum
-Log.Explore.NoItems=[faction name] explora uma ruína em uma clareira de [suit icon], mas não encontrou itens.
+Log.Explore.NoItems=[faction name] - explorando uma ruína em uma clareira de [suit icon], não encontrando itens.
 scenario.garden.name=Grande Jardim
 scenario.conquest.name=Conquista
 scenario.restlesssouls.name=Almas Perdidas
@@ -1164,10 +1164,10 @@ root.vagabond.scoundrel.ability.title=Terra Queimada
 root.vagabond.scoundrel.ability.text=Descarte sua tocha para remover todas as peças inimigas de sua clareira. Peças não podem mais ser posicionadas nem movidas para dentro da clareira incendiada.
 tuber.canis.abilities.LizardCultAbilities.CultSanctifyAbility=Escolha uma construção para santificar.
 playmat.boughthandcard=Carta da Mão Comprada!
-playmat.boughtriverboats=Barcos Comprados!
+playmat.boughtriverboats=Botes Comprados!
 playmat.boughtmercenaries=Mercenários Comprados!
-prompts.gameresults.winner.LizardCult=Vitória - Cultistas
-prompts.gameresults.winner.RiverfolkCompany=Vitória - Ribeirinhos
+prompts.gameresults.winner.LizardCult=Vitória - Lagartos Cultistas
+prompts.gameresults.winner.RiverfolkCompany=Vitória - Companhia Ribeirinha
 tuber.canis.abilities.LizardCultAbilities.CultConvertAbility=Escolha um guerreiro para converter
 vagabond.title.SecondVagabond_Thief=Malandro Ladrão
 vagabond.title.SecondVagabond_Tinker=Malandro Funileiro
@@ -1182,7 +1182,7 @@ ftt.servicecost=Custo de Serviço
 tooltip.ui.liz.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros na reserva, ele não poderá recrutar guerreiros.
 tooltip.ui.liz.cardsinhand=<size=125%><b>Cartas na Mão</b></size>\nOs Lagartos Cultistas compram cartas adicionais ao contruir Jardins.
 tuber.canis.actions.VagabondActions.Explore.ChooseItemToTake=Escolha um item para pegar.
-tuber.canis.actions.VagabondActions.Explore.ChooseItemToTake.opponent=O Malandro está escolhendo um item para pegar das Ruínas.
+tuber.canis.actions.VagabondActions.Explore.ChooseItemToTake.opponent=Malandro - escolhendo um item para pegar das Ruínas.
 tooltip.ui.vagabond.vagabond_vagrant=<size=125%><b>Vagabundo</b></size>\n<b>Instigar</b> — Exaura <sprite name="torch"> para iniciar uma batalha em sua clareira. Você escolhe tanto o atacante quanto o defensor e remove peças para cada um.
 tooltip.ui.vagabond.vagabond_arbiter=<size=125%><b>Árbitro</b></size>\n<b>Proteção</b> — Antes de rolar os dados na batalha, o defensor pode alistar o Árbitro se ele estiver na clareira da batalha. O Árbitro ganha <sprite name="1VP"> e adiciona espadas intactas ao máximo de golpes rolados pelo defensor.
 tooltip.ui.vagabond.vagabond_scoundrel=<size=125%><b>Patife</b></size>\n<b>Terra Queimada</b> — Descarte sua <sprite name="torch"> para remover todas as peças inimigas de sua clareira. Peças não podem mais ser posicionadas nem movidas para dentro da clareira incendiada.
@@ -1194,8 +1194,8 @@ tooltip.ui.vagabond.secondvagabond_arbiter=<size=125%><b>Árbitro</b></size>\n<b
 tooltip.ui.vagabond.secondvagabond_scoundrel=<size=125%><b>Patife</b></size>\n<b>Terra Queimada</b> — Descarte sua <sprite name="torch"> para remover todas as peças inimigas de sua clareira. Peças não podem mais ser posicionadas nem movidas para dentro da clareira incendiada.
 prompt.tutorial.riverfolk.upsell.title=Tutoriais da Companhia Ribeirinha
 prompt.tutorial.riverfolk.upsell.description=A Companhia Ribeirinha e os Lagartos Cultistas fazem parte da Expansão Ribeirinhos. Visitar a loja para saber mais?
-tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.opponent=Os Lagartos Cultistas estão escolhendo uma Conspiração
-Firsttime.ally=Agora você está <sprite name="Allied"><color=#4E6F89>aliado</color> com a [faction name]. Cada vez que você oferecer <sprite name="heart"> <color=#4E6F89>ajuda</color> a eles, você ganhará <style="vptext">PV</style>. Você também poderá comandar seus guerreiros em sua clareira para mover e lutar ao seu lado.
+tuber.canis.actions.LizardCultActions.LizardCultBirdsongAction.opponent=Lagartos Cultistas - escolhendo uma Conspiração.
+Firsttime.ally=Agora você está <sprite name="Allied"><color=#4E6F89>aliado</color> com [faction name]. Cada vez que você oferecer <sprite name="heart"> <color=#4E6F89>ajuda</color> ao seu aliado, você ganhará <style="vptext">PV</style>. Você também poderá comandar seus guerreiros em sua clareira para mover e lutar ao seu lado.
 factionnames.RiverfolkCompany=Companhia Ribeirinha
 aiplayername.secondvagabond=Malandro
 playmat.enlisted=Alistado!
@@ -1204,12 +1204,12 @@ playmat.establishtradepost=Estabelecer Entreposto Comercial!
 playmat.export=Exportar!
 prompts.gameresults.winner.SecondVagabond=Vitória - Malandro
 prompt.selectaplayer=Selecione um Jogador!
-Log.riverfolk.Favor.Craft=<color=#397F7F>Companhia Ribeirinha</color> compromete [X2] fundos para criar [name], removendo todas as peças inimigas nas clareiras de [suit icon].
+Log.riverfolk.Favor.Craft=<color=#397F7F>Companhia Ribeirinha</color> - comprometendo [X2] fundos para criar [name], removendo todas as peças inimigas nas clareiras de [suit icon].
 tooltip.ui.riverfolk.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nA Companhia Ribeirinha cria cartas usando Postos de Comércio.
 tooltip.ui.lizards.crafteditems=<size=125%><b>Itens Criados</b></size>\nO Malandro pode trocar cartas por esses itens. Os Lagartos Cultistas criam itens usando Jardins.
 tooltip.ui.lizards.craftedcards=<size=125%><b>Cartas Criadas</b></size>\nOs Lagartos Cultistas criam cartas usando Jardins que correspondam ao naipe do Pária.
 tuber.canis.abilities.CraftAbility.lizardcult=Escolha uma carta para criar usando os jardins do naipe do pária.
-tuber.canis.abilities.CraftAbility.lizardcult.opponent=Os Lagartos Cultistas estão escolhendo uma carta para criar
+tuber.canis.abilities.CraftAbility.lizardcult.opponent=Lagartos Cultistas - escolhendo uma carta para criar.
 tuber.canis.actions.LizardCultActions.ConfirmScoreForNoPoints=Escolher esta carta renderá 0 pontos. Tem certeza de que deseja continuar?
 prompt.vagabond.enlistarbiter.title=Alistar Árbitro
 prompt.export=Escolha uma carta para Exportar.
@@ -1229,11 +1229,11 @@ tuber.canis.abilities.VagabondAbilities.GlideAbility.Destination=Escolha uma cla
 vagabond.swiftstrike.activate=Gostaria de exaurir uma espada para causar um golpe extra?
 vagabond.improvise.activate=Gostaria de Improvisar esta tarefa?
 vagabond.improvise.item=Escolha um item para danificar para Improvisar.
-vagabond.improvise.item.opponent=[player] está escolhendo um item para danificar para Improvisar.
+vagabond.improvise.item.opponent=[player] - escolhendo um item para danificar para Improvisar.
 vagabond.improvise.item.quest=Escolha qual item de tarefa para exaurir.
-Log.Quest.Improvise=[faction name] Improvisou, exaurindo [item icon] e danificando [item icon 2] para completar a tarefa [name].
-log.vagabond.ronin.ability=[faction name] usou Golpe Rápido, exaurindo [item icon] para adicionar um golpe adicional.
-log.vagabond.harrier.ability=[faction name] usou Esgueirar para mover-se, planando pelo céu.
+Log.Quest.Improvise=[faction name] - escolhendo Improvisar, exaurindo [item icon] e danificando [item icon 2] para completar a tarefa [name].
+log.vagabond.ronin.ability=[faction name] - usando Golpe Rápido, exaurindo [item icon] para adicionar um golpe adicional.
+log.vagabond.harrier.ability=[faction name] - usando Esgueirar para mover-se, planando pelo céu.
 tooltip.ability.vagabond.glide=<size=125%><b>Esgueirar</b></size> - Exaura <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
 tooltip.ui.vagabond.Vagabond_Adventurer=<size=125%><b>Aventureiro</b></size>\n<b>Improvisar</b> — Uma vez por turno, você pode danificar qualquer item para tratá-lo como outro item para uma tarefa.
 tooltip.ui.vagabond.Vagabond_Harrier=<size=125%><b>Saqueador</b></size>\n<b>Esgueirar</b> — Exaura <sprite name="torch"> para mover-se para qualquer clareira (mesmo hostil). Você não pode trazer aliados e não precisa exaurir botas.
@@ -1247,9 +1247,9 @@ vagabond.title.Vagabond_Harrier=Saqueador
 vagabond.title.SecondVagabond_Harrier=Saqueador
 vagabond.title.SecondVagabond_Ronin=Ronin
 vagabond.title.SecondVagabond_Adventurer=Aventureiro
-vagabond.swiftstrike.activate.opponent=Malandro Ronin está considerando Ataque Rápido.
-vagabond.improvise.item.quest.opponent=[player] está escolhendo um item para exaurir para Improvisar.
-vagabond.improvise.activate.opponent=Malandro está escolhendo uma tarefa para completar.
+vagabond.swiftstrike.activate.opponent=Malandro  - considerando Ataque Rápido.
+vagabond.improvise.item.quest.opponent=[player] - escolhendo um item para exaurir para Improvisar.
+vagabond.improvise.activate.opponent=Malandro - escolhendo uma tarefa para completar.
 tooltip.swiftstrike.battle=<size=125%><b>Golpe Rápido:</b></size><br>Exaura uma espada para causar um golpe extra.
 root.cardname.exilesandpartisans.boatbuilders=Construtores Navais
 root.cardtext.exilesandpartisans.boatbuilders.any=Você trata rios como caminhos.
@@ -1288,65 +1288,65 @@ root.cardtext.exilesandpartisans.swapmeet.any=Uma vez durante o Amanhecer, pode 
 root.cardname.exilesandpartisans.tunnels=Túneis
 root.cardtext.exilesandpartisans.tunnels.any=Você trata clareiras com qualquer uma de suas peças de criação como adjacentes.
 tuber.canis.abilities.ExilesAndPartisansAbilities.CharmOffensiveAbility=Escolha um jogador para ganhar <sprite name="1VP">.
-tuber.canis.abilities.ExilesAndPartisansAbilities.CharmOffensiveAbility.opponent=[player] está escolhendo um oponente para ganhar <sprite name="1VP"> com Charme Ofensivo.
+tuber.canis.abilities.ExilesAndPartisansAbilities.CharmOffensiveAbility.opponent=[player] - escolhendo um oponente para ganhar <sprite name="1VP"> com Charme Ofensivo.
 tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigreAbility.move=Selecione uma clareira de onde mover usando Imigrante Rapina.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigreAbility.move.opponent=[player] está escolhendo uma clareira de onde mover usando Imigrante Rapina.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigreAbility.move.opponent=[player] - escolhendo uma clareira de onde mover usando Imigrante Rapina.
 tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.battle=Escolha um inimigo para batalhar usando Imigrante Rapina.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.battle.opponent=[player] está escolhendo um inimigo para batalhar usando Imigrante Rapina.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.battle.opponent=[player] - escolhendo um inimigo para batalhar usando Imigrante Rapina.
 tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.confirmdiscard=Você não conseguiu se mover e/ou batalhar com Imigrante Rapina. Pressione continuar para descartá-lo.
-tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.confirmdiscard.opponent=[player] deve descartar Imigrante Rapina, pois não conseguiu nem se mover nem batalhar com ele.
+tuber.canis.abilities.ExilesAndPartisansAbilities.EyrieEmigre.confirmdiscard.opponent=[player] - descartando Imigrante Rapina, pois não se moveu e/ou batalhou com ele.
 tuber.canis.abilities.FalseOrdersAbility.destination=Selecione uma clareira para mover a metade.
-tuber.canis.abilities.FalseOrdersAbility.destination.opponent=[player] está escolhendo uma clareira para mover guerreiros inimigos com Ordens Falsificadas.
+tuber.canis.abilities.FalseOrdersAbility.destination.opponent=[player] - escolhendo uma clareira para mover guerreiros inimigos com Ordens Falsificadas.
 tuber.canis.abilities.FalseOrdersAbility.origin=Selecione guerreiros para mover usando Ordens Falsificadas.
-tuber.canis.abilities.FalseOrdersAbility.origin.opponent=[player] está escolhendo guerreiros inimigos para mover com Ordens Falsificadas.
+tuber.canis.abilities.FalseOrdersAbility.origin.opponent=[player] - escolhendo guerreiros inimigos para mover com Ordens Falsificadas.
 tuber.canis.abilities.ExilesAndPartisansAbilities.InformantsAbility=Escolha uma Emboscada para comprar.
-tuber.canis.abilities.ExilesAndPartisansAbilities.InformantsAbility.opponent=[player] está escolhendo uma emboscada para comprar do monte de descarte usando Informantes.
+tuber.canis.abilities.ExilesAndPartisansAbilities.InformantsAbility.opponent=[player] - escolhendo uma emboscada para comprar do monte de descarte usando Informantes.
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.cost=Escolha um item para exaurir.
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.cost.opponent=[player] está escolhendo um item para exaurir com a Liga dos Ratos Aventureiros.
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.cost.opponent=[player] - escolhendo um item para exaurir com a Liga dos Ratos Aventureiros.
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.move=Mover
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.move.opponent=[player] está escolhendo uma clareira para mover-se com a Liga dos Ratos Aventureiros.
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.move.opponent=[player] - escolhendo uma clareira para mover-se com a Liga dos Ratos Aventureiros.
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.battle=Batalhar
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.battle.opponent=[player] está escolhendo uma clareira para batalhar com a Liga dos Ratos Aventureiros .
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.battle.opponent=[player] - escolhendo uma clareira para batalhar com a Liga dos Ratos Aventureiros .
 tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.outcome=Escolha uma opção
-tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.outcome.opponent=[player] está escolhendo se move ou batalha com a Liga dos Ratos Aventureiros.
+tuber.canis.abilities.ExilesAndPartisansAbilities.LeagueOfAdventurousMiceAbility.outcome.opponent=[player] - escolhendo se mover ou batalhar com a Liga dos Ratos Aventureiros.
 button.move=Mover
 button.battle=Batalhar
 tuber.canis.abilities.PropagandaBureauAbility.warrior=Escolha um guerreiro para substituir por um seu.
-tuber.canis.abilities.PropagandaBureauAbility.warrior.opponent=[player] está escolhendo um guerreiro para substituir usando Escritório de Propaganda.
+tuber.canis.abilities.PropagandaBureauAbility.warrior.opponent=[player] - escolhendo um guerreiro para substituir usando Escritório de Propaganda.
 tuber.canis.abilities.PropagandaBureauAbility.warrior.vagabond=Escolha um guerreiro para remover.
-tuber.canis.abilities.PropagandaBureauAbility.warrior.vagabond.opponent=[player] está escolhendo um guerreiro para remover usando Escritório de Propaganda.
+tuber.canis.abilities.PropagandaBureauAbility.warrior.vagabond.opponent=[player] - escolhendo um guerreiro para remover usando Escritório de Propaganda.
 tuber.canis.abilities.PropagandaBureauAbility.card=Escolha uma carta para descartar.
-tuber.canis.abilities.PropagandaBureauAbility.card.opponent=[player] está escolhendo uma carta para descartar como custo do Escritório de Propaganda.
+tuber.canis.abilities.PropagandaBureauAbility.card.opponent=[player] - escolhendo uma carta para descartar como custo do Escritório de Propaganda.
 tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.discard=Escolha uma carta inimiga para descartar do jogo.
-tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.discard.opponent=[player] está escolhendo uma carta inimiga para descartar do jogo.
+tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.discard.opponent=[player] - escolhendo uma carta inimiga para descartar do jogo.
 tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.player=Escolha um jogador para Sabotadores.
-tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.player.opponent=[player] está escolhendo um jogador para alvejar com Sabotadores.
+tuber.canis.abilities.ExilesAndPartisansAbilities.SaboteursAbility.player.opponent=[player] - escolhendo um jogador para alvejar com Sabotadores.
 tuber.canis.abilities.SwapMeetAbility.give=Escolha uma carta para dar a [USERNAME].
-tuber.canis.abilities.SwapMeetAbility.give.opponent=[player] está escolhendo uma carta para dar com Escambo.
+tuber.canis.abilities.SwapMeetAbility.give.opponent=[player] - escolhendo uma carta para dar com Escambo.
 tuber.canis.abilities.SwapMeetAbility.player=Escolha um jogador para trocar uma carta.
-tuber.canis.abilities.SwapMeetAbility.player.opponent=[player] está escolhendo um jogador para trocar uma carta.
+tuber.canis.abilities.SwapMeetAbility.player.opponent=[player] - escolhendo um jogador para trocar uma carta.
 Log.BoatBuilders=
-Log.CharmOffensive=[faction name] usa Charme Ofensivo para comprar uma carta e dar 1 <style="vptext">PV</style> para [faction name 2].
-Log.CoffinMakers.Warriors=[X] guerreiros removidos foram posicionados em Coveiros em vez da reserva.
+Log.CharmOffensive=[faction name] - usando Charme Ofensivo para comprar uma carta e dar 1 <style="vptext">PV</style> para [faction name 2].
+Log.CoffinMakers.Warriors=[X] guerreiro(s) removidos foram posicionados em Coveiros em vez da reserva.
 Log.CoffinMakers.Warriors.One=Um guerreiro removido foi posicionado em Coveiros em vez da reserva.
-Log.CoffinMakers.Points=[faction name] pontua [X] <style="vptext">PV</style> com Coveiros. [X2] guerreiros em Coveiros foram devolvidos à reserva.
-Log.CoffinMakers.Points.One=[faction name] pontua [X] <style="vptext">PV</style> com Coveiros. Um guerreiro em Coveiros foi devolvido à reserva.
-Log.EyrieEmigre.Move=[faction name] usa Imigrante Rapina para mover [X] guerreiros para uma clareira de [suit icon], mas não batalha.
-Log.EyrieEmigre.Move.One=[faction name] usa Imigrante Rapina para mover 1 guerreiro para uma clareira de [suit icon], mas não batalha.
-Log.EyrieEmigre.Battle=[faction name] usa Imigrante Rapina para mover [X] guerreiros para uma clareira de [suit icon] e batalhar contra [faction name 2].
-Log.EyrieEmigre.Battle.One=[faction name] usa Imigrante Rapina para mover 1 guerreiro para uma clareira de [suit icon] e batalhar contra [faction name 2].
-Log.EyrieEmigre.Discard=[faction name] descarta seu Imigrante Rapina, pois não se moveu nem batalhou com ele.
-Log.FalseOrdersAbility=[faction name] descarta Ordens Falsificadas para mover [X] guerreiros [faction name 2] para uma clareira de [suit icon].
-Log.Informants=[faction name] compra uma emboscada de [suit icon] do monte de descarte usando Informantes.
-Log.LeagueOfAdventurousMice=[faction name] exaure [item icon] para usar a Liga dos Ratos Aventureiros.
-Log.MasterEngravers=[faction name] ganha 1 <style="vptext">PV</style> por criar um item com Mestre Escultor.
-Log.MurineBroker=[faction name] compra uma carta com Camundongo Receptador a partir de um item criado.
-Log.Partisans=[faction name] descarta [cardnames] para causar um golpe extra com [name].
-Log.PropagandaBureauAbility=[faction name] usa Escritório de Propaganda para descartar [name], substituindo um guerreiro de [faction name 2] por um dos seus em uma clareira de [suit icon].
-Log.PropagandaBureauAbility.NoReplacement=[faction name] usa Escritório de Propaganda para descartar [name], apenas removendo um guerreiro de [faction name 2].
-Log.SaboteursAbility=[faction name] descarta Sabotadores para descartar [name] de [faction name 2].
-Log.SwapMeetAbility=[faction name] usa Escambo para trocar uma carta com [faction name 2].
-Log.Tunnels=[faction name] se moveu usando Túneis.
+Log.CoffinMakers.Points=[faction name] - pontuando [X] <style="vptext">PV</style> com Coveiros. [X2] guerreiros em Coveiros foram devolvidos à reserva.
+Log.CoffinMakers.Points.One=[faction name] - pontuando [X] <style="vptext">PV</style> com Coveiros. Um guerreiro em Coveiros foi devolvido à reserva.
+Log.EyrieEmigre.Move=[faction name] - usando Imigrante Rapina para mover [X] guerreiro(s) para uma clareira de [suit icon], mas sem batalhar.
+Log.EyrieEmigre.Move.One=[faction name] - usando Imigrante Rapina para mover 1 guerreiro para uma clareira de [suit icon], mas sem batalhar.
+Log.EyrieEmigre.Battle=[faction name] - usando Imigrante Rapina para mover [X] guerreiro(s) para uma clareira de [suit icon] e batalhar contra [faction name 2].
+Log.EyrieEmigre.Battle.One=[faction name] - usando Imigrante Rapina para mover 1 guerreiro para uma clareira de [suit icon] e batalhar contra [faction name 2].
+Log.EyrieEmigre.Discard=[faction name] - descartando o Imigrante Rapina, pois não se moveu e/ou batalhou com ele.
+Log.FalseOrdersAbility=[faction name] - descartando Ordens Falsificadas para mover [X] guerreiro(s) [faction name 2] para uma clareira de [suit icon].
+Log.Informants=[faction name] - comprando uma emboscada de [suit icon] do monte de descarte usando Informantes.
+Log.LeagueOfAdventurousMice=[faction name] - exaurindo [item icon] para usar a Liga dos Ratos Aventureiros.
+Log.MasterEngravers=[faction name] - ganhando 1 <style="vptext">PV</style> por criar um item com Mestre Escultor.
+Log.MurineBroker=[faction name] - comprando uma carta com Camundongo Receptador a partir de um item criado.
+Log.Partisans=[faction name] - descartando [cardnames] para causar um golpe extra com [name].
+Log.PropagandaBureauAbility=[faction name] - usando Escritório de Propaganda para descartar [name], substituindo um guerreiro de [faction name 2] por um dos seus em uma clareira de [suit icon].
+Log.PropagandaBureauAbility.NoReplacement=[faction name] - usando Escritório de Propaganda para descartar [name], apenas removendo um guerreiro de [faction name 2].
+Log.SaboteursAbility=[faction name] - descartando Sabotadores para descartar [name] de [faction name 2].
+Log.SwapMeetAbility=[faction name] - usando Escambo para trocar uma carta com [faction name 2].
+Log.Tunnels=[faction name] - se movendo usando Túneis.
 warning.unusable=Sua facção não pode usar a habilidade desta carta. Tem certeza de que deseja criá-la?
 warning.unusable.opponent=O oponente está considerando criar
 warning.unusable.boat=Sua facção já possui esta habilidade. Tem certeza de que deseja criá-la?
@@ -1374,12 +1374,12 @@ cct.Birdsong.t4.recruit=Envie seus <sprite name="corvid"><color=#6B5182>guerreir
 cct.Daylight.t1.actions=Durante o Dia, podemos realizar até 3 das seguintes ações:<br><sprite name="UIMoveToken">Mover<br><sprite name="UIBattleToken">Batalhar<br><sprite name="CorvidPlotToken">Tramar<br><sprite name="CorvidTrickToken">Despistar<br>
 cct.Daylight.t1.move.1=Use a ação Mover para consolidar seus <sprite name="corvid"><color=#6B5182>guerreiros</color> em uma clareira mais próxima do seu inimigo.
 cct.Daylight.t1.move.2=Mova-se novamente para continuar sua marcha em direção às forças da <color=#336699>Dinastia das Rapinas</color>.
-cct.Daylight.t1.plot=Vamos começar com o que nós <color=#6B5182>Corvídeos</color> fazemos de melhor, tramar!
+cct.Daylight.t1.plot=Vamos começar com o que nós da <color=#6B5182>Conspiração</color> fazemos de melhor, conspirar!
 cct.Daylight.t1.plot.extortion=Temos uma variedade de <color=#6B5182>tramas</color> à nossa disposição. Use <sprite name="plot_extortion"> <color=#6B5182>Extorsão</color> contra a <color=#336699>Dinastia</color> para melhorar nosso fluxo de cartas.
 cct.Daylight.t1.plot.hidden=A <color=#336699>Dinastia</color> pode ver que uma <color=#6B5182>trama</color> foi armada, mas não saberá o tipo de <color=#6B5182>trama</color> até que você escolha revelá-la.
 cct.Daylight.t1.plot.sacrifice=Conspirar requer sacrifício. Sua primeira <color=#6B5182>trama</color> do turno custa um <sprite name="corvid"><color=#6B5182>guerreiro</color> na clareira onde ela é posicionada. Cada <color=#6B5182>trama</color> sucessiva custará um <sprite name="corvid"><color=#6B5182>guerreiro</color> a mais que a anterior.
 cct.Daylight.t2.bird.expose=Que <color=#6B5182>trama</color> é esta que você tramou perto do nosso <sprite name="Roost"><color=#336699>ninho</color>? Isso não pode continuar! Deve ser exposta!
-cct.Daylight.t2.bird.guess=Aposto que vocês, astutos <sprite name="corvid"><color=#6B5182>Corvídeos</color>, colocaram uma <sprite name="plot_snare"> <color=#6B5182>Armadilha</color> no nosso <sprite name="Roost"><color=#336699>ninho</color>!
+cct.Daylight.t2.bird.guess=Aposto que vocês, astutos da <sprite name="corvid"><color=#6B5182>Conspiração</color>, colocaram uma <sprite name="plot_snare"> <color=#6B5182>Armadilha</color> no nosso <sprite name="Roost"><color=#336699>ninho</color>!
 cct.Daylight.t2.embedded=Uma defesa inabalável! Sua habilidade <sprite name="EmbeddedAgents"> <color=#6B5182>Agentes Escondidos</color> adiciona um acerto às batalhas defensivas em que você tenha um marcador de <color=#6B5182>trama</color> oculto.
 cct.Daylight.t2.exposure.1=Antes de comprar cartas durante o Anoitecer, um inimigo pode tentar <color=#6B5182>Expôr</color> sua <color=#6B5182>trama</color> ao adivinhar corretamente qual é o tipo de <color=#6B5182>trama</color>. Como custo, ele deve revelar uma carta que corresponda ao naipe da clareira.
 cct.Daylight.t2.exposure.2=Se ele estiver correto, você deve descartar sua <color=#6B5182>trama</color>, ignorando seu efeito. Se ele errar, você ganha a carta revelada.
@@ -1396,7 +1396,7 @@ cct.Daylight.t3.trick.2=O <sprite name="plot_snare"> <color=#6B5182>Armadilha</c
 cct.Daylight.t4.battle.1=Agora que estamos em posição, é hora de lutar!
 cct.Daylight.t4.battle.2=O <sprite name="Roost"><color=#336699>ninho</color> deles está indefeso! Ataque novamente para finalizar.
 cct.Daylight.t4.move=Com a liderança do seu inimigo em desordem, é o momento perfeito para uma demonstração de força. Mova seus <sprite name="corvid"><color=#6B5182>guerreiros</color> para levar a batalha até a <color=#336699>Dinastia das Rapinas</color>.
-cct.Daylight.t4.nimble=Que movimento Ágil o seu! Assim como o <color=#4E6F89>Malandro</color>, os <color=#6B5182>guerreiros Corvídeos <sprite name="corvid"> </color> movem-se sem restrições de controle de clareiras.
+cct.Daylight.t4.nimble=Que movimento Ágil o seu! Assim como o <color=#4E6F89>Malandro</color>, os <color=#6B5182>guerreiros da Conspiração <sprite name="corvid"> </color> movem-se sem restrições de controle de clareiras.
 cct.Daylight.t4.offrails=Você deve estar em uma posição forte para assumir o controle daqui. Pontue <style="vpnumddteen">15</style> ou destrua peças inimigas com uma <sprite name="plot_bomb"> <color=#6B5182>Bomba</color> para concluir este cenário.
 cct.Evening.t1.draw=Anoitecer se aproxima. Com suas ações de Dia concluídas, você comprará uma carta e passará a vez para a <color=#336699>Dinastia das Rapinas</color>.
 cct.Evening.t2.end=Parece que todas as peças estão no lugar. Mas antes que nossas <color=#6B5182>tramas</color> entrem em ação, precisamos passar a vez para a <color=#336699>Dinastia das Rapinas</color> realizar seu turno.
@@ -1429,57 +1429,57 @@ ftt.exposure.intro.2=Para fazer isso, selecione o botão Exposição e revele um
 lake.Ferry=Uma vez por turno, um jogador que se mova de uma clareira com a Balsa pode mover qualquer número de guerreiros e a Balsa daquela clareira para outra clareira costeira. Após isso, ele compra uma carta.
 lake.intro=Bem-vindo ao Lago! As coisas aqui são simples, desde que você saiba como usar a Balsa.
 lake.move.Ferry=Gostaria de usar a Balsa para realizar este movimento?
-log.banker=[faction name] descarta [cardnames] por [X] <style="vptext">PV</style>.
-log.brigadier.2battle=[faction name] ativa o Brigadeiro para realizar duas batalhas.
-log.brigadier.2move=[faction name] ativa o Brigadeiro para realizar dois movimentos.
-log.captain=[faction name] ativa o Capitão para realizar uma batalha.
-log.clear.path=[faction name] descarta [name] para abrir um caminho e pontuar 1 <style="vptext">PV</style>.
-log.corvid.move=<color=#9673B4>Conspiração Corvídea</color> move [X] guerreiros para uma clareira de [suit icon].
-log.corvid.move.one=<color=#9673B4>Conspiração Corvídea</color> move 1 guerreiro para uma clareira de [suit icon].
-log.corvid.recruit=[faction name] descarta [name] para colocar um guerreiro em cada clareira de [suit icon].
-log.corvid.setup=[faction name] coloca um guerreiro em uma clareira de [suit icon].
-log.duchy.build=[faction name] revela [name] para colocar uma [building name] em uma clareira de [suit icon].
-log.duchy.dig=[faction name] descarta [name] para colocar um túnel em uma clareira de [suit icon]. [X] guerreiro(s) foram movidos para lá a partir da Toca.
-log.duchy.dig.nomove=[faction name] descarta [name] para colocar um túnel em uma clareira de [suit icon].
-log.duchy.dig.tunnel.removed=[faction name] remove um túnel de uma clareira de [suit icon].
-log.duchy.Evening.step1.bird=[faction name] devolve suas cartas reveladas para a mão e descarta as seguintes cartas de pássaro reveladas: [cardnames].
-log.duchy.Evening.step1.nobird=[faction name] devolve suas cartas reveladas para a mão.
-log.duchy.failure=[faction name] devolve [name] e descarta [cardname] devido ao Preço da Derrota.
-log.duchy.lord.score=[faction name] ativa [name] para pontuar [X] <style="vptext">PV</style>.
-log.duchy.move=<color=#BD5752>Ducado Subterrâneo</color> move [X] guerreiros para uma clareira de [suit icon].
-log.duchy.move.burrow=<color=#BD5752>Ducado Subterrâneo</color> move [X] guerreiros da Toca para uma clareira de [suit icon].
-log.duchy.move.one=<color=#BD5752>Ducado Subterrâneo</color> move 1 guerreiro para uma clareira de [suit icon].
-log.duchy.move.one.burrow=<color=#BD5752>Ducado Subterrâneo</color> move 1 guerreiro da Toca para uma clareira de [suit icon].
-log.duchy.recruit=[faction name] coloca um guerreiro na Toca.
-log.duchy.setup=[faction name] coloca seu túnel inicial e 2 guerreiros em uma clareira de canto de [suit icon]. Mais 2 guerreiros são colocados em cada clareira adjacente.
-log.duchy.sway=[faction name] revela [cardnames] para influenciar [name], ganhando [X] <style="vptext">PV</style>.
-log.embedded.agents=[faction name] ganha um golpe extra por seu marcador de trama oculto na clareira da batalha.
-log.exert=[faction name] usa Exceder para ganhar uma ação extra de Dia no Anoitecer. Como pagamento, ele deixará de comprar cartas no Anoitecer.
-log.exposure.failure=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela [name] para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega [name].
-log.exposure.failure.opponent=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela uma carta para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega a carta revelada.
-log.exposure.success=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela [name] para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
-log.exposure.success.opponent=[faction name] tenta expor um marcador de trama em uma clareira de [suit icon] e revela uma carta para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
-log.flip=[faction name] revela [plot token name] em uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
+log.banker=[faction name] - descartando [cardnames] por [X] <style="vptext">PV</style>.
+log.brigadier.2battle=[faction name] - ativando o Brigadeiro para realizar duas batalhas.
+log.brigadier.2move=[faction name] - ativando o Brigadeiro para realizar dois movimentos.
+log.captain=[faction name] - ativando o Capitão para realizar uma batalha.
+log.clear.path=[faction name] - descartando [name] para abrir um caminho e pontuar 1 <style="vptext">PV</style>.
+log.corvid.move=<color=#9673B4>Conspiração Corvídea</color> - movendo [X] guerreiros para uma clareira de [suit icon].
+log.corvid.move.one=<color=#9673B4>Conspiração Corvídea</color> - movendo 1 guerreiro para uma clareira de [suit icon].
+log.corvid.recruit=[faction name] - descartando [name] para colocar um guerreiro em cada clareira de [suit icon].
+log.corvid.setup=[faction name] - colocando um guerreiro em uma clareira de [suit icon].
+log.duchy.build=[faction name] - revelando [name] para colocar [building name] em uma clareira de [suit icon].
+log.duchy.dig=[faction name] - descartando [name] para colocar um túnel em uma clareira de [suit icon]. [X] guerreiro(s) foram movidos para lá a partir da Toca.
+log.duchy.dig.nomove=[faction name] - descartando [name] para colocar um túnel em uma clareira de [suit icon].
+log.duchy.dig.tunnel.removed=[faction name] - removendo um túnel de uma clareira de [suit icon].
+log.duchy.Evening.step1.bird=[faction name] - devolvendo suas cartas reveladas para a mão e descartando as seguintes cartas de pássaro reveladas: [cardnames].
+log.duchy.Evening.step1.nobird=[faction name] - devolvendo suas cartas reveladas para a mão.
+log.duchy.failure=[faction name] - devolvendo [name] e descartando [cardname] devido ao Preço da Derrota.
+log.duchy.lord.score=[faction name] - ativando [name] para pontuar [X] <style="vptext">PV</style>.
+log.duchy.move=<color=#BD5752>Ducado Subterrâneo</color> - movendo [X] guerreiro(s) para uma clareira de [suit icon].
+log.duchy.move.burrow=<color=#BD5752>Ducado Subterrâneo</color> - movendo [X] guerreiro(s) da Toca para uma clareira de [suit icon].
+log.duchy.move.one=<color=#BD5752>Ducado Subterrâneo</color> - movendo 1 guerreiro para uma clareira de [suit icon].
+log.duchy.move.one.burrow=<color=#BD5752>Ducado Subterrâneo</color> - movendo 1 guerreiro da Toca para uma clareira de [suit icon].
+log.duchy.recruit=[faction name] - colocando um guerreiro na Toca.
+log.duchy.setup=[faction name] - colocando o túnel inicial e 2 guerreiros em uma clareira de canto de [suit icon]. Mais 2 guerreiros são colocados em cada clareira adjacente.
+log.duchy.sway=[faction name] - revelando [cardnames] para influenciar [name], ganhando [X] <style="vptext">PV</style>.
+log.embedded.agents=[faction name] - ganhando um golpe extra por seu marcador de trama oculto na clareira da batalha.
+log.exert=[faction name] - usando Exceder para ganhar uma ação extra de Dia no Anoitecer. Como pagamento, deixará de comprar cartas no Anoitecer.
+log.exposure.failure=[faction name] - tentando expor um marcador de trama em uma clareira de [suit icon], revelando [name] para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega [name].
+log.exposure.failure.opponent=[faction name] - tentando expor um marcador de trama em uma clareira de [suit icon], revelando uma carta para adivinhar [plot token name]. A aposta está errada, e [faction name 2] pega a carta revelada.
+log.exposure.success=[faction name] - tentando expor um marcador de trama em uma clareira de [suit icon], revelando [name] para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
+log.exposure.success.opponent=[faction name] - tentando expor um marcador de trama em uma clareira de [suit icon], revelando uma carta para adivinhar [plot token name]. A aposta está correta, e o [plot token name] é removido.
+log.flip=[faction name] - revelando [plot token name] em uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
 log.flip.resolution.bomb=Bomba remove [pieces] de [faction name].
-log.flip.resolution.extortion=[faction name] pega uma carta de [faction name 2].
-log.foremole=[faction name] ativa o Capataz, revelando [name] para colocar [building name] em uma clareira de [suit icon].
-log.lake.Ferry=[faction name] usou a Balsa ao se mover e comprou uma carta.
-log.marshal=[faction name] ativa o Marechal para um movimento.
-log.mayor=[faction name] copia a ação de [name] com o Prefeito.
-log.navalwarfare.hit=[faction name] pontua um golpe de Guerra Naval.
+log.flip.resolution.extortion=[faction name] - pegando uma carta de [faction name 2].
+log.foremole=[faction name] - ativando o Capataz, revelando [name] para colocar [building name] em uma clareira de [suit icon].
+log.lake.Ferry=[faction name] - usando a Balsa ao se mover e comprando uma carta.
+log.marshal=[faction name] - ativando o Marechal para um movimento.
+log.mayor=[faction name] - copiando a ação de [name] com o Prefeito.
+log.navalwarfare.hit=[faction name] - pontuando um golpe de Guerra Naval.
 log.playerwon=Vitória - [faction name]
-log.plot=[faction name] remove [X] guerreiros de uma clareira de [suit icon] para posicionar uma trama oculta lá.
-log.plot.one=[faction name] remove um de seus guerreiros de uma clareira de [suit icon] para posicionar uma trama oculta lá.
+log.plot=[faction name] - removendo [X] guerreiro(s) de uma clareira de [suit icon] para posicionar uma trama oculta lá.
+log.plot.one=[faction name] - removendo um de seus guerreiros de uma clareira de [suit icon] para posicionar uma trama oculta lá.
 log.spawn.burrow=[X] Guerreiro(s) adicionados à Toca
-log.Tower.score=[faction name] ganha 1 <style="vptext">PV</style> por governar a clareira com a <sprite name="TowerToken"> <color=#6E5656>Torre</color>.
-log.trick=[faction name] trocou a localização de dois marcadores de trama.
+log.Tower.score=[faction name] - ganhando 1 <style="vptext">PV</style> por governar a clareira com a <sprite name="TowerToken"> <color=#6E5656>Torre</color>.
+log.trick=[faction name] - trocando a localização de dois marcadores de trama.
 ministertype.lords=Lordes
 ministertype.nobles=Nobres
 ministertype.squires=Comuns
 mountain.intro=Bem-vindo à Montanha! Há algumas coisas que você deve saber se quiser ser o governante por aqui.
 mountain.pass=A clareira com a <sprite name="TowerToken"> <color=#6E5656>Torre</color> é chamada de Passagem. No final do Anoitecer de um jogador, ele pontua <sprite name="1VP"> se governar a Passagem.
 mountain.path=Há alguns caminhos fechados aqui que precisarão ser abertos se você quiser atravessá-los. Uma vez por turno durante o Dia, um jogador pode gastar uma carta para transformar um caminho fechado adjacente em um caminho aberto e pontuar <sprite name="1VP">.
-playerinfo.corvid.Birdsong=1º: Criar – usando tramas, reveladas ou ocultas.<br><br>2º: Revelar Tramas – Revele marcadores de trama à sua escolha em clareiras com guerreiros Corvídeos. Para cada revelação, pontue 1 PV por trama revelada no mapa e, em seguida, resolva seu efeito de revelação, se houver.<br><br>3º: Recrutar – uma vez por turno, gaste qualquer carta para posicionar um guerreiro em cada clareira correspondente.
+playerinfo.corvid.Birdsong=1º: Criar – usando tramas, reveladas ou ocultas.<br><br>2º: Revelar Tramas – Revele marcadores de trama à sua escolha em clareiras com guerreiros da Conspiração. Para cada revelação, pontue 1 PV por trama revelada no mapa e, em seguida, resolva seu efeito de revelação, se houver.<br><br>3º: Recrutar – uma vez por turno, gaste qualquer carta para posicionar um guerreiro em cada clareira correspondente.
 playerinfo.corvid.Daylight=Realize até 3 ações.<br><br><sprite index=96>Tramar<br>Remova um guerreiro Corvídeo, mais um por marcador de trama que você tenha posicionado neste turno, de uma clareira sem marcador de trama para posicionar um marcador de trama oculta lá.<br><br><sprite index=96>Despistar<br>Troque dois marcadores de trama, reveladas ou ocultas, no mapa.<br><br><sprite index=96>Mover<br><br><sprite index=96>Batalhar
 playerinfo.corvid.embeddedagents.description=Em batalha como defensor com um marcador de trama oculta, você causa um golpe extra.
 playerinfo.corvid.embeddedagents.title=Agentes Escondidos
@@ -1524,45 +1524,45 @@ prompt.challenges.nolordsbeforeme.minister.Lord=Escolha um Lorde para influencia
 prompt.challenges.nolordsbeforeme.minister.Squire=Escolha um Comum para influenciar gratuitamente.
 prompt.corvid.exposure.title=Exposição
 prompt.corvid.plot.place=Escolha uma trama para posicionar.
-prompt.corvid.plot.place.opponent=[player] está escolhendo uma trama para posicionar.
+prompt.corvid.plot.place.opponent=[player] - escolhendo uma trama para posicionar.
 prompt.corvid.plot.title=Trama
-prompt.corvid.raid.warrior=Escolha clareiras para posicionar [X] guerreiros.
-prompt.corvid.raid.warrior.opponent=[player] está escolhendo clareiras para posicionar guerreiros.
+prompt.corvid.raid.warrior=Escolha clareiras para posicionar [X] guerreiro(s).
+prompt.corvid.raid.warrior.opponent=[player] - escolhendo clareiras para posicionar guerreiros.
 prompt.corvid.trick.swap=Escolha um segundo marcador de trama para trocar.
-prompt.corvid.trick.swap.opponent=[player] está escolhendo marcadores de trama para trocar.
+prompt.corvid.trick.swap.opponent=[player] - escolhendo marcadores de trama para trocar.
 prompt.duchy.chooseminister.title=Escolha um Ministro
 prompt.duchy.dig.discard=Escolha uma carta para gastar.
-prompt.duchy.dig.discard.opponent=[player] está escolhendo uma carta para descartar para escavar um túnel.
+prompt.duchy.dig.discard.opponent=[player] - escolhendo uma carta para descartar para escavar um túnel.
 prompt.duchy.dig.tunnel.place=Posicione um túnel.
-prompt.duchy.dig.tunnel.place.opponent=[player] está posicionando um túnel.
+prompt.duchy.dig.tunnel.place.opponent=[player] - posicionando um túnel.
 prompt.duchy.dig.tunnel.remove=Escolha um túnel para remover do tabuleiro.
-prompt.duchy.dig.tunnel.remove.opponent=[player] está escolhendo um túnel para remover do jogo.
+prompt.duchy.dig.tunnel.remove.opponent=[player] - escolhendo um túnel para remover do jogo.
 prompt.duchy.dig.warriors.move=Mova até 4 guerreiros da toca.
 prompt.duchy.minister.banker.discard=Descarte qualquer número de cartas que compartilhem o mesmo naipe.
-prompt.duchy.minister.banker.discard.opponent=[player] está escolhendo cartas para descartar com o Banqueiro.
+prompt.duchy.minister.banker.discard.opponent=[player] - escolhendo cartas para descartar com o Banqueiro.
 prompt.duchy.minister.brigadier=Escolha Uma
 prompt.duchy.minister.brigadier.button.battle=Batalhar x2
 prompt.duchy.minister.brigadier.button.move=Mover x2
-prompt.duchy.minister.brigadier.opponent=[player] está considerando opções...
+prompt.duchy.minister.brigadier.opponent=[player] - considerando opções...
 prompt.duchy.minister.foremole.building=Escolha uma construção para construir.
 prompt.duchy.minister.foremole.clearing=Escolha uma clareira para construir.
 prompt.duchy.minister.mayor=Escolha um Nobre ou Comum influenciado.
-prompt.duchy.minister.mayor.opponent=[player] está considerando opções...
+prompt.duchy.minister.mayor.opponent=[player] - considerando opções...
 prompt.duchy.priceoffailure.description=Escolha um Ministro para devolver como o Preço da Derrota.
-prompt.duchy.priceoffailure.description.opponent=[player] está escolhendo um Ministro para devolver como o Preço da Derrota.
+prompt.duchy.priceoffailure.description.opponent=[player] - escolhendo um Ministro para devolver como o Preço da Derrota.
 prompt.duchy.priceoffailure.title=Preço da Derrota
 prompt.duchy.sway.minister=Escolha um ministro para influenciar.
 prompt.duchy.sway.minister.noneavailable=Nenhum ministro disponível para influenciar. Pressione o botão continuar.
-prompt.duchy.sway.minister.noneavailable.opponent=[player] está escolhendo um ministro para influenciar.
-prompt.duchy.sway.minister.opponent=[player] está escolhendo um ministro para influenciar.
-prompt.duchy.sway.reveal=Escolha [X] cartas para revelar. Cartas de pássaro reveladas serão descartadas.
-prompt.duchy.sway.reveal.opponent=[player] está escolhendo cartas para revelar.
+prompt.duchy.sway.minister.noneavailable.opponent=[player] - escolhendo um ministro para influenciar.
+prompt.duchy.sway.minister.opponent=[player] - escolhendo um ministro para influenciar.
+prompt.duchy.sway.reveal=Escolha [X] carta(s) para revelar. Cartas de pássaro reveladas serão descartadas.
+prompt.duchy.sway.reveal.opponent=[player] - escolhendo cartas para revelar.
 prompt.duchy.swayminister.crowns=<sprite name="crown"> x {0}
 prompt.duchy.swayministers.title=Influenciar Ministros
 prompt.exposure.card=Escolha uma carta para revelar.
-prompt.exposure.card.opponent=[player] está escolhendo cartas para revelar.
+prompt.exposure.card.opponent=[player] - escolhendo cartas para revelar.
 prompt.exposure.plot.type=Escolha um tipo de trama para proclamar.
-prompt.exposure.plot.type.opponent=[player] está escolhendo um tipo de trama para proclamar.
+prompt.exposure.plot.type.opponent=[player] - escolhendo um tipo de trama para proclamar.
 prompt.factiondraft.insurgent=Insurgente
 prompt.factiondraft.militant=Militante
 prompt.locked.factiondraft=Não pode ser escolhido a menos que ao menos uma facção militante tenha sido escolhida.
@@ -1570,8 +1570,8 @@ prompts.duchy.revealswayedministers.title=Ministros Influenciados
 prompts.duchy.revealunswayedministers.title=Ministros Não Influenciados
 prompts.duchybuild.citadel=Cidadela
 prompts.duchybuild.market=Mercado
-prompts.gameresults.winner.CorvidConspiracy=Vitória - Corvídios
-prompts.gameresults.winner.UndergroundDuchy=Vitória - Ducado
+prompts.gameresults.winner.CorvidConspiracy=Vitória - Conspiração Corvídea
+prompts.gameresults.winner.UndergroundDuchy=Vitória - Ducado Subterrâneo
 root.duchy.banker=Banqueiro
 root.duchy.banker.text=Gaste qualquer número de cartas do mesmo naipe para pontuar uma quantidade equivalente de <style="vptext">PV</style>.
 root.duchy.baronofdirt=Barão da Terra
@@ -1635,13 +1635,13 @@ tooltip.advancedsetup=<size=125%><b>Preparação Avançada</b></size><br>A Prepa
 tooltip.advancedsetup.locked=<size=125%><b>Preparação Avançada</b></size><br>A Preparação Avançada é uma forma alternativa de selecionar e preparar facções, que altera o equilíbrio entre elas e oferece maior variedade de posicionamentos iniciais. Ao usar essa preparação, os jogadores também compram 5 cartas iniciais e descartam 2. Para desbloquear este modo, você deve possuir 6 ou mais facções em sua coleção.
 tooltip.advancedsetup.ownedfactions=As facções incluídas no draft da preparação avançada não podem ser modificadas manualmente. Em vez disso, elas representam a coleção do jogador que criou o jogo.
 tooltip.banned.alliance=Aliança Banida
-tooltip.banned.corvid=Corvídeos Banidos
+tooltip.banned.corvid=Conspiração Banida
 tooltip.banned.duchy=Ducado Banido
 tooltip.banned.eyrie=Rapinas Banidas
-tooltip.banned.lizards=Lagartos Banidos
+tooltip.banned.lizards=Cultistas Banidos
 tooltip.banned.marquise=Marqueses Banidos
 tooltip.banned.riverfolk=Ribeirinhos Banidos
-tooltip.banned.secondvagabond=Segundo Malandro Banidos
+tooltip.banned.secondvagabond=Segundo Malandro Banido
 tooltip.banned.vagabond=Malandro Banido
 tooltip.corvid.plots.description=Cada clareira pode conter apenas um marcador de trama.
 tooltip.crowns=Cada nível de Ministro (Comum, Nobre, Lorde) pode ser influenciado no máximo 3 vezes por jogo. A quantidade de vezes restantes é representada por coroas.
@@ -1654,13 +1654,13 @@ tooltip.minister.moreinfo=Para Influenciar um ministro, você deve revelar um n�
 tooltip.mountainmap=<size=125%><b>Mapa da Montanha</b></size><br>Limpe caminhos bloqueados e controle a Torre para ganhar pontos de vitória adicionais.
 tooltip.mountainmap.tower=<size=125%><b>Torre</b></size>\nA clareira com a <sprite name="TowerToken"> <color=#6E5656>Torre</color> é chamada de Passagem. No final do Anoitecer de um jogador, ele pontua <sprite name="1VP"> se governar a Passagem.
 tooltip.offensiveagents.battle=<size=125%><b>Agentes Ofensivos:</b></size><br>Ao atacar em uma clareira com um marcador de trama oculto, cause um golpe extra.
-tooltip.opponent.corvid=<size=125%><b>Oponente da Conspiração Corvídea</b></size>
-tooltip.opponent.duchy=<size=125%><b>Oponente do Ducado Subterrâneo</b></size>
+tooltip.opponent.corvid=<size=125%><b>Oponente: Conspiração Corvídea</b></size>
+tooltip.opponent.duchy=<size=125%><b>Oponente: Ducado Subterrâneo</b></size>
 tooltip.opponent.invalid=<size=125%><b>Oponente sem Facção</b></size>
 tooltip.playmat.citadel=<size=125%><b>Cidadela</b></size>\nContribui com o naipe da clareira onde está para pagar custos de criação. Cidadelas também aumentam o número de Guerreiros adicionados ao Túnel no Amanhecer.
 tooltip.playmat.corvidplots=<size=125%><b>Tramas da Conspiração Corvídea</b></size>
-tooltip.playmat.corvidstack=<size=125%><b>Guerreiros da Conspiração Corvídea</b></size>
-tooltip.playmat.duchystack=<size=125%><b>Guerreiros do Ducado Subterrâneo</b></size>
+tooltip.playmat.corvidstack=<size=125%><b>Guerreiros da Conspiração</b></size>
+tooltip.playmat.duchystack=<size=125%><b>Guerreiros do Ducado</b></size>
 tooltip.playmat.Ferry=<size=125%><b>Balsa</b></size>\nUma vez por turno, um jogador que realizar um movimento a partir da clareira costeira com a Balsa pode se mover para outra clareira costeira, movendo também a Balsa. (Segue as regras normais de movimento.) Após realizar esse movimento, o jogador compra uma carta. A Balsa não pode ser alvo de batalhas ou ser removida.
 tooltip.playmat.market=<size=125%><b>Mercado</b></size>\nContribui com o naipe da clareira onde está para pagar custos de criação. Mercados também aumentam o número de cartas que o jogador do Ducado Subterrâneo compra no Anoitecer.
 tooltip.playmat.plot.Bomb.Down=<size=125%><b>Bomba Oculta</b></size>\nQuando revelado, remova todas as peças inimigas na sua clareira e, em seguida, remova este marcador.
@@ -1701,61 +1701,61 @@ tooltip.ui.reset.disabled=Facções não podem ser redefinidas enquanto a Prepar
 tooltip.ui.swayedministers=<size=125%><b>Ministros Influenciados</b></size>\nVeja os Ministros que o jogador do Ducado Subterrâneo influenciou.
 tooltip.ui.unswayedministers=<size=125%><b>Ministros Não Influenciados</b></size>\nVeja os Ministros que você não influenciou.
 tuber.canis.abilities.CorvidConspiracyAbilities.BattleAbility=Escolha um oponente para batalhar.
-tuber.canis.abilities.CorvidConspiracyAbilities.BattleAbility.opponent=[player] está escolhendo um inimigo para batalhar.
+tuber.canis.abilities.CorvidConspiracyAbilities.BattleAbility.opponent=[player] - escolhendo um inimigo para batalhar.
 tuber.canis.abilities.CorvidConspiracyAbilities.plotAbility=Escolha uma clareira para colocar uma trama.
-tuber.canis.abilities.CorvidConspiracyAbilities.plotAbility.opponent=[player] está escolhendo uma clareira para colocar uma trama.
+tuber.canis.abilities.CorvidConspiracyAbilities.plotAbility.opponent=[player] - escolhendo uma clareira para colocar uma trama.
 tuber.canis.abilities.CorvidConspiracyAbilities.TrickAbility=Escolha um marcador de trama para trocar.
-tuber.canis.abilities.CorvidConspiracyAbilities.TrickAbility.opponent=[player] está escolhendo marcadores de trama para trocar.
+tuber.canis.abilities.CorvidConspiracyAbilities.TrickAbility.opponent=[player] - escolhendo marcadores de trama para trocar.
 tuber.canis.abilities.ExposureAbility=Escolha uma trama para expor.
-tuber.canis.abilities.ExposureAbility.opponent=[player] está escolhendo uma trama para expor.
+tuber.canis.abilities.ExposureAbility.opponent=[player] - escolhendo uma trama para expor.
 tuber.canis.abilities.TrailblazingAbility=Escolha uma carta para descartar.
-tuber.canis.abilities.TrailblazingAbility.opponent=[player] está escolhendo uma carta para descartar como parte da abertura de um caminho.
+tuber.canis.abilities.TrailblazingAbility.opponent=[player] - escolhendo uma carta para descartar como parte da abertura de um caminho.
 tuber.canis.abilities.UndergroundDuchyAbilities.DuchyBattleAbility=Escolha um inimigo para batalhar.
-tuber.canis.abilities.UndergroundDuchyAbilities.DuchyBattleAbility.opponent=[player] está escolhendo um inimigo para batalhar.
+tuber.canis.abilities.UndergroundDuchyAbilities.DuchyBattleAbility.opponent=[player] - escolhendo um inimigo para batalhar.
 tuber.canis.abilities.UndergroundDuchyAbilities.DuchyBuildAbility=Escolha uma clareira para construir.
-tuber.canis.abilities.UndergroundDuchyAbilities.DuchyBuildAbility.opponent=[player] está escolhendo uma clareira para construir.
+tuber.canis.abilities.UndergroundDuchyAbilities.DuchyBuildAbility.opponent=[player] - escolhendo uma clareira para construir.
 tuber.canis.abilities.UndergroundDuchyAbilities.DuchyChooseBuilding=Escolha uma construção para erguer.
-tuber.canis.abilities.UndergroundDuchyAbilities.DuchyChooseBuilding.opponent=[player] está escolhendo uma construção para erguer.
+tuber.canis.abilities.UndergroundDuchyAbilities.DuchyChooseBuilding.opponent=[player] - escolhendo uma construção para erguer.
 tuber.canis.actions.BirdsongActivations.Expose=Expor uma trama?
-tuber.canis.actions.BirdsongActivations.Expose.opponent=[player] está escolhendo expor uma trama.
+tuber.canis.actions.BirdsongActivations.Expose.opponent=[player] - escolhendo expor uma trama.
 tuber.canis.actions.BirdsongActivations.ExposeOrCard=Expor uma trama ou escolher uma carta com ativação de Amanhecer para ativar.
-tuber.canis.actions.BirdsongActivations.ExposeOrCard.opponent=[player] está considerando opções...
+tuber.canis.actions.BirdsongActivations.ExposeOrCard.opponent=[player] - considerando opções...
 tuber.canis.actions.challenges.DredgingTheLakeDraw.discardchoice=Escolha uma carta descartada para comprar.
 tuber.canis.actions.challenges.DredgingTheLakeDraw.drawfromdeckordiscard=Comprar do monte de descarte em vez do baralho?
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongFlipTokens=Revele marcadores de trama.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongFlipTokens.NoActions=Sem tramas para revelar. Pressione o botão de continuar.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongFlipTokens.NoActions.opponent=Aguardando a Conspiração Corvídea para continuar.
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongFlipTokens.opponent=A Conspiração Corvídea está escolhendo marcadores de trama para revelar.
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongFlipTokens.opponent=Conspiração Corvídea - escolhendo marcadores de trama para revelar.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruit=Descarte uma carta para recrutar um guerreiro em cada clareira correspondente ao seu naipe.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruit.NoActions=Sem cartas na mão para descartar para recrutar. Pressione o botão de continuar.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruit.NoActions.opponent=Aguardando a Conspiração Corvídea para continuar.
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruit.opponent=A Conspiração Corvídea está escolhendo uma carta para descartar e recrutar.
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruit.opponent=Conspiração Corvídea - escolhendo uma carta para descartar e recrutar.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitClearing=Escolha o tipo de clareira para recrutar.
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitClearing.opponent=[player] está considerando opções...
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitClearing.opponent=[player] - considerando opções...
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitSuit=Escolha o tipo de clareira para recrutar.
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitSuit.opponent=Corvídeos estão escolhendo um tipo de clareira para recrutar.
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitWithCount=Escolha o tipo de clareira para recrutar. O número de guerreiros recrutados será reduzido devido à reserva limitada ([X] guerreiros).
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitWithCount.opponent=Corvídeos estão escolhendo um tipo de clareira para recrutar.
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitSuit.opponent=Conspiração Corvídea - escolhendo um tipo de clareira para recrutar.
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitWithCount=Escolha o tipo de clareira para recrutar. O número de guerreiros recrutados será reduzido devido à reserva limitada ([X] guerreiro(s)).
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyBirdsongAction.CorvidBirdsongRecruitWithCount.opponent=Conspiração Corvídea - escolhendo um tipo de clareira para recrutar.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyChoicePhase.CorvidEveningActivations=Escolha uma ação.
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyChoicePhase.CorvidEveningActivations.opponent=A Conspiração Corvídea está escolhendo ações de Anoitecer.
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracyChoicePhase.CorvidEveningActivations.opponent=Conspiração Corvídea - escolhendo ações de Anoitecer.
 tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracySetup.CorvidStartingWarriorLocations=Escolha um de cada naipe de clareira para os seus 3 guerreiros iniciais.
-tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracySetup.CorvidStartingWarriorLocations.opponent=A Conspiração Corvídea está escolhendo clareiras para seus guerreiros iniciais.
+tuber.canis.actions.CorvidConspiracyActions.CorvidConspiracySetup.CorvidStartingWarriorLocations.opponent=Conspiração Corvídea - escolhendo clareiras para seus guerreiros iniciais.
 tuber.canis.actions.DaylightChoicePhase=Escolha uma ação.
-tuber.canis.actions.DaylightChoicePhase.opponent=[player] está ponderando sua próxima ação.
+tuber.canis.actions.DaylightChoicePhase.opponent=[player] - ponderando a próxima ação.
 tuber.canis.actions.endTurnConfirmation.CorvidConspiracy=Você ainda tem ações de Dia disponíveis. Tem certeza de que deseja avançar para o Anoitecer?
 tuber.canis.actions.endTurnConfirmation.UndergroundDuchy=Você ainda tem ações de Assembleia disponíveis. Tem certeza de que deseja avançar para a próxima etapa?
 tuber.canis.actions.UndergroundDuchyActions.RevealCardCost=Escolha uma carta para revelar. Uma carta de Pássaro revelada será descartada.
-tuber.canis.actions.UndergroundDuchyActions.RevealCardCost.opponent=O Ducado está escolhendo uma carta para revelar.
+tuber.canis.actions.UndergroundDuchyActions.RevealCardCost.opponent=Ducado Subterrâneo - escolhendo uma carta para revelar.
 tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchyParliamentPhase.DuchyDaylightParliament=Escolha um Ministro para ativar.
-tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchyParliamentPhase.DuchyDaylightParliament.opponent=O Ducado está escolhendo Ministros para ativar.
+tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchyParliamentPhase.DuchyDaylightParliament.opponent=Ducado Subterrâneo - escolhendo Ministros para ativar.
 tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchySetup.ChooseStarting=Escolha uma clareira de canto para seu túnel.
-tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchySetup.ChooseStarting.opponent=O Ducado está escolhendo uma clareira de canto para seu túnel.
+tuber.canis.actions.UndergroundDuchyActions.UndergroundDuchySetup.ChooseStarting.opponent=Ducado Subterrâneo - escolhendo uma clareira de canto para o túnel.
 tuber.canis.undo.CorvidCompanySetupUndo=Pressione o botão de continuar para concluir a preparação.
 tuber.canis.undo.CorvidCompanySetupUndo.opponent=Aguardando a Conspiração Corvídea confirmar a preparação.
 tuber.canis.undo.EyrieDynastiesSetupUndo=Pressione o botão de continuar para concluir a preparação.
 tuber.canis.undo.EyrieDynastiesSetupUndo.opponent=Aguardando a Dinastia das Rapinas confirmar a preparação.
 tuber.canis.undo.UndergroundDuchySetupUndo=Pressione o botão de continuar para concluir a preparação.
-tuber.canis.undo.UndergroundDuchySetupUndo.opponent=Aguardando o Ducado confirmar a preparação.
+tuber.canis.undo.UndergroundDuchySetupUndo.opponent=Aguardando o Ducado Subterrâneo confirmar a preparação.
 tutorial.crownslabel=Coroas Restantes
 tutorial.description.TutorialU01=Aprenda a jogar com o Ducado Subterrâneo
 tutorial.description.TutorialU02=Aprenda a jogar com a Conspiração Corvídea
@@ -1802,12 +1802,12 @@ tooltip.disablefactiondraft=<size=125%><b>Desativar Escolha de Facção</b></siz
 creategame.disablefactiondraft=Desativar Escolha de Facção
 tooltip.bansecondvagabond=<size=125%><b>Banir Segundo Malandro</b></size><br>Proíbe múltiplos Malandros no modo de Preparação Avançada.
 creategame.bansecondvagabond=Banir Segundo Malandro
-shortfactionnames.corvidconspiracy=Corvídea
+shortfactionnames.corvidconspiracy=Conspiração
 shortfactionnames.undergroundduchy=Ducado
 factionnames.keepersiniron=Guardiões de Ferro
 factionnames.lordofthehundreds=Senhor das Centenas
-tooltip.opponent.keepers=<size=125%><b>Oponente dos Guardiões de Ferro</b></size>
-tooltip.opponent.hundreds=<size=125%><b>Oponente do Senhor das Centenas</b></size>
+tooltip.opponent.keepers=<size=125%><b>Oponente: Guardiões de Ferro</b></size>
+tooltip.opponent.hundreds=<size=125%><b>Oponente: Senhor das Centenas</b></size>
 playerinfo.keepersiniron.devoutknights.title=Cavaleiros Devotos
 playerinfo.keepersiniron.devoutknights.description=Em batalha, ignore o primeiro golpe que você sofrer se tiver uma relíquia e um guerreiro Guardião. Ao mover, você pode mover uma relíquia com cada guerreiro Guardião.
 playerinfo.keepersiniron.prizedtrophies.title=Troféus Valiosos
@@ -1863,7 +1863,7 @@ keepers.faithfulretainers.desc=Quando você descartar esta carta, remova-a perma
 hundreds.command=Comandar
 hundreds.prowess=Proeza
 hundreds.lavish.desc=Você pode escolher remover itens do seu Tesouro para posicionar dois guerreiros na clareira do seu Senhor da Guerra por item removido.
-hundreds.lavish.title=Remover Itens para Luxuoso?
+hundreds.lavish.title=Remover Itens por Esbanjador?
 hundreds.contemptfortrade.button.victorypoints=<style="vptext">PV</style>
 hundreds.contemptfortrade.button.hoard=Tesouro
 hundreds.contemptfortrade.desc=Crie para adicionar <sprite name="[item]"> ao Tesouro ou para <sprite name="2VP">
@@ -1939,8 +1939,8 @@ keepers.prompt.recovered.title=Recuperado
 keepers.prompt.recovered.desc=Bônus Completo:
 keepers.prompt.delve.title=Escavar
 keepers.prompt.retinuelost.title=Séquito Perdido
-keepers.prompt.retinuelost.delve.desc=Guardas governam menos clareiras adjacentes à floresta de onde a relíquia veio do que o valor dela.
-keepers.prompt.retinuelost.recover.desc=Guardas governam menos clareiras correspondentes do que o valor da relíquia recuperada.
+keepers.prompt.retinuelost.delve.desc=Guardiões governam menos clareiras adjacentes à floresta de onde a relíquia veio do que o valor dela.
+keepers.prompt.retinuelost.recover.desc=Guardiões governam menos clareiras correspondentes do que o valor da relíquia recuperada.
 hundreds.prompt.item.tohoard=<b>Desprezo pelo Comércio</b><br>Item Adicionado ao Tesouro e Não Pontuado
 hundreds.prompt.item.tononhoard=<b>Desprezo pelo Comércio</b><br>Item Removido e Pontuado
 hundreds.prompt.warlordanointed.title=Senhor da Guerra Convocado
@@ -1964,10 +1964,10 @@ tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoRecruit=N
 creategame.enablehirelings=Habilitar Mercenários
 tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoves=Nenhum movimento possível
 tuber.canis.abilities.KeepersInIronAbilities.KeepersMoveAbility.ChooseMoveRelics=Escolha guerreiros e relíquias para mover
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve=Escolha uma clareira para Batalhar, depois Escavar
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve=Escolha uma clareira para Batalhar e Escavar.
 tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.BattleOrDelve=Escolha guerreiros inimigos para batalhar ou escolha uma relíquia para escavar
 tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.Delve=Escolha uma relíquia para Escavar
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoBattleDelve=Nenhuma Batalha, depois Escavar possível
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoBattleDelve=Sem opções para Batalhar e Escavar.
 tuber.canis.abilities.KeepersInIronAbilities.KeepersBattleDelveAbility.ChooseBattleEnemy=Escolha um inimigo para batalhar
 tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseMoveRecover=Escolha guerreiros para Mover ou uma relíquia para Recuperar
 tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseRecover=Escolha uma relíquia para recuperar
@@ -1975,7 +1975,7 @@ tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoveRecov
 tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseStarting=Escolha uma clareira para posicionar quatro guerreiros
 tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseSecond=Escolha uma clareira vizinha para posicionar quatro guerreiros
 tuber.canis.undo.KeepersSetupUndo=Pressione o botão continuar para concluir a preparação.
-tuber.canis.actions.KeepersInIronActions.KeepersRelicDestroyed=Escolha uma floresta para posicionar esta relíquia
+tuber.canis.actions.KeepersInIronActions.KeepersRelicDestroyed=Escolha uma floresta para posicionar a relíquia [X] [type] removida.
 tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.AddOrShift=Adicione cartas ao seu Séquito (máximo 10) ou mova 1 carta dentro dele
 tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Add=Adicione cartas ao seu Séquito (máximo 10)
 tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Shift=Mova uma carta no seu Séquito
@@ -2015,7 +2015,7 @@ tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseIncite
 tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteCard=Escolha uma carta correspondente para gastar.
 tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteCard=Nenhuma carta na mão correspondendo a uma compensação válida para Incitar. Pressione continuar.
 tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteMob=Nenhuma turba em estoque para Incitar. Pressione continuar.
-tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.JubilantChooseRoll=Rolar para colocar uma turba? ([X] restantes)
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.JubilantChooseRoll=Rolar para colocar uma turba? ([X] restante(s))
 keepers.prompt.mobdie.title=Dado de turba
 playerinfo.lordofthehundreds.command=Comandar
 playerinfo.lordofthehundreds.prowess=Proeza
@@ -2029,74 +2029,74 @@ tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.Adv
 tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoActions=Sem investidas restantes.
 tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.CommandNoActions=Nenhuma ação de Comando restante.
 warning.keepers.encamp=Esta clareira não tem um slot de construção aberto para sua Estação. Tem certeza de que quer escolhê-la e colocar apenas um guerreiro?
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseNewEncamp.opponent=[player] está Acampando.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseEncamp.opponent=[player] está Acampando.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseWaystation.opponent=[player] está Acampando.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoEncamp.opponent=[player] está Acampando.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseDecamp.opponent=[player] está Levantando Acampamento.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoDecamp.opponent=[player] está Levantando Acampamento.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseCardRecruit.opponent=[player] está recrutando.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseRecruitClearing.opponent=[player] está recrutando.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoRecruit.opponent=[player] está recrutando.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoves.opponent=[player] está movendo.
-tuber.canis.abilities.KeepersInIronAbilities.KeepersMoveAbility.ChooseMoveRelics.opponent=[player] está movendo.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.opponent=[players] está escolhendo Batalhar, depois Escavar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.BattleOrDelve.opponent=[players] está escolhendo Batalhar, depois Escavar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.Delve.opponent=[players] está escolhendo Escavar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoBattleDelve.opponent=[players] está escolhendo Batalhar, depois Escavar.
-tuber.canis.abilities.KeepersInIronAbilities.KeepersBattleDelveAbility.ChooseBattleEnemy.opponent=[players] está escolhendo Batalhar, depois Escavar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseMoveRecover.opponent=[players] está escolhendo Mover ou Recuperar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseRecover.opponent=[players] está escolhendo Mover ou Recuperar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoveRecover.opponent=[players] está escolhendo Mover ou Recuperar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseStarting.opponent=[player] está escolhendo uma clareira para começar.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseSecond.opponent=[player] está escolhendo uma clareira para começar.
-tuber.canis.undo.KeepersSetupUndo.opponent=[player] está escolhendo uma clareira para começar.
-tuber.canis.actions.KeepersInIronActions.KeepersRelicDestroyed.opponent=[player] está colocando a relíquia removida em uma floresta.
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.AddOrShift.opponent=[player] está recebendo o Séquito.
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Add.opponent=[player] está recebendo o Séquito.
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Shift.opponent=[player] está recebendo o Séquito.
-tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.None.opponent=[player] está recebendo o Séquito.
-tuber.canis.undo.HundredsSetupUndo.opponent=[player] está escolhendo uma clareira para começar.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsSetup.ChooseStarting.opponent=[player] está escolhendo uma clareira para começar.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRaze.opponent=[player] está iniciando seu turno.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMobClearing.opponent=[player] está escolhendo uma clareira para colocar uma turba.
-tuber.canis.actions.LordOfTheHundredsActions.NoClearingsForMob.opponent=[player] está escolhendo uma clareira para colocar uma turba.
-tuber.canis.actions.LordOfTheHundredsActions.NoMobTokens.opponent=[player] está escolhendo uma clareira para colocar uma turba.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.NoMobsForRaze.opponent=[player] está escolhendo uma clareira para colocar uma turba.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRazeTakeItem.opponent=[player] está escolhendo um item para pegar da ruína.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRecruit.opponent=[player] está recrutando.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitClearing.opponent=[player] está recrutando.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToAnoint.opponent=[player] está recrutando.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointClearing.opponent=[player] está colocando seu Senhor da Guerra.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointWarrior.opponent=[player] está convocando um guerreiro.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.AnointAlreadyPresent.opponent=[player] está escolhendo um novo humor.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMood.opponent=[player] está escolhendo um novo humor.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToLavish.opponent=[player] está escolhendo um novo humor.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseLavish.opponent=[player] está removendo itens de seu Tesouro para colocar guerreiros.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToBirdsongEnd.opponent=[player] está terminando o Amanhecer.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCraftMode.opponent=[player] está criando.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseNoCraft.opponent=[player] está criando.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCommand.opponent=[player] está escolhendo uma ação de Comando para realizar.
-tuber.canis.actions.LordOfTheHundredsActions.HundredsHoardDiscard.opponent=[player] está escolhendo um item para descartar.
-tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLoot.opponent=[player] está escolhendo se vai saquear.
-tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLootItem.opponent=[player] está escolhendo um item para saquear.
-tuber.canis.actions.LordOfTheHundredsActions.HundredsBattleBitter.opponent=[player] está escolhendo uma turba para substituir com guerreiros.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildClearing.opponent=[player] está construindo.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildCard.opponent=[player] está construindo.
-tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsBattleAbility.opponent=[player] está escolhendo Batalhar.
-tuber.canis.actions.LordOfTheHundredsActions.HundredsDaylightRelentless.opponent=[player] está escolhendo Mover ou Batalhar.
-tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteClearing.opponent=[player] está Incitando!
-tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteCard.opponent=[player] está Incitando!
-tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteCard.opponent=[player] está Incitando!
-tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteMob.opponent=[player] está Incitando!
-tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.JubilantChooseRoll.opponent=[player] está colocando uma turba usando Jubilante.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseMoveWarlord.opponent=[player] está movendo.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoWarlord.opponent=[player] está avançando o Senhor da Guerra.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOrBattle.opponent=[player] está avançando o Senhor da Guerra.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOnly.opponent=[player] está avançando o Senhor da Guerra.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceBattleOnly.opponent=[player] está avançando o Senhor da Guerra.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoActions.opponent=[player] está avançando o Senhor da Guerra.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.CommandNoActions.opponent=[player] está escolhendo uma ação de Comando para realizar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseNewEncamp.opponent=[player] - Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseEncamp.opponent=[player] - Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseWaystation.opponent=[player] - Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoEncamp.opponent=[player] - Acampando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseDecamp.opponent=[player] - Levantando Acampamento.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoDecamp.opponent=[player] - Levantando Acampamento.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseCardRecruit.opponent=[player] - recrutando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.ChooseRecruitClearing.opponent=[player] - recrutando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.NoRecruit.opponent=[player] - recrutando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoves.opponent=[player] - se movendo.
+tuber.canis.abilities.KeepersInIronAbilities.KeepersMoveAbility.ChooseMoveRelics.opponent=[player] - se movendo.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.opponent=[player] - escolhendo Batalhar e Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseBattleDelve.BattleOrDelve.opponent=[player] - escolhendo Batalhar e Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.Delve.opponent=[player] - escolhendo Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoBattleDelve.opponent=[player] - escolhendo Batalhar e Escavar.
+tuber.canis.abilities.KeepersInIronAbilities.KeepersBattleDelveAbility.ChooseBattleEnemy.opponent=[player] - escolhendo Batalhar e Escavar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseMoveRecover.opponent=[player] - escolhendo Mover ou Recuperar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.ChooseRecover.opponent=[player] - escolhendo Mover ou Recuperar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronDaylightAction.NoMoveRecover.opponent=[player] - escolhendo Mover ou Recuperar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseStarting.opponent=[player] - escolhendo uma clareira para começar.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronSetup.ChooseSecond.opponent=[player] - escolhendo uma clareira para começar.
+tuber.canis.undo.KeepersSetupUndo.opponent=[player] - escolhendo uma clareira para começar.
+tuber.canis.actions.KeepersInIronActions.KeepersRelicDestroyed.opponent=[player] - colocando a relíquia removida em uma floresta.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.AddOrShift.opponent=[player] - recebendo o Séquito.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Add.opponent=[player] - recebendo o Séquito.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.Shift.opponent=[player] - recebendo o Séquito.
+tuber.canis.actions.KeepersInIronActions.KeepersGatherRetinueAction.None.opponent=[player] - recebendo o Séquito.
+tuber.canis.undo.HundredsSetupUndo.opponent=[player] - escolhendo uma clareira para começar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsSetup.ChooseStarting.opponent=[player] - escolhendo uma clareira para começar.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRaze.opponent=[player] - iniciando o turno.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMobClearing.opponent=[player] - escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.NoClearingsForMob.opponent=[player] - escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.NoMobTokens.opponent=[player] - escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.NoMobsForRaze.opponent=[player] - escolhendo uma clareira para colocar uma turba.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRazeTakeItem.opponent=[player] - escolhendo um item para pegar da ruína.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToRecruit.opponent=[player] - recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitClearing.opponent=[player] - recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToAnoint.opponent=[player] - recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointClearing.opponent=[player] - colocando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseAnointWarrior.opponent=[player] - convocando um guerreiro.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.AnointAlreadyPresent.opponent=[player] - escolhendo um novo humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseMood.opponent=[player] - escolhendo um novo humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToLavish.opponent=[player] - escolhendo um novo humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseLavish.opponent=[player] - removendo itens de seu Tesouro para colocar guerreiros.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ContinueToBirdsongEnd.opponent=[player] - terminando o Amanhecer.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCraftMode.opponent=[player] - criando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseNoCraft.opponent=[player] - criando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseCommand.opponent=[player] - escolhendo uma ação de Comando para realizar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsHoardDiscard.opponent=[player] - escolhendo um item para descartar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLoot.opponent=[player] - escolhendo se vai saquear.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsChooseLootItem.opponent=[player] - escolhendo um item para saquear.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsBattleBitter.opponent=[player] - escolhendo uma turba para substituir com guerreiros.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildClearing.opponent=[player] - construindo.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseBuildCard.opponent=[player] - construindo.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsBattleAbility.opponent=[player] - escolhendo batalhar.
+tuber.canis.actions.LordOfTheHundredsActions.HundredsDaylightRelentless.opponent=[player] - escolhendo mover ou batalhar.
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteClearing.opponent=[player] - Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.ChooseInciteCard.opponent=[player] - Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteCard.opponent=[player] - Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.NoInciteMob.opponent=[player] - Incitando!
+tuber.canis.abilities.LordOfTheHundredsPlayer.HundredsInciteAbility.JubilantChooseRoll.opponent=[player] - colocando uma turba usando Jubilante.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.ChooseMoveWarlord.opponent=[player] - se movendo.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoWarlord.opponent=[player] - avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOrBattle.opponent=[player] - avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveOnly.opponent=[player] - avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceBattleOnly.opponent=[player] - avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceNoActions.opponent=[player] - avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.CommandNoActions.opponent=[player] - escolhendo uma ação de Comando para realizar.
 scenario.ironritual.name=Ritual de Ferro
 scenario.ironritual.tier1description=Você não pode vencer a menos que tenha 3 relíquias de tipos diferentes (figuras, tábuas, jóias) espalhadas uniformemente entre 3 clareiras de canto diferentes.
 scenario.ironritual.tier2description=Você não pode vencer a menos que tenha 3 relíquias de valores diferentes (1, 2, 3) distribuídas uniformemente entre as 3 clareiras de canto diferentes nas quais você não começou o jogo.
@@ -2115,19 +2115,19 @@ scenario.infiltrationmission.tier2description=A Opressão é substituída pela I
 scenario.mobjustice.name=Justiça da Turba
 scenario.mobjustice.tier1description=Você não pode começar batalhas em clareiras sem uma turba presente.
 scenario.mobjustice.tier2description=Você não pode começar batalhas em clareiras sem uma turba presente. Você começa com menos 1 turba e menos 3 fortes em seu suprimento.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitStronghold=No limite de suprimento de guerreiros. Escolha um Forte para recrutar um guerreiro. ([X] restantes)
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitStronghold.opponent=[player] está recrutando.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitStronghold=No limite de suprimento de guerreiros. Escolha um Forte para recrutar um guerreiro. ([X] restante(s))
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.ChooseRecruitStronghold.opponent=[player] - recrutando.
 tuber.canis.abilities.LordOfTheHundredsPlayer.TemperamentalChallengeAbility.ChooseCard=Gaste uma carta correspondente para redefinir seu humor.
 tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsSetup.ChooseMobJustice=Escolha uma clareira para colocar uma turba.
 tuber.canis.actions.ContinueToEvening=Continue para o Anoitecer.
 tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.DeliveryMissionRecruitClearing=Escolha uma clareira com uma estação para recrutar um guerreiro lá.
-tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.DeliveryMissionRecruitClearing.opponent=[player] está Recrutando.
+tuber.canis.actions.KeepersInIronActions.KeepersInIronBirdsongAction.DeliveryMissionRecruitClearing.opponent=[player] - recrutando.
 tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.TemperamentalMoodChosen=Humor determinado aleatoriamente.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.TemperamentalMoodChosen.opponent=[player] está escolhendo um novo Humor.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.TemperamentalMoodChosen.opponent=[player] - escolhendo um novo Humor.
 aiplayername.keepersiniron=Guardiões de Ferro
 aiplayername.lordofthehundreds=Senhor das Centenas
 tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.LavishNoItems=Nenhum item para remover para Esbanjador. Pressione continuar.
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.LavishNoItems.opponent=[player] está removendo itens de seu Tesouro para colocar guerreiros.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsBirdsongAction.LavishNoItems.opponent=[player] - removendo itens de seu Tesouro para colocar guerreiros.
 lht.intro.1=A Floresta treme - as <color=#B40518>Centenas</color> convocaram um novo Senhor da Guerra. Suas legiões de guerreiros e turbas empunhando tochas arrasarão Clareiras ao comando de seu demagogo.<br>Ganhar itens aumenta suas ações, e o humor inconstante de seu líder fortalece suas forças.
 lht.intro.2=Você aí! O velho <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color> caiu. Um novo <sprite name="HundredsWarrior"><color=#B40518>guerreiro</color> foi escolhido para tomar seu lugar. Vida longa ao <sprite name="HundredsWarlord"><color=#B40518>Senhor da Guerra</color>!
 lht.setup.1=Coloque seu <sprite name="Stronghold"><b><color=#B40518>Forte</color></b>, <sprite name="HundredsWarlord"><color=#B40518><b>Senhor da Guerra</b></color> e 4 <sprite name="HundredsWarrior"><color=#B40518>guerreiros</color> nesta clareira.
@@ -2289,12 +2289,12 @@ tutorial.description.TutorialM01=Aprenda a jogar com os Guardiões do Ferro
 tutorial.title.TutorialM02=Agitadores da Ralé
 tutorial.description.TutorialM02=Aprenda a jogar com o Senhor dos Centenas
 lht.2.8.gamepad=Use seu <sprite name="Stronghold"><color=#B40518>forte</color> para criar a <sprite name="bag"> que você comprou no último turno.
-tuber.canis.actions.ContinueToEvening.opponent=[player] está movendo.
+tuber.canis.actions.ContinueToEvening.opponent=[player] - se movendo.
 kiit.goal.figure=Recupere uma <sprite name="RelicFigure">
 kiit.goal.tablet=Recupere uma <sprite name="RelicTablet">
 kiit.goal.15vp=Pontue <style="vpnumddteen">15</style> ({0}/{1})
-Log.Hundreds.Start.Location=[faction name] coloca seu Senhor da Guerra e forte em uma clareira [suit icon].
-Log.Keepers.Start.Location=[faction name] coloca 4 guerreiros em uma clareira [suit icon].
+Log.Hundreds.Start.Location=[faction name] - colocando o Senhor da Guerra e um forte em uma clareira de [suit icon].
+Log.Keepers.Start.Location=[faction name] - colocando 4 guerreiros em uma clareira de [suit icon].
 Log.exile.start=O capanga Exilado é colocado em uma floresta
 Log.uprising.start=O dado da Insurgência rola [suit icon] e um guerreiro da Insurgência é colocado em uma clareira correspondente.
 Log.dynasty.start=5 guerreiros da Dinastia são colocados em uma clareira [suit icon] na borda do mapa.
@@ -2302,36 +2302,36 @@ log.patrol.start=Um guerreiro de Patrulha é colocado em cada clareira
 log.band.start=Os guerreiros da Banda são colocados em duas clareiras diferentes.
 log.vault.keepers.start=2 guerreiros Guardiões e um Cofre são colocados em uma clareira [ícone de traje]
 log.bearers.start=2 guerreiros Portadores são colocados em clareiras
-log.encamp=[faction name] substitui um guerreiro por uma estação [type] dento de um clareira [suit icon].
-log.decamp=[faction name] substitui uma estação [type] dentro de uma clareira [suit icon] por um guerreiro.
-log.recruit.keepers=[faction name] gasta [card] para recrutar dois guerreiros em uma clareira [suit icon]
-log.delve=[faction name] escava dentro de uma clareira [suit icon], descobrindo uma relíquia [X] [type].
-log.retinue.lost=[faction name] descarta [card] de seu Séquito [type].
-log.recover=[faction name] recupera uma relíquia [type], pontuando [X] <style=""vptext"">VP</style>.
-log.live.off.land=[faction name] perde um guerreiro em uma clareira [suit icon] devido à Deixe a Terra.
-log.gather.retinue=[faction name] adiciona [card] para seu Séquito [type].
-log.shift.retinue=[faction name] muda o [suit icon] de Séquito [type1] para Séquito [type2].
-log.move.relic=[faction name] move uma relíquia [type] para uma clareira [suit icon].
-log.prized.relic=[faction name] pontua um 1 <style=""vptext"">PV</style> extra de Troféu Premiado por remover uma relíquia e a colocar de volta em uma floresta
-log.raze=[faction name] arrasa uma clareira [suit icon], removendo todas as ruínas, construções inimigas e marcadores.
-log.razeitem=[faction name] arrasa uma ruína em uma clareira [suit icon]. Eles ganham [item icon].
-log.razeitem.noitems=[faction name] arrasa uma ruína em uma clareira [suit icon], mas não havia nenhum item lá.
-log.mob.spread=A turba do [faction name] se espalha para uma clareira [suit icon].
-log.anoint=[faction name] convoca um novo líder em uma clareira [suit icon].
-log.mood=[faction name] se torna [name].
-log.trash.item=[faction name] descarta [item icon] para pontuar [X] <style=""vptext"">PV</style>.
-log.hundreds.craft=[faction name] adiciona [item icon] para sua trilha [type].
-log.incite=[faction name] incita uma turba em uma clareira [suit icon].
-log.oppress=[faction name] oprime [X] clareira(s) por [X2] <style=""vptext"">PV</style>.
-log.loot=[faction name] saqueia [item icon] de [faction name 2].
-log.stubborn=A teimosia do [faction name] faz com que receba 1 dano a menos!
-log.bitter=[faction name] remove uma turba de uma clareira [suit icon] para recrutar um guerreiro.
-log.lavish=[faction name] remove [items] de seu tesouro para recrutar [X] guerreiro(s).
-log.wrathful=[faction name] recebe 1 dano extra devido ao humor Colérico!
-log.winterschill=[faction name] perde um guerreiro em uma clareira [suit icon] devido ao Frio do Inverno.
-log.infiltration=[faction name] se infiltra em [X] clareira(s) por [X2] <style=""vptext"">PV</style>.
-log.deliverymission.recover=[faction name] recupera relíquias, pontuando [X] <style=""vptext"">PV</style>.
-log.move.warlord=[faction name] move o Senhor da Guerra para uma clareira [suit icon].
+log.encamp=[faction name] - substituindo um guerreiro por uma estação [type] dentro de um clareira de [suit icon].
+log.decamp=[faction name] - substituindo uma estação [type] dentro de uma clareira de [suit icon] por um guerreiro.
+log.recruit.keepers=[faction name] - gastando [card] para recrutar dois guerreiros em uma clareira de [suit icon]
+log.delve=[faction name] - escavando dentro de uma clareira de [suit icon], descobrindo uma relíquia [X] [type].
+log.retinue.lost=[faction name] - descartando [card] de seu Séquito [type].
+log.recover=[faction name] - recuperando uma relíquia [type], pontuando [X] <style=""vptext"">VP</style>.
+log.live.off.land=[faction name] - perdendo um guerreiro em uma clareira de [suit icon] devido à Deixe a Terra.
+log.gather.retinue=[faction name] - adicionando [card] para o Séquito [type].
+log.shift.retinue=[faction name] - mudando o [suit icon] de Séquito [type1] para Séquito [type2].
+log.move.relic=[faction name] - movendo uma relíquia [type] para uma clareira de [suit icon].
+log.prized.relic=[faction name] - pontuando um 1 <style=""vptext"">PV</style> extra de Troféu Premiado por remover uma relíquia e a colocar de volta em uma floresta.
+log.raze=[faction name] - arrasando uma clareira de [suit icon], removendo todas as ruínas, construções inimigas e marcadores.
+log.razeitem=[faction name] - arrasando uma ruína em uma clareira de [suit icon], ganhando [item icon].
+log.razeitem.noitems=[faction name] - arrasando uma ruína em uma clareira de [suit icon], mas não havia nenhum item lá.
+log.mob.spread=[faction name] - a turba se espalha para uma clareira de [suit icon].
+log.anoint=[faction name] - convocando um novo líder em uma clareira de [suit icon].
+log.mood=[faction name] - se tornando [name].
+log.trash.item=[faction name] - descartando [item icon] para pontuar [X] <style=""vptext"">PV</style>.
+log.hundreds.craft=[faction name] - adicionando [item icon] para a trilha [type].
+log.incite=[faction name] - incitando uma turba em uma clareira de [suit icon].
+log.oppress=[faction name] - oprimindo [X] clareira(s) por [X2] <style=""vptext"">PV</style>.
+log.loot=[faction name] - saqueando [item icon] de [faction name 2].
+log.stubborn=[faction name] - recebendo 1 dano a menos devido ao humor Teimoso!
+log.bitter=[faction name] - removendo uma turba de uma clareira de [suit icon] para recrutar um guerreiro.
+log.lavish=[faction name] - removendo [items] do tesouro para recrutar [X] guerreiro(s).
+log.wrathful=[faction name] - recebendo 1 dano extra devido ao humor Colérico!
+log.winterschill=[faction name] - perdendo um guerreiro em uma clareira de [suit icon] devido ao Frio do Inverno.
+log.infiltration=[faction name] - se infiltrando em [X] clareira(s) por [X2] <style=""vptext"">PV</style>.
+log.deliverymission.recover=[faction name] - recuperando relíquias, pontuando [X] <style=""vptext"">PV</style>.
+log.move.warlord=[faction name] - movendo o Senhor da Guerra para uma clareira de [suit icon].
 tooltip.ui.hundreds.warriorcount=<size=125%><b>Guerreiros na Reserva</b></size>\nSe um jogador não tiver mais guerreiros em reserva, ele não poderá recrutar guerreiros.
 tooltip.ui.hundreds.drawrate=<size=125%><b>Cartão na Mão</b></size>\nO Senhor das Centenas compra cartas adicionais usando o humor Conflitante.
 tooltip.ui.hundreds.strongholds=<size=125%><b>Fortes</b></size>
@@ -2368,7 +2368,7 @@ tooltip.playmat.relic.tablet=<size=125%><b>Relíquia</b></size>\nRelíquia de T�
 tooltip.playmat.relic.figure=<size=125%><b>Relíquia</b></size>\nRelíquia de Figura
 tooltip.playmat.relic.jewelry=<size=125%><b>Relíquia</b></size>\nRelíquia de Jóias
 tooltip.playmat.stronghold=<size=125%><b>Forte</b></size>
-tooltip.playmat.mob=<size=125%><b>Turba </b></size>
+tooltip.playmat.mob=<size=125%><b>Turba</b></size>
 tooltip.playmat.waystation=Estação
 tooltip.playmat.waystation.figure.backj=Estação: <sprite name="RelicFigure"><br>Verso: <sprite name="RelicJewelry">
 tooltip.playmat.waystation.figure.backt=Estação: <sprite name="RelicFigure"><br>Verso : <sprite name="RelicTablet">
@@ -2386,7 +2386,7 @@ tooltip.playerinfo.keepers.relic.tablet.empty=<sprite name="RelicTablet"> relíq
 tooltip.playerinfo.hundreds.oppress=<b>Espaços Oprimidos</b><br>Clareiras que você governa que têm uma peça das Centenas e nenhuma peça inimiga.
 tooltip.playerinfo.hundreds.infiltration.normal=<b>Espaços Infiltrados</b><br>Clareiras governadas por inimigos e que contenham um guerreiro das Centenas ou o Senhor da Guerra.
 tooltip.playerinfo.hundreds.infiltration.heroic=<b>Espaços Infiltrados</b><br>Clareiras governadas por inimigos com pelo menos quatro peças e que contenham também um guerreiro das Centenas ou o Senhor da Guerra.
-tooltip.playmat.keeperstack=<size=125%><b>Guerreiros Guardiões</b></size>
+tooltip.playmat.keeperstack=<size=125%><b>Guerreiros dos Guardiões</b></size>
 tooltip.playmat.hundredsstack=<size=125%><b>Guerreiros das Centenas</b></size>
 tooltip.playmat.hundredswarlord=<size=125%><b>Senhor da Guerra</b></size>
 tooltip.ability.hundreds.craftforvp=<size=125%><b>Criar para <style="vptext">VP</style></b></size>\nCriar um item e marcar seus pontos de vitória normalmente. Remova o item do jogo em vez de colocá-lo em seu Tesouro.
@@ -2406,15 +2406,15 @@ lht.3.5.gamepad=Crie o <sprite name="teapot"> em sua mão para continuar aumenta
 title.keepersiniron=Guardiões de Ferro
 prompt.hundreds.choosetoloot.header=Saquear o Defensor?
 tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveNumber=Escolha o número de guerreiros para mover com seu Senhor da Guerra
-tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveNumber.opponent=[player] está avançando o Senhor da Guerra.
+tuber.canis.actions.LordOfTheHundredsActions.LordOfTheHundredsDaylightAction.AdvanceMoveNumber.opponent=[player] - avançando o Senhor da Guerra.
 shortfactionnames.keepersiniron=Guardiões
 shortfactionnames.lordofthehundreds=Centenas
 prompt.advancedsetup.keepersiniron.homeland.1=Escolha uma clareira de origem para colocar quatro guerreiros. Ela deve estar na borda do mapa com 2+ clareiras entre ela e as clareiras de origem inimigas.
-prompt.advancedsetup.keepersiniron.homeland.1.opponent=[player] está escolhendo uma clareira de origem.
+prompt.advancedsetup.keepersiniron.homeland.1.opponent=[player] - escolhendo uma clareira de origem.
 prompt.advancedsetup.keepersiniron.homeland.2=Escolha uma segunda clareira de origem para colocar quatro guerreiros. Ela deve ser adjacente à sua outra clareira de origim, na borda do mapa e com 2+ clareiras entre ela e as clareiras de origem inimigas.
-prompt.advancedsetup.keepersiniron.homeland.2.opponent=[player] está escolhendo uma segunda clareira de origem.
+prompt.advancedsetup.keepersiniron.homeland.2.opponent=[player] - escolhendo uma segunda clareira de origem.
 prompt.advancedsetup.lordofthehundreds.homeland=Escolha uma clareira de origem para colocar seu Senhor da Guerra, 4 guerreiros e um forte. Ela deve estar na borda do mapa com 2+ clareiras entre ela e as clareiras de origem inimigas.
-prompt.advancedsetup.lordofthehundreds.homeland.opponent=[player] está escolhendo uma clareira de origem.
+prompt.advancedsetup.lordofthehundreds.homeland.opponent=[player] - escolhendo uma clareira de origem.
 tooltip.devoutknights.battle=<size=125%><b>Cavaleiros Devotos</b></size><br>O primeiro golpe é ignorado porque há uma relíquia e um guerreiro Guardião nesta clareira.
 tooltip.wrathful.battle=<size=125%><b>Humor Colérico</b></size><br>Como atacante em batalha com seu Senhor da Guerra, Centenas causam um golpe adicional.
 tooltip.stubborn.battle=<size=125%><b>Humor Teimoso</b></size><br>Na batalha com seu Senhor da Guerra, Centenas ignoram o primeiro golpe que recebem.
@@ -2629,7 +2629,7 @@ root.electricEyrie.trait.nobility.bold=<size=125%><b>Nobreza</b></size>
 root.electricEyrie.trait.nobility.text=Agora você entra em tumulto se não puder posicionar um ninho ou um guerreiro.<br>Sempre que entrar em tumulto, você não perde pontos de vitória. Em vez disso, pontue um ponto por carta de pássaro no Decreto.
 root.automatedAlliance.trait.informants=Informantes
 root.automatedAlliance.trait.informants.bold=<size=125%><b>Informantes</b></size>
-root.automatedAlliance.trait.informants.text=Marcadores de simpatia indefesos se beneficiam de Emboscada Automática.
+root.automatedAlliance.trait.informants.text=Marcadores de simpatia indefesos se beneficiam de Emboscada Automatizada.
 root.automatedAlliance.trait.popularity=Popularidade
 root.automatedAlliance.trait.popularity.bold=<size=125%><b>Popularidade</b></size>
 root.automatedAlliance.trait.popularity.text=Os inimigos não pontuam ao remover marcadores de simpatia.
@@ -2914,7 +2914,7 @@ Firsttime.discard=No final do turno, você deve descartar até o limite máximo 
 Firsttime.sympathyTokenRemoved=Seu oponente removeu seu <sprite name="Sympathy"><color=#008D3F>marcador de simpatia</color>, pontuando <sprite name="1VP">. Marcadores podem ser atacados em batalha assim como Guerreiros, mas eles não podem revidar.
 practice.openingLine=Hora de colocar seu treinamento à prova. Neste jogo de prática, a primeira facção a alcançar <style="vpnumdd">20</style> vence!
 tutorial3.turnthree.turmoil.1.b=Sinto que o tumulto está se aproximando, mas você deve adicionar ao <color=#336699>Decreto</color> a cada turno, não importa o que aconteça. Faça uma atribuição agora — apenas não se preocupe muito com onde.
-tutorial3.turnthree.turmoil.1.cats=Aquelas malévolas <color=#CC6633>Marqueses</color> destruíram seu único <sprite name="Roost"><color=#336699>ninho</color> em uma clareira <sprite name="ClearingFox"> de Raposa no último turno, deixando você sem clareiras <sprite name="ClearingFox"> de Raposa para recrutar.
+tutorial3.turnthree.turmoil.1.cats=Aqueles  <color=#CC6633>Marqueses</color> destruíram seu único <sprite name="Roost"><color=#336699>ninho</color> em uma clareira <sprite name="ClearingFox"> de Raposa no último turno, deixando você sem clareiras <sprite name="ClearingFox"> de Raposa para recrutar.
 tutorial3.aiturnthree.use.sappers=Selecione a carta de Armadilheiros que você criou para remover um guerreiro inimigo adicional.
 tutorial3.turnfour.goal.1=Parece que você está pronto para seguir sozinho. Destrua construções inimigas, crie cartas e construa e proteja <sprite name="Roost"><color=#336699>ninhos</color> para pontuar <style="vpnumddteen">10</style> e completar este cenário.
 Firsttime.ally.Marquise=Você agora está <sprite name="Allied"><color=#4E6F89>aliado</color> aos <color=#CC6633>Marqueses</color>. Cada vez que você lhes fornecer <sprite name="heart"> <color=#4E6F89>ajuda</color>, você pontuará <style="vptext">PV</style>. Você também pode comandar os guerreiros deles em sua clareira para se mover e lutar ao seu lado.
@@ -2938,7 +2938,7 @@ tutorial2.ftt.encouragement=Bom trabalho destruindo aquele <sprite name="Roost">
 Clockwork.tutorial.intro=Bots Autômatos são uma alternativa desafiadora e personalizável à IA. A versão bot de cada facção funciona de maneira um pouco diferente de sua contraparte viva.
 Clockwork.tutorial.orders=No turno dele, um bot compra e revela uma carta de ordem e usa seu naipe para determinar as ações que realiza.
 Clockwork.tutorial.crafting=Se a carta de ordem tiver um item, o bot cria esse item. Ele ignora os pontos de vitória listados e, em vez disso, pontua apenas <sprite name="1VP">.
-Clockwork.tutorial.powers.1=Você pode revisar os poderes especiais de um bot e a ordem de seu turno selecionando o avatar dele. Vamos fazer isso agora para os Marqueses Mecânicos.
+Clockwork.tutorial.powers.1=Você pode revisar os poderes especiais de um bot e a ordem de seu turno selecionando o avatar dele. Vamos fazer isso agora para o Marquês Mecânico.
 Clockwork.tutorial.powers.1.gamepad=Você pode revisar os poderes especiais de um bot e a ordem de seu turno selecionando o avatar dele. Pressione <sprite name="Switch_LeftBumper"> duas vezes para fazer isso agora.
 Clockwork.tutorial.powers.2=Os seguintes poderes são compartilhados por todos os bots.
 Clockwork.tutorial.traits.gamepad=Em cada jogo, bots podem receber modificadores de dificuldade e traços adicionais. Realce um traço e pressione <sprite name="Switch_Action4"> para ver o que ele faz, depois pressione <sprite name="Switch_Action4"> novamente para descartá-lo.
@@ -2959,7 +2959,7 @@ tutorial.strategic.touch=Para ajustar o nível de zoom, posicione dois dedos no 
 tutorial.strategic.mouse=Para ajustar o nível de zoom, use a roda do mouse, as teclas de seta para cima e para baixo ou os botões +/-. Diminua o zoom ao máximo agora para entrar na visão estratégica (o que bloqueia o movimento da câmera).
 tutorial.strategic.gamepad=Para ajustar o nível de zoom, use os botões <sprite name="Switch_LeftTrigger"> e <sprite name="Switch_RightTrigger">. Diminua o zoom ao máximo agora para entrar na visão estratégica (o que bloqueia o movimento da câmera).
 scenario.fortified.name=Fortificado
-scenario.fortified.description=Use o Traço Fortificado dos Marqueses Mecânicos para enfrentar inimigos automatizados poderosos. <b>Fortificado:</b> Suas construções precisam de dois acertos para serem removidas.
+scenario.fortified.description=Use o Traço Fortificado do Marquês Mecânico para enfrentar inimigos automatizados poderosos. <b>Fortificado:</b> Suas construções precisam de dois acertos para serem removidas.
 scenario.wartax.name=Imposto de Guerra
 scenario.wartax.description=Use o Traço de Imposto de Guerra das Rapinas Elétricas para enfrentar inimigos automatizados poderosos. \n<b>Imposto de Guerra:</b> Sempre que você remover uma construção ou marcador inimigo, o dono perde um ponto de vitória.
 scenario.popularity.name=Popularidade
@@ -2987,7 +2987,7 @@ tooltip.ability.cat.march=<size=125%><b>Marchar</b></size>\nMova guerreiros entr
 tooltip.ability.cat.recruit=<size=125%><b>Recrutar</b></size>\nUma vez por turno, posicione um guerreiro em cada recrutador.
 tooltip.ability.cat.build=<size=125%><b>Erguer</b></size>\nGaste madeira para posicionar uma construção em uma clareira que você governa com um espaço de construção livre.
 tooltip.ability.cat.overwork=<size=125%><b>Hora Extra</b></size>\nGaste uma carta para posicionar uma madeira em uma clareira com uma serraria correspondente à carta.
-tooltip.ability.cat.birdaction=<size=125%><b>Rapinas para Contratar</b></size>\nGaste 1 carta de pássaro para realizar uma ação adicional.
+tooltip.ability.cat.birdaction=<size=125%><b>Pássaros para Contratar</b></size>\nGaste 1 carta de pássaro para realizar uma ação adicional.
 tooltip.ui.alliance.warriorcount=<size=125%><b>Reserva (Guerreiros + Oficiais)</b></size>\nSe um jogador não tiver mais peças em reserva, ele não poderá recrutar guerreiros nem ganhar oficiais.
 tooltip.ui.alliance.officercount=<size=125%><b>Oficiais</b></size>\nA Aliança usa oficiais para comandar operações militares: Mover, Recrutar, Batalha e Organizar.
 tooltip.ability.alliance.revolt=<size=125%><b>Revolta</b></size>\nGaste 2 apoiadores correspondentes a uma clareira simpática para remover peças inimigas lá, posicionar uma base e guerreiros correspondentes e ganhar um oficial.
@@ -3142,10 +3142,10 @@ tooltip.ui.crackdown=<size=125%><b>Repressão:</b></size><br>Sempre que uma base
 tooltip.ui.coop=<size=125%><b>Jogo Cooperativo</b></size><br>Jogue como um time contra oponentes Autômatos. Para vencer, os jogadores (e a IA) devem pontuar 30 pontos de vitória antes que qualquer oponente Autômato alcance 30 pontos de vitória. Cartas de Domínio são removidas.
 landing.grm=Ir para o aplicativo Dire Wolf Game Room
 grm.return=Voltar ao aplicativo Dire Wolf Game Room
-tooltip.opponent.mechanical.marquise=<size=125%><b>Oponente Marqueses Mecânicos</b></size>
-tooltip.opponent.electric.eyrie=<size=125%><b>Oponente Rapinas Elétricas</b></size>
-tooltip.opponent.automated.alliance=<size=125%><b>Oponente Aliança Automatizada</b></size>
-tooltip.opponent.vagabot=<size=125%><b>Oponente Automalandro</b></size>
+tooltip.opponent.mechanical.marquise=<size=125%><b>Oponente: Marquês Mecânico</b></size>
+tooltip.opponent.electric.eyrie=<size=125%><b>Oponente: Rapinas Elétricas</b></size>
+tooltip.opponent.automated.alliance=<size=125%><b>Oponente: Aliança Automatizada</b></size>
+tooltip.opponent.vagabot=<size=125%><b>Oponente: Automalandro</b></size>
 tooltip.regularmap=<size=125%><b>Mapa de Outono</b></size><br> O mapa padrão de Root.
 tooltip.fallmap=<size=125%><b>Mapa de Outono</b></size><br> O mapa padrão de Root.
 tooltip.wintermap=<size=125%><b>Mapa de Inverno</b></size><br> Um mapa avançado com localizações de naipes das clareiras randomizadas. Diferente do mapa de Outono, o rio divide a floresta como se fosse um caminho.
@@ -3215,7 +3215,7 @@ rules.marqsetup=<style=RSH>Preparação</style><br><br>∙Compre 3 cartas.<br>�
 title.thekeep=A Torre da Guarda
 rules.thekeep=A Torre da Guarda dos Marqueses concede duas habilidades especiais enquanto estiver no mapa. Primeiro, ninguém além dos Marqueses pode colocar peças na clareira com o marcador da Torre da Guarda. Além disso, sempre que guerreiros dos Marqueses forem removidos, os Marqueses podem recorrer a seus Hospitais de Campo, gastando uma carta correspondente ao naipe da clareira dos guerreiros para colocá-los de volta na clareira com o marcador da Torre da Guarda. Essa habilidade pode ser usada instantaneamente para resgatar guerreiros removidos da clareira da Torre e no início do turno dos Marqueses para guerreiros removidos de outras clareiras.
 rules.marqturn=<style=RSH><sprite index=66>Amanhecer</style><br><br>Cada serraria gera um marcador de madeira.<br><br><style=RSH><sprite index=65>Dia</style><br><br>Primeiro, você pode criar qualquer carta em sua mão usando oficinas.<br><br>Em seguida, você pode realizar até três das seguintes ações:<br><br><style=RB>Batalha:</style> Inicie uma batalha.<br><style=RB>Marchar:</style> Realize dois movimentos.<br><style=RB>Recrutar:</style> Coloque um guerreiro em cada recrutador. Você só pode realizar essa ação uma vez por turno.<br><style=RB>Erguer:</style> Coloque uma construção em uma clareira que você controle com um espaço livre ao gastar marcadores de madeira iguais ao custo da construção. Você pode gastar qualquer madeira no mapa conectada a essa clareira por qualquer número de clareiras que você controle. Ao colocar a construção, pontue os pontos de vitória mostrados na sua trilha de construções.<br><style=RB>Hora Extra:</style> Gaste uma carta para colocar um marcador de madeira em uma serraria em uma clareira cujo naipe corresponda à carta gasta.
-rules.hawks=Rapinas para Contratar: Você pode realizar qualquer número de ações extras ao gastar uma carta de pássaro por ação extra.
+rules.hawks=Pássaros para Contratar: Você pode realizar qualquer número de ações extras ao gastar uma carta de pássaro por ação extra.
 rules.marqeve=<style=RSH><sprite index=64>Anoitecer</style><br><br>Compre uma carta, mais uma carta por cada bônus de compra descoberto. Em seguida, se você tiver mais de cinco cartas em sua mão, descarte até ficar com cinco.
 rules.eyrie=A Dinastia das Rapinas deseja restaurar sua outrora digna linhagem à antiga glória na Floresta, reassentando as clareiras da floresta. Durante o Anoitecer, a Dinastia das Rapinas pontua pontos de vitória com base no número de ninhos no mapa. Quanto maior sua presença, maiores seus ganhos. No entanto, a Dinastia das Rapinas está vinculada ao seu Decreto, um conjunto de ações obrigatórias prometidas por seu líder que cresce a cada turno. A cada turno, eles devem realizar todas as ações do Decreto, ou então entrar em tumulto.
 rules.eyriesetup=<style=RSH>Preparação</style><br><br>∙ Compre 3 cartas.<br>∙ Você começa com 6 guerreiros e 1 ninho na clareira de canto diagonalmente oposta à clareira com a Torre da Guarda. Se os Marqueses não estiverem jogando, coloque essas peças na clareira de canto à sua escolha.<br>Escolha um líder.</margin=3em>
@@ -3275,7 +3275,7 @@ rules.autoallioverview=A Aliança Automatizada é especialmente zelosa e irá se
 rules.autoallitraits=<style=RSH>Veteranos</style><br>Ganhe a habilidade Guerrilha da Aliança da Floresta. (Em batalha como defensor, você usa o resultado mais alto e o atacante usa o mais baixo.)<br><br><style=RSH>Popularidade</style><br>Os inimigos não pontuam pontos de vitória ao remover marcadores de simpatia.<br><br><style=RSH>Informantes</style><br>Marcadores de simpatia indefesos se beneficiam de Emboscadas Automatizadas.<br><br><style=RSH>Incêndio</style><br>No final do Anoitecer, Espalhe Simpatia. Não pontue pontos ao colocar este marcador de simpatia.
 rules.autoallidifficulties=<style=RSH>Fácil</style><br>Você só Organiza se uma clareira tiver quatro ou mais guerreiros da Aliança.<br><br><style=RSH>Normal</style><br>Nada é alterado.<br><br><style=RSH>Desafiador</style><br>Você Organiza se uma clareira tiver dois ou mais guerreiros da Aliança.<br><br><style=RSH>Pesadelo</style><br>Você Organiza se uma clareira tiver dois ou mais guerreiros da Aliança.<br>No final do Anoitecer, pontue um ponto de vitória.
 rules.autoalliabilities=<b>Emboscada Automatizada:</b> Em batalha como defensor com pelo menos um guerreiro da Aliança, a Aliança causa um golpe extra.<br><br><b>Ultraje Automatizado:</b> Sempre que um humano remover um marcador de simpatia ou mover qualquer guerreiro para uma clareira simpática, esse jogador deve descartar uma carta correspondente. Se não puder, a Aliança pontua um ponto de vitória. (Isso não aciona a Habilidade de Pouca Destreza Manual)<br><br><b>Repressão:</b> Sempre que uma base da Aliança for removida, devolva todos os marcadores de simpatia das clareiras correspondentes ao naipe da base removida.<br><br><b>Lei Marcial:</b> Se a Aliança colocar um marcador de simpatia em uma clareira com três ou mais guerreiros pertencentes ao mesmo inimigo, a Aliança pontua um ponto de vitória a menos, até o mínimo de zero.
-rules.autoalliturnorder=<style=RSH><sprite index=66>Amanhecer</style><br><br>Seu Amanhecer tem quatro etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><b>3º: Revolta</b><br>Se a carta de ordem não for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas que corresponda a uma base em seu estoque e, em seguida, coloque a base ordenada lá.<br><br><b>4º: Comiseração Pública</b><br>Se você não se revoltar neste Amanhecer, espalhe simpatia com base no número de marcadores de simpatia no mapa, conforme segue. Se tiver de zero a quatro, espalhe simpatia duas vezes; se tiver cinco ou mais, espalhe simpatia uma vez. (Você espalhará simpatia novamente no Dia.)<br><br><br><style=RSH><sprite index=65>Dia</style><br><br>Seu Dia tem duas etapas na seguinte ordem.<br><br><b>1º: Espalhar Simpatia</b><br>Coloque um marcador de simpatia em uma clareira ordenada não simpática com menos guerreiros inimigos adjacente a qualquer clareira simpática. Pontue os pontos de vitória conforme mostrado na sua trilha de simpatia.<br><br><b>Sem Clareiras:</b> Se não houver clareiras possíveis para alvejar, coloque um marcador de simpatia na clareira com menos peças inimigas.<br><br><b>Não Pode Espalhar:</b> Se você não puder colocar um marcador de simpatia (porque sua trilha de Simpatia está vazia ou porque não há clareira onde você possa colocar um marcador de simpatia), pontue 5 pontos de vitória.<br><br><b>2º: Revolta Surpresa</b><br>Se a carta de ordem for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática com mais peças inimigas que corresponda a uma base em seu estoque, então coloque a base correspondente lá. (Se houver múltiplas opções, revolte na clareira de maior prioridade.)<br><br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Seu Anoitecer tem três etapas na seguinte ordem:<br><br><b>1º: Organizar</b><br>Em cada clareira com uma base e três ou mais guerreiros da Aliança, remova todos os guerreiros da Aliança dessa clareira e, em seguida, espalhe simpatia.<br><br><b>2º: Recrutar</b><br>Coloque um guerreiro em cada clareira com uma base.<br><br><b>3º: Descartar Ordem</b><br>Descarte a carta de ordem atual.
+rules.autoalliturnorder=<style=RSH><sprite index=66>Amanhecer</style><br><br>Seu Amanhecer tem quatro etapas na seguinte ordem:<br><br><b>1º: Revelar Ordem</b><br>Revele uma carta de ordem.<br><br><b>2º: Criar</b><br>Crie a carta de ordem por <style=vpone>1</style> se ela tiver um item disponível.<br><br><b>3º: Revolta</b><br>Se a carta de ordem não for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática ordenada com mais peças inimigas que corresponda a uma base em seu estoque e, em seguida, coloque a base ordenada lá.<br><br><b>4º: Pena Pública</b><br>Se você não se revoltar neste Amanhecer, espalhe simpatia com base no número de marcadores de simpatia no mapa, conforme segue. Se tiver de zero a quatro, espalhe simpatia duas vezes; se tiver cinco ou mais, espalhe simpatia uma vez. (Você espalhará simpatia novamente no Dia.)<br><br><br><style=RSH><sprite index=65>Dia</style><br><br>Seu Dia tem duas etapas na seguinte ordem.<br><br><b>1º: Espalhar Simpatia</b><br>Coloque um marcador de simpatia em uma clareira ordenada não simpática com menos guerreiros inimigos adjacente a qualquer clareira simpática. Pontue os pontos de vitória conforme mostrado na sua trilha de simpatia.<br><br><b>Sem Clareiras:</b> Se não houver clareiras possíveis para alvejar, coloque um marcador de simpatia na clareira com menos peças inimigas.<br><br><b>Não Pode Espalhar:</b> Se você não puder colocar um marcador de simpatia (porque sua trilha de Simpatia está vazia ou porque não há clareira onde você possa colocar um marcador de simpatia), pontue 5 pontos de vitória.<br><br><b>2º: Revolta Surpresa</b><br>Se a carta de ordem for uma carta de <sprite name="birdicon">, remova todas as peças inimigas da clareira simpática com mais peças inimigas que corresponda a uma base em seu estoque, então coloque a base correspondente lá. (Se houver múltiplas opções, revolte na clareira de maior prioridade.)<br><br><br><style=RSH><sprite index=64>Anoitecer</style><br><br>Seu Anoitecer tem três etapas na seguinte ordem:<br><br><b>1º: Organizar</b><br>Em cada clareira com uma base e três ou mais guerreiros da Aliança, remova todos os guerreiros da Aliança dessa clareira e, em seguida, espalhe simpatia.<br><br><b>2º: Recrutar</b><br>Coloque um guerreiro em cada clareira com uma base.<br><br><b>3º: Descartar Ordem</b><br>Descarte a carta de ordem atual.
 rules.autoallistoprevolt=<b>O que pode impedir uma Revolta?</b> <br><br>As revoltas podem falhar por três razões: Primeiro, se a carta de ordem for um pássaro. Segundo, se a base ordenada já estiver no mapa. Terceiro, se nenhuma clareira simpática corresponder a uma base que não está no mapa. Como as criaturas da Floresta gostam de uma boa insurreição, essas falhas desencadeiam pena pública.
 rules.vagabotoverview=O Automalandro é um amigo ou inimigo caprichoso. Como um jogador humano, ele recompensará aqueles que criarem itens. Mas cuidado, ele pode se tornar um inimigo perigoso quando obtiver itens suficientes para aumentar seus golpes máximos.
 rules.vagabottraits=<style=RSH>Atirador de Elite</style><br>No início da batalha como atacante, cause um golpe imediato (pontuando um ponto se remover um guerreiro inimigo).<br><br><style=RSH>Berserker</style><br>Sempre que você Batalhar, mova-se para a clareira mais próxima com mais peças e ataque o jogador com mais peças lá. No Anoitecer, repare mais um item.<br><br><style=RSH>Auxiliador</style><br>Sempre que você Ajudar, pontue um ponto de vitória extra, e o jogador ajudado compra duas cartas em vez de uma.<br><br><style=RSH>Aventureiro</style><br>Você pode Batalhar no máximo uma vez por turno. No final do Dia, repita a Tarefa quantas vezes for possível.
@@ -3294,7 +3294,7 @@ title.characters=Personagens
 rules.riverfolk=Quando chegaram notícias de que a Floresta nas margens do grande lago estava mergulhando em uma guerra total, a Companhia Ribeirinha rapidamente enviou seus oficiais para estabelecer operações comerciais. À medida que as outras facções compram serviços, a Companhia Ribeirinha poderá expandir ainda mais seus interesses comerciais ao construir entrepostos comerciais pela floresta. A construção desses entrepostos é uma maneira viável de pontuar, assim como os dividendos que podem ser obtidos a partir de sua riqueza.
 rules.riverfolksetup=<style=RSH>Preparação</style><br><br><b>1º:</b> Coloque 4 guerreiros em qualquer clareira ao longo do rio.<br><b>2º:</b> Defina os preços dos serviços.
 rules.riverfolksupply=<style=RSH>Suprimento</style><br><br>∙Guerreiros x15<br>∙Bases x3 (uma de cada naipe)
-rules.riverfolkturn1=<style=RSH>Habilidades</style><br><br><b>Nadadores:</b> Você trata rios como caminhos e pode se mover ao longo dos rios independentemente de quem domine a clareira.<br><br><b>À Venda:</b> Você tem uma mão pública.<br><br><style=RSH>Serviços</style><br><br>A Companhia Ribeirinha é uma facção comercial que oferece serviços a outros jogadores. Os custos dos serviços são definidos durante o Anoitecer.<br><br>Qualquer outro jogador, no início de seu Amanhecer, pode comprar um serviço da Companhia Ribeirinha mais um adicional por clareira com um entreposto comercial e qualquer uma de suas peças. O comprador paga pelos serviços pegando guerreiros de seu próprio suprimento e adicionando-os à caixa de Pagamentos da Companhia Ribeirinha.<br><br><style=RB>Cartas da Mão:</style> O comprador pega uma carta da mão da Companhia Ribeirinha e a adiciona à sua mão.<br><style=RB>Barcos:</style> O comprador trata os rios como caminhos até o final de seu turno.<br><style=RB>Mercenários:</style> Durante o Dia e o Anoitecer deste turno, o comprador trata os guerreiros da Companhia Ribeirinha como se fossem seus, para fins de governar e batalhar (o comprador não pode movê-los, contá-los para domínio ou removê-los, exceto ao receber golpes).<br><br><b>Recebendo Golpes:</b> O comprador deve dividir os golpes recebidos igualmente entre suas peças e os guerreiros da Companhia Ribeirinha, com o comprador recebendo os golpes ímpares.
+rules.riverfolkturn1=<style=RSH>Habilidades</style><br><br><b>Nadadores:</b> Você trata rios como caminhos e pode se mover ao longo dos rios independentemente de quem domine a clareira.<br><br><b>À Venda:</b> Você tem uma mão pública.<br><br><style=RSH>Serviços</style><br><br>A Companhia Ribeirinha é uma facção comercial que oferece serviços a outros jogadores. Os custos dos serviços são definidos durante o Anoitecer.<br><br>Qualquer outro jogador, no início de seu Amanhecer, pode comprar um serviço da Companhia Ribeirinha mais um adicional por clareira com um entreposto comercial e qualquer uma de suas peças. O comprador paga pelos serviços pegando guerreiros de seu próprio suprimento e adicionando-os à caixa de Pagamentos da Companhia Ribeirinha.<br><br><style=RB>Cartas da Mão:</style> O comprador pega uma carta da mão da Companhia Ribeirinha e a adiciona à sua mão.<br><style=RB>Botes:</style> O comprador trata os rios como caminhos até o final de seu turno.<br><style=RB>Mercenários:</style> Durante o Dia e o Anoitecer deste turno, o comprador trata os guerreiros da Companhia Ribeirinha como se fossem seus, para fins de governar e batalhar (o comprador não pode movê-los, contá-los para domínio ou removê-los, exceto ao receber golpes).<br><br><b>Recebendo Golpes:</b> O comprador deve dividir os golpes recebidos igualmente entre suas peças e os guerreiros da Companhia Ribeirinha, com o comprador recebendo os golpes ímpares.
 rules.riverfolkvagapayment=O Malandro paga pelos serviços exaurindo itens—para cada item exaurido, a Companhia Ribeirinha coloca um de seus guerreiros na caixa de Pagamentos. O Malandro não pode comprar Mercenários.
 rules.riverfolkturn2=<style=RSH><sprite index=66>Amanhecer</style><br><br>Se sua caixa de Pagamentos estiver vazia, coloque dois guerreiros nela. Em seguida, se você tiver entrepostos comerciais no mapa, pontue 1 ponto de vitória para cada dois fundos (guerreiros na caixa de Fundos). Por fim, mova todos os guerreiros de suas caixas de Comprometidos e Pagamentos para seus fundos.<br><br><style=RSH><sprite index=65>Dia</style><br><br>Você pode realizar ações gastando e comprometendo fundos—guerreiros na sua caixa de Fundos. Quando você gasta um fundo, devolva o guerreiro ao suprimento de seu dono. Quando você compromete um fundo, mova o guerreiro para a caixa de Comprometidos.<br><br><style=RB>Mover:</style> Comprometa um fundo para realizar um movimento.<br><style=RB>Batalhar:</style> Comprometa um fundo para iniciar uma batalha.<br><style=RB>Criar:</style> Comprometa fundos para criar uma carta da sua mão usando entrepostos comerciais.<br><style=RB>Exportar:</style> Comprometa fundos para criar uma carta da sua mão usando entrepostos comerciais. Em vez de ganhar o efeito de criação listado na carta, descarte a carta e coloque um guerreiro na caixa de Pagamentos.<br><style=RB>Comprar:</style> Comprometa um fundo para comprar uma carta.<br><style=RB>Recrutar:</style> Gaste um fundo para colocar um guerreiro em qualquer clareira com rio.<br><style=RB>Estabeleça um Entreposto Comercial com Guarnição:</style> Gaste dois fundos para colocar um entreposto comercial e um guerreiro em uma clareira. Você deve gastar fundos da facção que domina a clareira escolhida. Cada clareira pode ter apenas um entreposto comercial.
 rules.riverfolktradedisruption=Perturbação do Comércio: Sempre que um entreposto comercial for removido, você perde metade de seus fundos. O entreposto comercial removido não retorna ao seu suprimento.<br><br>Entrepostos Comerciais removidos ainda contribuem para seu poder de criação.
@@ -3333,14 +3333,14 @@ title.closedpaths=<b>Caminhos Fechados</b>
 rule.mountainmap2=Um caminho coberto por um marcador de caminho fechado é considerado um caminho fechado. Clareiras conectadas por um caminho fechado não são adjacentes. No entanto, caminhos fechados cercam e dividem florestas da mesma forma que caminhos normais. Uma vez por turno, durante o Dia, um jogador pode gastar uma carta para remover um marcador de caminho fechado e pontuar 1 ponto de vitória. O jogador deve ter ao menos uma peça em qualquer clareira conectada ao caminho fechado para removê-lo.
 title.thepass=<b>O Desfiladeiro</b>
 rule.mountainmap3=A clareira com a torre é chamada de Desfiladeiro. No final do Anoitecer de um jogador, se esse jogador governar o Desfiladeiro, ele pontua 1 ponto de vitória.
-rule.corvidintro=Enquanto os grandes poderes lutavam pelo controle da floresta, rumores e sussurros se espalhavam por seus cantos mais sombrios. Prosperando no caos da guerra aberta, a Conspiração Corvídea elabora tramas para financiar suas operações criminosas e aterrorizar seus oponentes, até forçar a submissão da Floresta. Sempre que uma trama é revelada, os Corvídeos pontuam pontos de vitória com base no número de tramas já reveladas no mapa. Por isso, os Corvídeos devem proteger cuidadosamente suas tramas contra ataques e exposição total.
+rule.corvidintro=Enquanto os grandes poderes lutavam pelo controle da floresta, rumores e sussurros se espalhavam por seus cantos mais sombrios. Prosperando no caos da guerra aberta, a Conspiração Corvídea elabora tramas para financiar suas operações criminosas e aterrorizar seus oponentes, até forçar a submissão da Floresta. Sempre que uma trama é revelada, a Conspiração pontua pontos de vitória com base no número de tramas já reveladas no mapa. Por isso, a Conspiração deve proteger cuidadosamente suas tramas contra ataques e exposição total.
 rule.corvidsetup=<style=RSH>Preparação</style><br><br>Para cada naipe, coloque 1 guerreiro em uma clareira correspondente.
 rule.corvidsupply=<style=RSH>Suprimento</style><br><br>∙ Guerreiros x15<br>∙ Trama de Bomba x2<br>∙ Trama de Armadilha x2<br>∙ Trama de Saque x2<br>∙ Trama de Extorsão x2
 title.plots=<b>Tramas</b>
 rule.corvidplots1=A Conspiração Corvídea possui oito marcadores de trama, dois de cada um dos quatro tipos. Marcadores de trama pontuam quando são revelados durante o Amanhecer. Além disso, cada marcador de trama possui um efeito, listado abaixo.
 rule.corvidplots2=<style=RSH>Bomba</style><br>Quando revelada, remova todas as peças inimigas de sua clareira e, em seguida, remova este marcador de trama.<br><br><style=RSH>Armadilha</style><br>Enquanto estiver com a face para cima, peças inimigas não podem ser colocadas ou movidas de sua clareira.<br><br><style=RSH>Extorsão</style><br>Quando revelada, pegue uma carta aleatória de cada jogador inimigo com qualquer peça em sua clareira. Enquanto estiver com a face para cima, você compra uma carta extra durante o Anoitecer.<br><br><style=RSH>Ataque</style><br>Quando removido, coloque um guerreiro em cada clareira adjacente. Ignore este efeito se o ataque foi removido por Exposição (veja abaixo).
-rule.corvidplots3=Marcadores de trama podem ser removidos por jogadores inimigos da mesma forma que qualquer outro marcador pode ser. Além disso, jogadores inimigos podem tentar remover marcadores de trama com a face para baixo por meio de <b>Exposição:</b> A qualquer momento antes de comprar cartas durante o Anoitecer, um jogador inimigo com uma peça em uma clareira contendo um marcador de trama com a face para baixo pode mostrar aos Corvídeos uma carta que corresponda à clareira para adivinhar o tipo da trama. Se estiver correto, ele remove o marcador (pontuando um ponto) e ignora o seu efeito. Se estiver incorreto, o marcador permanece com a face para baixo, e ele entrega a carta para os Corvídeos.
-rule.corvidabilities=Para proteger seus marcadores de trama, os Corvídeos precisarão mover seus guerreiros para o fundo do território inimigo. Felizmente, seus guerreiros são <b>Ágeis</b>, o que permite que eles ignorem o controle ao se mover. Além disso, seus <b>Agentes Escondidos</b> oferecem proteção eficaz. Sempre que os Corvídeos estiverem defendendo em uma batalha em uma clareira com um marcador de trama com a face para baixo, eles causam um golpe extra — mesmo que o marcador de trama esteja indefeso!
+rule.corvidplots3=Marcadores de trama podem ser removidos por jogadores inimigos da mesma forma que qualquer outro marcador pode ser. Além disso, jogadores inimigos podem tentar remover marcadores de trama com a face para baixo por meio de <b>Exposição:</b> A qualquer momento antes de comprar cartas durante o Anoitecer, um jogador inimigo com uma peça em uma clareira contendo um marcador de trama com a face para baixo pode mostrar à Conspiração uma carta que corresponda à clareira para adivinhar o tipo da trama. Se estiver correto, ele remove o marcador (pontuando um ponto) e ignora o seu efeito. Se estiver incorreto, o marcador permanece com a face para baixo, e ele entrega a carta para a Conspiração.
+rule.corvidabilities=Para proteger seus marcadores de trama, a Conspiração precisará mover seus guerreiros para o fundo do território inimigo. Felizmente, seus guerreiros são <b>Ágeis</b>, o que permite que eles ignorem o controle ao se mover. Além disso, seus <b>Agentes Escondidos</b> oferecem proteção eficaz. Sempre que a Conspiração estiver defendendo em uma batalha em uma clareira com um marcador de trama com a face para baixo, eles causam um golpe extra — mesmo que o marcador de trama esteja indefeso!
 rule.corvidbirdsong=<style=RSH><sprite index=66>Amanhecer</style> <br><br>Primeiramente, você pode criar usando marcadores de trama, estejam eles com a face para cima ou para baixo.<br><br>Depois, você pode revelar marcadores de trama em qualquer clareira onde tenha pelo menos um guerreiro. Cada vez que você revelar uma trama, você pontua <sprite name="1VP"> por marcador de trama com a face para cima no mapa, incluindo o que acabou de revelar, e então resolve seu efeito de revelação se for uma bomba ou extorsão.<br><br>Por fim, uma vez por turno, você pode gastar qualquer carta para colocar um guerreiro em cada clareira correspondente. Se você descartar uma carta de pássaro, escolha um naipe de clareiras para colocar os guerreiros.
 rule.corviddaylight=<style=RSH><sprite index=65>Dia</style> <br><br>Você pode realizar até três das seguintes ações. <br><br><style=RB>Tramar:</style> Remova um guerreiro Corvídeo, mais um guerreiro Corvídeo por marcador de trama que você já tenha colocado neste turno, de uma clareira para colocar um marcador de trama com a face para baixo nessa clareira. Cada clareira só pode conter um marcador de trama por vez, e todos os guerreiros removidos para colocar a trama devem vir da clareira onde a trama será colocada. <br><style=RB>Despistar:</style> Troque dois marcadores de trama no mapa. Ambos os marcadores de trama devem estar com a face para cima ou com a face para baixo.<br><style=RB>Mover:</style> Realize um movimento.<br><style=RB>Batalhar:</style> Inicie uma batalha.<br><br>Adicionalmente, o jogador pode <b>Exceder</b> para realizar uma ação extra de Dia durante o Anoitecer. Se o fizer, ele não comprará cartas durante o Anoitecer deste turno.
 rule.corvidevening=<style=RSH><sprite index=64>Anoitecer</style> <br><br>Compre uma carta, mais uma carta por marcador de extorsão com a face para cima no mapa. Em seguida, descarte até ficar com cinco cartas na mão.
@@ -3351,7 +3351,7 @@ rule.duchyabilities=O Ducado recruta seus guerreiros em uma clareira especial ch
 rule.duchyBirdsong=<style=RSH><sprite index=66>Amanhecer</style> <br><br>Coloque um guerreiro, mais um guerreiro para cada ícone de guerreiro descoberto na trilha das Cidadelas, na Toca.
 rule.duchydaylight=<style=RSH><sprite index=65>Dia</style> <br><br>Primeiro, realize até duas das seguintes ações:<br><br><style=RB>Construir:</style> Revele uma carta para colocar um mercado ou cidadela em uma clareira correspondente que você governe. <br><style=RB>Recrutar:</style> Coloque um guerreiro na Toca.<br><style=RB>Mover:</style> Realize um movimento.<br><style=RB>Batalhar:</style> Inicie uma batalha.<br><style=RB>Escavar:</style> Gaste uma carta para colocar um marcador de túnel em uma clareira correspondente sem túnel e, em seguida, mova até quatro guerreiros da Toca para essa clareira. Se todos os túneis já estiverem no mapa, você pode remover um túnel no início desta ação.<br><br>Após realizar essas ações, você pode agir com qualquer um de seus ministros influenciados em qualquer ordem:<br><br><b>Capataz:</b> Revele qualquer carta para colocar uma cidadela ou mercado em qualquer clareira (correspondente ou não) que você governe.<br><b>Capitão:</b> Inicie uma batalha.<br><b>Marechal:</b> Realize um movimento.<br><b>Brigadeiro:</b> Realize até dois movimentos ou inicie até duas batalhas.<br><b>Banqueiro:</b> Gaste qualquer número de cartas (até mesmo uma) do mesmo naipe para pontuar pontos de vitória em igual número.<br><b>Prefeito:</b> Realize a ação de qualquer nobre ou comum influenciado.<br><b>Duquesa da Lama:</b> Pontue 2 pontos de vitória se todos os três túneis estiverem no mapa.<br><b>Barão da Terra:</b> Pontue <sprite name="1VP"> por mercado no mapa.<br><b>Conde da Pedra:</b> Pontue <sprite name="1VP"> por cidadela no mapa.<br><br>Por fim, você pode influenciar um ministro não influenciado. Para isso, você deve revelar um número de cartas com base na patente do ministro—um comum precisa de duas cartas, um nobre precisa de três, e um lorde precisa de quatro. No entanto, você só pode revelar cartas que correspondam a clareiras onde você tenha qualquer peça, e cada uma dessas clareiras permite revelar apenas uma carta. Além disso, você perde uma de suas três coroas iniciais dessa patente de Ministros e não poderá influenciar mais desse tipo após gastar essas três coroas. <br><br>Por fim, pontue pontos de vitória iguais à patente do ministro (Comum: <sprite name="1VP">, Nobre: <sprite name="2VP">, Lorde: <sprite name="3VP">).
 rule.duchyevening=<style=RSH><sprite index=64>Anoitecer</style> <br><br>Descarte todas as cartas de pássaro que você revelou neste turno e devolva todas as outras cartas reveladas para sua mão. Em seguida, você pode criar ativando cidadelas e mercados—eles são tratados da mesma forma aqui. Depois, compre uma carta mais uma carta por cada bônus de compra descoberto. Por fim, descarte até ficar com cinco cartas na mão.
-rule.corvidconspiracy=A Conspiração Corvídea elabora tramas para financiar suas operações criminosas e aterrorizar seus oponentes até que possam subjugar a Floresta. Os Corvídeos pontuam pontos de vitória com base em quantas tramas estão reveladas no mapa.
+rule.corvidconspiracy=A Conspiração Corvídea elabora tramas para financiar suas operações criminosas e aterrorizar seus oponentes até que possam subjugar a Floresta. A Conspiração pontua pontos de vitória com base em quantas tramas estão reveladas no mapa.
 rule.undergroundduchy=O Ducado Subterrâneo lidera seu ataque a partir do subsolo usando túneis para se mobilizar pelo mapa, convencendo ministros a se juntarem à sua causa. O Ducado ergue mercados e cidadelas para justificar sua conquista e ganhar mais apoio de separatistas da Floresta.
 rules.keepers.1=Os Guardiões de Ferro são uma ordem de cavaleiros exilados que retornaram para recuperar <b>relíquias</b> perdidas em conflitos passados.
 rules.keepers.2=Primeiro, eles devem <b>escavar</b> relíquias das florestas, depois mover as relíquias para suas <b>estações</b>, onde finalmente podem <b>recuperá-las</b> para marcar pontos. Mas eles devem planejar cuidadosamente, já que contam com seu <b>Séquito</b> de moradores da Floresta, que podem desaparecer — ou pior — enquanto ajudam os Guardiões a vasculhar e recuperar as relíquias que procuram.
@@ -3448,7 +3448,7 @@ tuber.canis.actions.VagabondActions.DiscardItems=Sua mochila está sobrecarregad
 tuber.canis.abilities.StandAndDeliverAbility=Escolha um jogador para roubar uma carta.
 tuber.canis.abilities.ActivateDominanceAbility=Escolha um jogador para formar uma coalizão.
 tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWood=Escolha onde colocar esta madeira.
-tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWoodWithCount=No limite de suprimento. Escolha onde colocar esta madeira. ([X] restantes)
+tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWoodWithCount=No limite de suprimento. Escolha onde colocar esta madeira. ([X] restante(s))
 tuber.canis.actions.MarquiseDeCatActions.FieldHospitalSelection=Descarte uma carta correspondente para o Hospital de Campo<br>para devolver ([count]) guerreiros à sua Torre da Guarda.
 tuber.canis.actions.CostActions.ExhaustSelectedItem=Escolha um item para exaurir.
 tuber.canis.actions.VagabondActions.AidActions.ChooseCardForAiding=Escolha uma carta para ajudar.
@@ -3458,7 +3458,7 @@ tuber.canis.abilities.MarquiseDeCatAbilities.BattleAbility=Escolha um inimigo pa
 tuber.canis.abilities.MarquiseDeCatAbilities.BuildAbility=Escolha uma clareira para erguer.
 tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.Discard=Escolha uma carta para descartar ao fazer Hora Extra.
 tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbility=Escolha uma clareira para recrutar um guerreiro.
-tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbilityWithCount=No limite de suprimento. Escolha uma clareira para recrutar um guerreiro. ([X] restantes)
+tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbilityWithCount=No limite de suprimento. Escolha uma clareira para recrutar um guerreiro. ([X] restante(s))
 tuber.canis.abilities.MarquiseDeCatAbilities.SpendBirdForAction=Escolha uma carta de pássaro para gastar.
 tuber.canis.abilities.VagabondAbilities.HideoutAbility=Escolha três itens para reparar.
 tuber.canis.abilities.VagabondAbilities.StealAbility=Escolha um jogador para roubar uma carta.
@@ -3475,7 +3475,7 @@ tuber.canis.abilities.WoodlandAllianceAbilities.RevoltAbility=Escolha uma clarei
 tuber.canis.abilities.WoodlandAllianceAbilities.OutrageHand=Mão do inimigo revelada após o último Ultraje.
 tuber.canis.abilities.WoodlandAllianceAbilities.SpreadSympathyAbility=Escolha uma clareira para espalhar simpatia.
 tuber.canis.abilities.WoodlandAllianceAbilities.SingleTrainAbility=Escolha uma carta para descartar e treinar um oficial.
-tuber.canis.abilities.WoodlandAllianceAbilities.TrainAbility=Escolha [X] cartas para descartar e treinar um oficial.
+tuber.canis.abilities.WoodlandAllianceAbilities.TrainAbility=Escolha [X] carta(s) para descartar e treinar um oficial.
 tuber.canis.abilities.WoodlandAllianceAbilities.WoodlandAllianceRecruitAbility=Escolha uma clareira para recrutar um guerreiro.
 tuber.canis.abilities.BetterBurrowBankAbility=Escolha outro jogador para comprar cartas junto com você.
 tuber.canis.abilities.ClaimDominanceAbility=Escolha uma carta para descartar e comprar aquela Carta de Domínio.
@@ -3493,104 +3493,104 @@ tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Re
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Move=Nenhum guerreiro em clareiras correspondentes ao decreto para mover. Continue para entrar em Tumulto.
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Battle=Nenhuma clareira para batalhar que corresponda ao decreto.<br>Continue para entrar em Tumulto.
 tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Build=Nenhuma clareira para construir que corresponda ao decreto.<br>Continue para entrar em Tumulto.
-nonPrompt.vagabondDamage=O Malandro está selecionando [X] itens para danificar.
-nonPrompt.vagabondDamageWithAllies=O Malandro está selecionando [X] itens ou aliados para danificar.
-nonPrompt.removeItems=O Malandro está selecionando [X] itens para descartar.
-nonPrompt.decreeResolve_Recruit=O decreto das Rapinas diz que devem recrutar em <line-height=120%>\n[Suits].
-nonPrompt.decreeResolve_Move=O decreto das Rapinas diz que devem mover-se de <line-height=120%>\n[Suits].
-nonPrompt.decreeResolve_Battle=O decreto das Rapinas diz que devem batalhar em <line-height=120%>\n[Suits].
-nonPrompt.decreeResolve_Build=O decreto das Rapinas diz que devem construir em <line-height=120%>\n[Suits].
-tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatSetup.ChooseStarting.opponent=Os Marqueses estão escolhendo onde colocar sua torre da guarda.
-tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Sawmill.opponent=Os Marqueses estão escolhendo uma clareira para sua serraria.
-tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Workshop.opponent=Os Marqueses estão escolhendo uma clareira para sua oficina.
-tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Recruiter.opponent=Os Marqueses estão escolhendo uma clareira para seu recrutador.
+nonPrompt.vagabondDamage=Malandro - selecionando [X] item(s) para danificar.
+nonPrompt.vagabondDamageWithAllies=Malandro - selecionando [X] item(s) ou aliados para danificar.
+nonPrompt.removeItems=Malandro - selecionando [X] item(s) para descartar.
+nonPrompt.decreeResolve_Recruit=O decreto das Rapinas diz que devem recrutar em <line-height=120%>\n[Suits]
+nonPrompt.decreeResolve_Move=O decreto das Rapinas diz que devem mover-se à partir de <line-height=120%>\n[Suits]
+nonPrompt.decreeResolve_Battle=O decreto das Rapinas diz que devem batalhar em <line-height=120%>\n[Suits]
+nonPrompt.decreeResolve_Build=O decreto das Rapinas diz que devem construir em <line-height=120%>\n[Suits]
+tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatSetup.ChooseStarting.opponent=Marqueses - escolhendo onde colocar a Torre da Guarda.
+tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Sawmill.opponent=Marqueses - escolhendo uma clareira para a serraria.
+tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Workshop.opponent=Marqueses - escolhendo uma clareira para a oficina.
+tuber.canis.actions.MarquiseDeCatActions.MarquisePlaceStartingBuildings.Recruiter.opponent=Marqueses - escolhendo uma clareira para o recrutador.
 tuber.canis.actions.MarquiseDeCatActions.RemoveWoodForBuilding=Escolha a madeira para gastar. ([X])
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesSetup.ChooseLeader.opponent=As Rapinas estão escolhendo um líder.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesSetup.ChooseStarting.opponent=As Rapinas estão escolhendo uma clareira para seu ninho.
-tuber.canis.actions.VagabondActions.VagabondSetup.ChooseVagabond.opponent=O Malandro está escolhendo seu personagem.
-tuber.canis.actions.VagabondActions.VagabondSetup.ChooseStartingLocation.opponent=O Malandro está escolhendo uma floresta para começar.
-tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatChoicePhase.opponent=Os Marqueses estão ponderando sua próxima ação.
-tuber.canis.actions.BattleActions.BattleGetDefender.opponent=[player] está escolhendo quem atacar.
-tuber.canis.actions.BattleActions.VagabondChooseAlliedAttacker.opponent=O Malandro está escolhendo um atacante aliado para atacar junto.
-tuber.canis.actions.BattleActions.ChooseInterruptCards.opponent=[player] está considerando opções...
-tuber.canis.actions.BattleActions.ChooseAmbushCards.opponent=[player] está considerando opções...
-tuber.canis.actions.MovePieces.VagabondChooseAlly.opponent=[player] está se movendo.
-tuber.canis.actions.MovePiece.NumberToMove.opponent=[player] está se movendo.
-tuber.canis.actions.MovePieces.SelectSource.opponent=[player] está se movendo.
-tuber.canis.actions.MovePieces.SelectDestination.opponent=[player] está se movendo.
-tuber.canis.actions.BirdsongActivations.opponent=[player] está considerando opções...
-tuber.canis.actions.EyrieDynastiesActions.ChooseDecrees.opponent=A Dinastia das Rapinas está atribuindo cartas ao seu decreto.
-tuber.canis.actions.DaylightActivations.opponent=[player] está considerando opções de criação.
-tuber.canis.actions.DaylightActivations.NoActions.opponent=[player] está considerando opções de criação.
-tuber.canis.actions.DrawThenDiscard.opponent=[player] está escolhendo cartas para descartar.
-tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.RevoltAction.opponent=A Aliança da Floresta está considerando uma revolta.
-tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.RevoltAction.NoActions.opponent=A Aliança da Floresta está considerando uma revolta.
-tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.SympathyAction.opponent=A Aliança da Floresta está espalhando simpatia.
-tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.SympathyAction.NoActions.opponent=A Aliança da Floresta está espalhando simpatia.
-tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceDaylightAction.opponent=[player] está considerando opções...
-tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceEveningAction.opponent=[player] está considerando opções...
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesSetup.ChooseLeader.opponent=Dinastia das Rapinas - escolhendo um líder.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesSetup.ChooseStarting.opponent=Dinastia das Rapinas - escolhendo uma clareira para o ninho.
+tuber.canis.actions.VagabondActions.VagabondSetup.ChooseVagabond.opponent=Malandro - escolhendo o personagem.
+tuber.canis.actions.VagabondActions.VagabondSetup.ChooseStartingLocation.opponent=Malandro - escolhendo uma floresta para começar.
+tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatChoicePhase.opponent=Marqueses - ponderando a próxima ação.
+tuber.canis.actions.BattleActions.BattleGetDefender.opponent=[player] - escolhendo quem atacar.
+tuber.canis.actions.BattleActions.VagabondChooseAlliedAttacker.opponent=Malandro - escolhendo um atacante aliado para atacar junto.
+tuber.canis.actions.BattleActions.ChooseInterruptCards.opponent=[player] - considerando opções...
+tuber.canis.actions.BattleActions.ChooseAmbushCards.opponent=[player] - considerando opções...
+tuber.canis.actions.MovePieces.VagabondChooseAlly.opponent=[player] - se movendo.
+tuber.canis.actions.MovePiece.NumberToMove.opponent=[player] - se movendo.
+tuber.canis.actions.MovePieces.SelectSource.opponent=[player] - se movendo.
+tuber.canis.actions.MovePieces.SelectDestination.opponent=[player] - se movendo.
+tuber.canis.actions.BirdsongActivations.opponent=[player] - considerando opções...
+tuber.canis.actions.EyrieDynastiesActions.ChooseDecrees.opponent=Dinastia das Rapinas - atribuindo cartas ao decreto.
+tuber.canis.actions.DaylightActivations.opponent=[player] - considerando opções de criação.
+tuber.canis.actions.DaylightActivations.NoActions.opponent=[player] - considerando opções de criação.
+tuber.canis.actions.DrawThenDiscard.opponent=[player] - escolhendo cartas para descartar.
+tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.RevoltAction.opponent=Aliança da Floresta - considerando uma revolta.
+tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.RevoltAction.NoActions.opponent=Aliança da Floresta - considerando uma revolta.
+tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.SympathyAction.opponent=Aliança da Floresta - espalhando simpatia.
+tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceBirdsongAction.SympathyAction.NoActions.opponent=Aliança da Floresta - espalhando simpatia.
+tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceDaylightAction.opponent=[player] - considerando opções...
+tuber.canis.actions.WoodlandAllianceActions.WoodlandAllianceEveningAction.opponent=[player] - considerando opções...
 tuber.canis.actions.tuber.canis.actions.WoodlandAllianceActions.Outrage.opponent=O jogador está escolhendo uma carta para adicionar aos Apoiadores da Aliança.
-tuber.canis.actions.VagabondActions.VagabondBirdsongActionRefresh.opponent=O Malandro está escolhendo itens para reanimar.
-tuber.canis.actions.VagabondActions.VagabondBirdsongActionSlip.opponent=O Malandro está escolhendo uma localização para deslizar.
-tuber.canis.actions.VagabondActions.AidActions.ChooseWhoToAid.opponent=O Malandro está escolhendo um jogador para ajudar.
-tuber.canis.actions.VagabondActions.ChooseQuestOption.opponent=O Malandro está escolhendo a recompensa de uma tarefa.
-tuber.canis.actions.VagabondActions.VagabondDamageActionSelectionsWithAllies.opponent=O Malandro está escolhendo baixas.
-tuber.canis.actions.VagabondActions.VagabondDamageActionSelections.opponent=O Malandro está escolhendo itens para destruir.
-tuber.canis.actions.VagabondActions.DaylightChoice.opponent=[player] está considerando opções...
-tuber.canis.actions.VagabondActions.AidActions.ChooseItemToTake.opponent=O Malandro está escolhendo um item para receber por ajudar.
-tuber.canis.actions.VagabondActions.DiscardItems.opponent=O Malandro está descartando itens.
-tuber.canis.abilities.ActivateDominanceAbility.opponent=[player] está considerando opções...
-tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWood.opponent=Os Marqueses estão escolhendo uma clareira para gerar madeira.
-tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWoodWithCount.opponent=Os Marqueses estão escolhendo uma clareira para gerar madeira.
-tuber.canis.actions.MarquiseDeCatActions.FieldHospitalSelection.opponent=Os Marqueses estão considerando o Hospital de Campo.
-tuber.canis.actions.CostActions.ExhaustSelectedItem.opponent=[player] está escolhendo um item para exaurir.
-tuber.canis.actions.VagabondActions.AidActions.ChooseCardForAiding.opponent=O Malandro está ajudando.
-tuber.canis.abilities.MarquiseDeCatAbilities.ChooseBuilding.opponent=Os Marqueses estão escolhendo um tipo de construção.
-tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.opponent=Os Marqueses estão escolhendo uma clareira para fazer Hora Extra.
-tuber.canis.abilities.MarquiseDeCatAbilities.BattleAbility.opponent=Os Marqueses estão escolhendo uma clareira para iniciar uma batalha.
-tuber.canis.abilities.MarquiseDeCatAbilities.BuildAbility.opponent=Os Marqueses estão escolhendo uma clareira para erguer uma construção.
-tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.Discard.opponent=Os Marqueses estão escolhendo uma carta para descartar e fazer Hora Extra.
-tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbility.opponent=Os Marqueses estão escolhendo uma clareira para recrutar um guerreiro.
-tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbilityWithCount.opponent=Os Marqueses estão escolhendo uma clareira para recrutar um guerreiro.
-tuber.canis.abilities.MarquiseDeCatAbilities.SpendBirdForAction.opponent=Os Marqueses estão escolhendo uma carta de pássaro para gastar em uma ação extra.
-tuber.canis.abilities.VagabondAbilities.HideoutAbility.opponent=O Malandro está reparando itens.
-tuber.canis.abilities.VagabondAbilities.StealAbility.opponent=O Malandro está escolhendo um jogador para roubar uma carta.
-tuber.canis.abilities.VagabondAbilities.TinkerAbility.opponent=O Malandro está escolhendo uma carta para pegar da pilha de descarte.
-tuber.canis.abilities.VagabondAbilities.VagabondAidAbility.opponent=O Malandro está escolhendo um jogador para ajudar.
-tuber.canis.abilities.VagabondAbilities.VagabondBattleAbility.opponent=O Malandro está escolhendo quem atacar.
-tuber.canis.abilities.VagabondAbilities.VagabondMoveAbility.opponent=O Malandro está se movendo.
-tuber.canis.abilities.VagabondAbilities.VagabondQuestAbility.opponent=O Malandro está escolhendo uma tarefa para completar.
-tuber.canis.abilities.VagabondAbilities.VagabondRepairAbility.opponent=O Malandro está escolhendo um item para reparar.
-tuber.canis.abilities.VagabondAbilities.VagabondStrikeAbility.opponent=O Malandro está escolhendo o que atacar.
-tuber.canis.abilities.WoodlandAllianceAbilities.MobilizeAbility.opponent=A Aliança da Floresta está escolhendo uma carta para adicionar aos seus Apoiadores.
-tuber.canis.abilities.WoodlandAllianceAbilities.OrganizeAbility.opponent=A Aliança da Floresta está escolhendo um guerreiro para sacrificar por simpatia.
-tuber.canis.abilities.WoodlandAllianceAbilities.RevoltAbility.opponent=A Aliança da Floresta está escolhendo uma clareira para se revoltar.
-tuber.canis.abilities.WoodlandAllianceAbilities.SpreadSympathyAbility.opponent=A Aliança da Floresta está escolhendo uma clareira para espalhar simpatia.
-tuber.canis.abilities.WoodlandAllianceAbilities.TrainAbility.opponent=A Aliança da Floresta está treinando um oficial.
-tuber.canis.abilities.WoodlandAllianceAbilities.WoodlandAllianceRecruitAbility.opponent=A Aliança da Floresta está escolhendo uma clareira para recrutar um guerreiro.
-tuber.canis.abilities.BetterBurrowBankAbility.opponent=A Aliança da Floresta está escolhendo um jogador para comprar uma carta com o Banco Bom Bocado.
-tuber.canis.abilities.ClaimDominanceAbility.opponent=[player] está escolhendo uma carta para trocar por uma carta de domínio na loja.
-tuber.canis.abilities.CobblerAbility.opponent=[player] está usando o Sapateiro para mover.
-tuber.canis.abilities.CodeBreakersAbility.opponent=[player] está usando Decodificadores para olhar a mão de um jogador.
-tuber.canis.abilities.CommandWarrenAbility.opponent=[player] está usando o Comando para batalhar.
-tuber.canis.abilities.CraftAbility.opponent=[player] está escolhendo uma carta para criar.
-tuber.canis.abilities.StandAndDeliverAbility.opponent=[player] está escolhendo um jogador para roubar uma carta com Mãos ao Alto!
-tuber.canis.abilities.TaxCollectorAbility.opponent=[player] está escolhendo um guerreiro para sacrificar por uma carta com o Coletor de Taxas.
-tuber.canis.entities.PlayableClasses.ChoosePiecesToRemove.opponent=[player] está escolhendo baixas.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Recruit.opponent=A Dinastia das Rapinas está escolhendo uma clareira para recrutar guerreiros.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Move.opponent=A Dinastia das Rapinas está escolhendo uma clareira para mover.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Battle.opponent=A Dinastia das Rapinas está escolhendo uma clareira para iniciar uma batalha.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Build.opponent=A Dinastia das Rapinas está escolhendo uma clareira para construir um ninho.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Recruit.opponent=A Dinastia das Rapinas está entrando em Tumulto.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Move.opponent=A Dinastia das Rapinas está entrando em Tumulto.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Battle.opponent=A Dinastia das Rapinas está entrando em Tumulto.
-tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Build.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+tuber.canis.actions.VagabondActions.VagabondBirdsongActionRefresh.opponent=Malandro - escolhendo itens para reanimar.
+tuber.canis.actions.VagabondActions.VagabondBirdsongActionSlip.opponent=Malandro - escolhendo uma localização para deslizar.
+tuber.canis.actions.VagabondActions.AidActions.ChooseWhoToAid.opponent=Malandro - escolhendo um jogador para ajudar.
+tuber.canis.actions.VagabondActions.ChooseQuestOption.opponent=Malandro - escolhendo a recompensa de uma tarefa.
+tuber.canis.actions.VagabondActions.VagabondDamageActionSelectionsWithAllies.opponent=Malandro - escolhendo baixas.
+tuber.canis.actions.VagabondActions.VagabondDamageActionSelections.opponent=Malandro - escolhendo itens para destruir.
+tuber.canis.actions.VagabondActions.DaylightChoice.opponent=[player] - considerando opções...
+tuber.canis.actions.VagabondActions.AidActions.ChooseItemToTake.opponent=Malandro - escolhendo um item para receber por ajudar.
+tuber.canis.actions.VagabondActions.DiscardItems.opponent=Malandro - descartando itens.
+tuber.canis.abilities.ActivateDominanceAbility.opponent=[player] - considerando opções...
+tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWood.opponent=Marqueses - escolhendo uma clareira para gerar madeira.
+tuber.canis.actions.MarquiseDeCatActions.MarquiseDeCatBirdsongAction.ChooseWhereToPutWoodWithCount.opponent=Marqueses - escolhendo uma clareira para gerar madeira.
+tuber.canis.actions.MarquiseDeCatActions.FieldHospitalSelection.opponent=Marqueses - considerando o Hospital de Campo.
+tuber.canis.actions.CostActions.ExhaustSelectedItem.opponent=[player] - escolhendo um item para exaurir.
+tuber.canis.actions.VagabondActions.AidActions.ChooseCardForAiding.opponent=Malandro - ajudando.
+tuber.canis.abilities.MarquiseDeCatAbilities.ChooseBuilding.opponent=Marqueses - escolhendo um tipo de construção.
+tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.opponent=Marqueses - escolhendo uma clareira para fazer Hora Extra.
+tuber.canis.abilities.MarquiseDeCatAbilities.BattleAbility.opponent=Marqueses - escolhendo uma clareira para iniciar uma batalha.
+tuber.canis.abilities.MarquiseDeCatAbilities.BuildAbility.opponent=Marqueses - escolhendo uma clareira para erguer uma construção.
+tuber.canis.abilities.MarquiseDeCatAbilities.OverworkAbility.Discard.opponent=Marqueses - escolhendo uma carta para descartar e fazer Hora Extra.
+tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbility.opponent=Marqueses - escolhendo uma clareira para recrutar um guerreiro.
+tuber.canis.abilities.MarquiseDeCatAbilities.RecruitAbilityWithCount.opponent=Marqueses - escolhendo uma clareira para recrutar um guerreiro.
+tuber.canis.abilities.MarquiseDeCatAbilities.SpendBirdForAction.opponent=Marqueses - escolhendo uma carta de pássaro para gastar em troca de uma ação extra.
+tuber.canis.abilities.VagabondAbilities.HideoutAbility.opponent=Malandro - reparando itens.
+tuber.canis.abilities.VagabondAbilities.StealAbility.opponent=Malandro - escolhendo um jogador para roubar uma carta.
+tuber.canis.abilities.VagabondAbilities.TinkerAbility.opponent=Malandro - escolhendo uma carta para pegar da pilha de descarte.
+tuber.canis.abilities.VagabondAbilities.VagabondAidAbility.opponent=Malandro - escolhendo um jogador para ajudar.
+tuber.canis.abilities.VagabondAbilities.VagabondBattleAbility.opponent=Malandro - escolhendo quem atacar.
+tuber.canis.abilities.VagabondAbilities.VagabondMoveAbility.opponent=Malandro - se movendo.
+tuber.canis.abilities.VagabondAbilities.VagabondQuestAbility.opponent=Malandro - escolhendo uma tarefa para completar.
+tuber.canis.abilities.VagabondAbilities.VagabondRepairAbility.opponent=Malandro - escolhendo um item para reparar.
+tuber.canis.abilities.VagabondAbilities.VagabondStrikeAbility.opponent=Malandro - escolhendo o que atacar.
+tuber.canis.abilities.WoodlandAllianceAbilities.MobilizeAbility.opponent=Aliança da Floresta - escolhendo uma carta para adicionar aos Apoiadores.
+tuber.canis.abilities.WoodlandAllianceAbilities.OrganizeAbility.opponent=Aliança da Floresta - escolhendo um guerreiro para sacrificar por simpatia.
+tuber.canis.abilities.WoodlandAllianceAbilities.RevoltAbility.opponent=Aliança da Floresta - escolhendo uma clareira para se revoltar.
+tuber.canis.abilities.WoodlandAllianceAbilities.SpreadSympathyAbility.opponent=Aliança da Floresta - escolhendo uma clareira para espalhar simpatia.
+tuber.canis.abilities.WoodlandAllianceAbilities.TrainAbility.opponent=Aliança da Floresta - treinando um oficial.
+tuber.canis.abilities.WoodlandAllianceAbilities.WoodlandAllianceRecruitAbility.opponent=Aliança da Floresta - escolhendo uma clareira para recrutar um guerreiro.
+tuber.canis.abilities.BetterBurrowBankAbility.opponent=Aliança da Floresta - escolhendo um jogador para comprar uma carta com o Banco Bom Bocado.
+tuber.canis.abilities.ClaimDominanceAbility.opponent=[player] - escolhendo uma carta para trocar por uma carta de domínio na loja.
+tuber.canis.abilities.CobblerAbility.opponent=[player] - usando o Sapateiro para se mover.
+tuber.canis.abilities.CodeBreakersAbility.opponent=[player] - usando Decodificadores para olhar a mão de um jogador.
+tuber.canis.abilities.CommandWarrenAbility.opponent=[player] - usando o Comando para batalhar.
+tuber.canis.abilities.CraftAbility.opponent=[player] - escolhendo uma carta para criar.
+tuber.canis.abilities.StandAndDeliverAbility.opponent=[player] - escolhendo um jogador para roubar uma carta com Mãos ao Alto!
+tuber.canis.abilities.TaxCollectorAbility.opponent=[player] - escolhendo um guerreiro para sacrificar por uma carta com o Coletor de Taxas.
+tuber.canis.entities.PlayableClasses.ChoosePiecesToRemove.opponent=[player] - escolhendo baixas.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Recruit.opponent=Dinastia das Rapinas - escolhendo uma clareira para recrutar guerreiros.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Move.opponent=Dinastia das Rapinas - escolhendo uma clareira para mover.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Battle.opponent=Dinastia das Rapinas - escolhendo uma clareira para iniciar uma batalha.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightAction_Build.opponent=Dinastia das Rapinas - escolhendo uma clareira para construir um ninho.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Recruit.opponent=Dinastia das Rapinas - entrando em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Move.opponent=Dinastia das Rapinas - entrando em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Battle.opponent=Dinastia das Rapinas - entrando em Tumulto.
+tuber.canis.actions.EyrieDynastiesActions.EyrieDynastiesDaylightActionTurmoil_Build.opponent=Dinastia das Rapinas - entrando em Tumulto.
 tuber.canis.actions.usecraftedcards=Ativar cartas criadas?
-tuber.canis.actions.usecraftedcards.opponent=[player] está considerando opções...
+tuber.canis.actions.usecraftedcards.opponent=[player] - considerando opções...
 tuber.canis.abilities.ClaimDominanceAbility.PickDominanceCard=Escolha uma carta de domínio para reivindicar.
-tuber.canis.abilities.ClaimDominanceAbility.PickDominanceCard.opponent=[player] está escolhendo uma carta de domínio.
+tuber.canis.abilities.ClaimDominanceAbility.PickDominanceCard.opponent=[player] - escolhendo uma carta de domínio.
 tuber.canis.actions.BattleActions.ChooseAmbushCards.CancelDefenderAmbush=Usar uma Emboscada para cancelar uma Emboscada inimiga correspondente?
-tuber.canis.actions.BattleActions.ChooseAmbushCards.CancelDefenderAmbush.opponent=[player] está considerando opções...
+tuber.canis.actions.BattleActions.ChooseAmbushCards.CancelDefenderAmbush.opponent=[player] - considerando opções...
 build.turmoil.noRoosts=Não há mais ninhos em seu suprimento para construir. <br> Continue para entrar em Tumulto.
 build.turmoil.noBuildableSpots=Não é possível construir um Ninho em uma clareira [X] <br> porque não há espaços de construção disponíveis <br> nas clareiras que você controla nesse naipe. <br> Continue para entrar em Tumulto.
 build.turmoil.noControl=Não é possível construir um Ninho em uma clareira [X] <br> porque você não governa nenhuma clareira nesse naipe. <br> Continue para entrar em Tumulto.
@@ -3602,14 +3602,14 @@ lobby.gamecompleted={0} foi concluído.
 tutorial.completedbody=O tutorial foi concluído. Coloque seus conhecimentos à prova no modo Desafio?
 tutorial.completedheader=Tutorial concluído!
 tuber.canis.entities.discardpile=PILHA DE DESCARTE
-recruit.trumoil.notEnoughWarriors.opponent=A Dinastia das Rapinas está entrando em Tumulto.
-build.turmoil.noRoosts.opponent=A Dinastia das Rapinas está entrando em Tumulto.
-build.turmoil.noBuildableSpots.opponent=A Dinastia das Rapinas está entrando em Tumulto.
-build.turmoil.noControl.opponent=A Dinastia das Rapinas está entrando em Tumulto.
+recruit.trumoil.notEnoughWarriors.opponent=Dinastia das Rapinas - entrando em Tumulto.
+build.turmoil.noRoosts.opponent=Dinastia das Rapinas - entrando em Tumulto.
+build.turmoil.noBuildableSpots.opponent=Dinastia das Rapinas - entrando em Tumulto.
+build.turmoil.noControl.opponent=Dinastia das Rapinas - entrando em Tumulto.
 tuber.canis.actions.EyrieDynastiesActions.RestoreEyrieChoice=Escolha uma clareira para colocar um ninho e 3 guerreiros.
-tuber.canis.actions.EyrieDynastiesActions.RestoreEyrieChoice.opponent=A Dinastia das Rapinas está escolhendo uma clareira para colocar um ninho e 3 guerreiros.
+tuber.canis.actions.EyrieDynastiesActions.RestoreEyrieChoice.opponent=Dinastia das Rapinas - escolhendo uma clareira para colocar um ninho e 3 guerreiros.
 tuber.canis.actions.tuber.canis.actions.automateactions.outrage=Escolha uma carta para adicionar aos apoiadores da Aliança Automatizada.
-tuber.canis.actions.tuber.canis.actions.automateactions.outrage.opponent=[player] está escolhendo uma carta para adicionar aos apoiadores da Aliança Automatizada.
+tuber.canis.actions.tuber.canis.actions.automateactions.outrage.opponent=[player] - escolhendo uma carta para adicionar aos apoiadores da Aliança Automatizada.
 vagabot.abiltiy.marksman=Atirador de Elite
 electriceyrie.ability.wartax=Imposto de Guerra
 mechanicalmarquise.score.buildings={0} Construções
@@ -3625,13 +3625,13 @@ tuber.canis.undo.vagabondSetupUndo.opponent=Aguardando o Malandro confirmar a pr
 prompts.productunlock.cosmetic.title={0}
 prompts.productunlock.cosmetic.description={0} foi desbloqueado para sua conta.
 tuber.canis.actions.DrawThenDiscard.NoActions=Não há mais cartas para descartar. Pressione o botão continuar.
-tuber.canis.actions.DrawThenDiscard.NoActions.opponent=[player] está escolhendo cartas para descartar.
+tuber.canis.actions.DrawThenDiscard.NoActions.opponent=[player] - escolhendo cartas para descartar.
 prompt.platform.warning=Essa configuração pode fazer com que a interface pareça incorreta em determinados dispositivos e não pode ser alterada durante o jogo. Tem certeza de que deseja continuar?
 prompt.readylivegame=Seu jogo ao vivo está pronto. Como os temporizadores de turno são curtos, você deve ir até lá agora ou desistir.
 prompt.game.aitakeover=Você ficou sem tempo para fazer uma jogada no Root, então seu turno foi assumido por uma IA. Faça sua próxima jogada dentro do tempo permitido ou será removido do jogo.
 prompt.first.live.game=Bem-vindo ao seu primeiro jogo ao vivo. Você tem 3 minutos para completar um turno. Se exceder esse tempo, seu turno será assumido por uma IA. Se a IA assumir seu turno duas vezes seguidas, você será resignado. Divirta-se e não vá a lugar nenhum!
 tuber.canis.actions.RequiredAbilitySelect=Você deve usar a carta criada [ability] para continuar.
-tuber.canis.actions.RequiredAbilitySelect.opponent=[player] está considerando opções...
+tuber.canis.actions.RequiredAbilitySelect.opponent=[player] - considerando opções...
 login.deleteaccountbutton=Excluir Conta
 deleteaccount.confirm.message=Tem certeza de que deseja excluir sua conta?
 deleteaccount.complete.message=Verifique seu e-mail para concluir a exclusão da conta.
@@ -3639,35 +3639,35 @@ deleteaccount.failed.message=Um erro de rede impediu a exclusão de sua conta. T
 prompt.advancedsetup.choose.faction=Escolha Sua Facção
 prompt.advancedsetup.choose.faction.opponent=Um oponente está escolhendo sua Facção.
 prompt.advancedsetup.discard=Escolha 2 cartas para devolver ao baralho.
-prompt.advancedsetup.discard.opponent=[player] está escolhendo 2 cartas para devolver ao baralho.
+prompt.advancedsetup.discard.opponent=[player] - escolhendo 2 cartas para devolver ao baralho.
 prompt.advancedsetup.marquisedecat.sawmill=Escolha uma clareira de origem para sua serraria.
-prompt.advancedsetup.marquisedecat.sawmill.opponent=[player] está escolhendo uma clareira de origem para sua serraria.
+prompt.advancedsetup.marquisedecat.sawmill.opponent=[player] - escolhendo uma clareira de origem para a serraria.
 prompt.advancedsetup.marquisedecat.workshop=Escolha uma clareira de origem para sua oficina adjacente à sua serraria.
-prompt.advancedsetup.marquisedecat.workshop.opponent=[player] está escolhendo uma clareira de origem para sua oficina.
+prompt.advancedsetup.marquisedecat.workshop.opponent=[player] - escolhendo uma clareira de origem para a oficina.
 prompt.advancedsetup.marquisedecat.recruiter=Escolha uma clareira de origem para seu recrutador adjacente à sua oficina ou serraria.
-prompt.advancedsetup.marquisedecat.recruiter.opponent=[player] está escolhendo uma clareira de origem para seu recrutador.
+prompt.advancedsetup.marquisedecat.recruiter.opponent=[player] - escolhendo uma clareira de origem para o recrutador.
 prompt.advancedsetup.marquisedecat.homeland.1=Escolha uma clareira de origem para colocar uma construção.
-prompt.advancedsetup.marquisedecat.homeland.1.opponent=[player] está escolhendo uma clareira de origem para sua primeira construção.
+prompt.advancedsetup.marquisedecat.homeland.1.opponent=[player] - escolhendo uma clareira de origem para a primeira construção.
 prompt.advancedsetup.marquisedecat.homeland.2=Escolha outra clareira de origem adjacente à última para colocar uma construção.
-prompt.advancedsetup.marquisedecat.homeland.2.opponent=[player] está escolhendo uma clareira de origem para sua segunda construção.
+prompt.advancedsetup.marquisedecat.homeland.2.opponent=[player] - escolhendo uma clareira de origem para a segunda construção.
 prompt.advancedsetup.marquisedecat.homeland.3=Escolha outra clareira de origem adjacente a uma de suas clareiras de origem para colocar sua última construção.
-prompt.advancedsetup.marquisedecat.homeland.3.opponent=[player] está escolhendo uma clareira de origem para sua terceira construção.
+prompt.advancedsetup.marquisedecat.homeland.3.opponent=[player] - escolhendo uma clareira de origem para a terceira construção.
 prompt.advancedsetup.marquisedecat.keep=Coloque a Torre da Guarda em uma de suas clareiras de origem. Você deve escolher uma clareira que não esteja adjacente à clareira de origem de outro jogador, se possível.
-prompt.advancedsetup.marquisedecat.keep.opponent=[player] está escolhendo uma clareira de origem para sua Torre da Guarda.
+prompt.advancedsetup.marquisedecat.keep.opponent=[player] - escolhendo uma clareira de origem para a Torre da Guarda.
 prompt.advancedsetup.eyriedynasties.roost=Escolha uma clareira de origem para seu Ninho na borda do mapa que tenha 2 ou mais clareiras de distância das clareiras de origem inimigas.
-prompt.advancedsetup.eyriedynasties.roost.opponent=[player] está escolhendo uma clareira de origem para seu Ninho.
+prompt.advancedsetup.eyriedynasties.roost.opponent=[player] - escolhendo uma clareira de origem para o Ninho.
 prompt.advancedsetup.lizardcult.garden=Escolha uma clareira de origem que não seja adjacente às clareiras de origem inimigas para colocar um Jardim e quatro guerreiros.
-prompt.advancedsetup.lizardcult.garden.opponent=[player] está escolhendo uma clareira de origem para seu Jardim.
-prompt.advancedsetup.place.warriors.evenly=Coloque [X] guerreiros em clareiras adjacentes à sua clareira de origem de maneira uniforme.
-prompt.advancedsetup.place.warriors.evenly.opponent=[player] está escolhendo clareiras de origem para seus guerreiros.
+prompt.advancedsetup.lizardcult.garden.opponent=[player] - escolhendo uma clareira de origem para o Jardim.
+prompt.advancedsetup.place.warriors.evenly=Coloque [X] guerreiro(s) em clareiras adjacentes à sua clareira de origem de maneira uniforme.
+prompt.advancedsetup.place.warriors.evenly.opponent=[player] - escolhendo clareiras de origem para os guerreiros.
 prompt.advancedsetup.corvidconspiracy.homeland=Escolha uma clareira de origem.
-prompt.advancedsetup.corvidconspiracy.homeland.opponent=[player] está escolhendo uma clareira de origem.
+prompt.advancedsetup.corvidconspiracy.homeland.opponent=[player] - escolhendo uma clareira de origem.
 prompt.advancedsetup.corvidconspiracy.plot=Coloque um plano oculto em sua clareira de origem.
-prompt.advancedsetup.corvidconspiracy.plot.opponent=[player] está escolhendo um plano para sua clareira de origem.
+prompt.advancedsetup.corvidconspiracy.plot.opponent=[player] - escolhendo uma trama para a clareira de origem.
 prompt.advancedsetup.undergroundduchy.homeland=Escolha uma clareira de origem que não seja adjacente às clareiras de origem inimigas e coloque 2 guerreiros e um Túnel lá.
-prompt.advancedsetup.undergroundduchy.homeland.opponent=[player] está escolhendo uma clareira de origem.
+prompt.advancedsetup.undergroundduchy.homeland.opponent=[player] - escolhendo uma clareira de origem.
 tuber.canis.actions.CharmOffensiveInformants=Substituir compra de Carta Charme Ofensivo por Informantes ou continuar.
-tuber.canis.actions.CharmOffensiveInformants.opponent=[player] está considerando as opções.
+tuber.canis.actions.CharmOffensiveInformants.opponent=[player] - considerando as opções...
 prompt.challenges.sectionheader.standard=Padrão
 prompt.controllersupport.enable=Detectamos uma entrada de controle. Deseja habilitar o suporte para gamepad?
 store.product.clockwork.name=A Expansão Autômata
@@ -3721,163 +3721,163 @@ scenario.work.tier2description=Suas construções iniciais são três oficinas. 
 scenario.ww.name=Guerreiros do Inverno
 scenario.ww.tier1description=Você começa com três guerreiros e um oficial e usa guerreiros para criar neste jogo, em vez de marcadores de simpatia. Você não pode mobilizar cartas de pássaro.
 scenario.ww.tier2description=Você começa com três guerreiros e um oficial e usa guerreiros para criar neste jogo, em vez de marcadores de simpatia. Você não pode mobilizar cartas de pássaro e começa sem apoiadores.
-Log.Eyrie.Selects.Character=<color=#3a63cb>Dinastia das Rapinas</color> seleciona [name] como seu líder, adicionando um <sprite name="birdicon"> aos decretos [area1] e [area2].
-Log.Eyrie.Selects.Roost=[faction name] constrói seu Ninho inicial em uma clareira de [suit icon].
-Log.Vagabond.Character=[faction name] escolhe [name] como seu personagem.
-Log.Keep.Choice=[faction name] coloca sua Torre da Guarda em uma clareira de [suit icon].
-Log.SetupBuilding.Choice=[faction name] coloca [piece] em uma clareira de [suit icon].
+Log.Eyrie.Selects.Character=<color=#3a63cb>Dinastia das Rapinas</color> - selecionando [name] como líder, adicionando <sprite name="birdicon"> aos decretos [area1] e [area2].
+Log.Eyrie.Selects.Roost=[faction name] - construindo o Ninho inicial em uma clareira de [suit icon].
+Log.Vagabond.Character=[faction name] - escolhendo [name] como seu personagem.
+Log.Keep.Choice=[faction name] - colocando a Torre da Guarda em uma clareira de [suit icon].
+Log.SetupBuilding.Choice=[faction name] - colocando [piece] em uma clareira de [suit icon].
 Log.Start.Game=Início do Jogo
 Log.Start.Turn=Turno de [faction name]
 Log.Birdsong=<sprite name="Birdsong">Amanhecer
 Log.Daylight=<sprite name="Daylight">Dia
 Log.Evening=<sprite name="Evening">Anoitecer
-Log.initiate.battle=[faction name] inicia uma batalha contra [faction name 2] em uma clareira de [suit icon].
-Log.Ambush=[faction name] embosca [faction name 2] com uma emboscada de [suit icon].
-Log.Ambush.Cancel=[faction name] cancela a emboscada de [faction name 2] com uma emboscada de [suit icon].
-Log.Roll=[faction name] pega o dado [X]. [faction name 2] pega o dado [X2].
-Log.Defenseless.Hit=[faction name] ganha um golpe adicional porque seu oponente está indefeso.
-Log.Casualties=[faction name] perde [pieces].
-Log.Nonvagabond.Move=[faction name] move [X] guerreiro(s) para uma clareira de [suit icon].
-Log.Craft.Persistent=[faction name] cria [name].
-Log.Craft.Item=[faction name] criou [name], recebendo [item icon] e [X] <style="vptext">PV</style>.
-Log.Build=[faction name] constrói um(a) [building name] em uma clareira de [suit icon].
-Log.Recruit.single=[faction name] recruta um guerreiro em uma clareira de [suit icon].
-Log.Recruit.multiple=[faction name] recruta [X] guerreiros.
-Log.Discard.eot=[faction name] descarta [X] cartas para atender ao limite de cartas na mão.
-Log.Draw=[faction name] compra [X] cartas.
-Log.Generic.Scoring=[faction name] ganha [X] <style="vptext">PV</style>.
-Log.Claim.Dominance.supply=[faction name] descartou uma carta de [suit icon] para reivindicar [suit icon 2] [name] do estoque.
+Log.initiate.battle=[faction name] - iniciando uma batalha contra [faction name 2] em uma clareira de [suit icon].
+Log.Ambush=[faction name] - emboscando [faction name 2] com uma emboscada de [suit icon].
+Log.Ambush.Cancel=[faction name] - cancelando a emboscada de [faction name 2] com uma emboscada de [suit icon].
+Log.Roll=[faction name] - pegando o dado [X], deixando [faction name 2] com o dado [X2].
+Log.Defenseless.Hit=[faction name] - ganhando um golpe adicional porque o oponente está indefeso.
+Log.Casualties=[faction name] - perdendo [pieces].
+Log.Nonvagabond.Move=[faction name] - movendo [X] guerreiro(s) para uma clareira de [suit icon].
+Log.Craft.Persistent=[faction name] - criando [name].
+Log.Craft.Item=[faction name] - criando [name], recebendo [item icon] e [X] <style="vptext">PV</style>.
+Log.Build=[faction name] - construindo [building name] em uma clareira de [suit icon].
+Log.Recruit.single=[faction name] - recrutando um guerreiro em uma clareira de [suit icon].
+Log.Recruit.multiple=[faction name] - recrutando [X] guerreiro(s).
+Log.Discard.eot=[faction name] - descartando [X] carta(s) para atender ao limite de cartas na mão.
+Log.Draw=[faction name] - comprando [X] carta(s).
+Log.Generic.Scoring=[faction name] - ganhando [X] <style="vptext">PV</style>.
+Log.Claim.Dominance.supply=[faction name] - descartando uma carta de [suit icon] para reivindicar [suit icon 2] [name] do estoque.
 Log.Reshuffle=O baralho ficou sem cartas e foi reembaralhado.
-Log.Aid=[faction name] exaure [item icon] para ajudar [faction name 2] com uma carta.
-Log.Aid.Item=[faction name] recebe [item icon] em troca pela ajuda.
-Log.Slip.Clearing=[faction name] desliza para uma clareira de [suit icon].
-Log.Slip.Forest=[faction name] desliza para uma floresta.
-Log.Quest=[faction name] exaure [item icon] e [item icon 2] para completar a tarefa [name].
-Log.Quest.Draw.Reward=[faction name] compra 2 cartas como recompensa da tarefa.
-Log.Quest.Point.Reward=[faction name] pontua [X] <style="vptext">PV</style> como recompensa da tarefa.
-Log.Relationship.1=[faction name] aumenta sua relação com [faction name 2] para nível 1, ganhando 1 <style="vptext">PV</style>.
-Log.Relationship.2=[faction name] aumenta sua relação com [faction name 2] para nível 2, ganhando 2 <style="vptext">PV</style>.
-Log.Relationship.3=[faction name] aumenta sua relação com [faction name 2] para aliado, ganhando 2 <style="vptext">PV</style>.
-Log.Relationship.Hostile=[faction name] torna-se hostil à [faction name 2].
-Log.Refresh=[faction name] reanima os seguintes itens no Amanhecer: [items].
-Log.Explore=[faction name] explora uma ruína em uma clareira de [suit icon]. Ganham 1 <style="vptext">PV</style> e obtêm um [item icon].
-Log.Strike=[faction name] ataca [piece] de [faction name 2] em uma clareira de [suit icon].
-Log.Repair=[faction name] exaure <sprite name="hammer"> para reparar [item icon].
-Log.Evenings.Rest=[faction name] repara todos os itens com Descanso do Anoitecer.
-Log.Satchel.Discard=[faction name] remove os seguintes itens de sua mochila por estar sobrecarregada: [items].
-Log.Steal=[faction name] usa Roubo, exaurindo <sprite name="torch"> para pegar uma carta aleatória de [faction name 2].
-Log.Hideout=[faction name] usa Esconderijo, exaurindo <sprite name="torch"> para reparar [items]. Isso encerra o dia.
-Log.Day.Labor=[faction name] usa Dia de Trabalho, exaurindo <sprite name="torch"> para pegar uma carta da pilha de descarte e colocá-la na mão.
-Log.Move.Vagabond=[faction name] exaure <sprite name="boot"> para mover-se para uma clareira de [suit icon].
-Log.Vagabond.item.damage.gen=[faction name] danifica os seguintes itens: [items].
-Log.Enter.Coalition=[faction name] entra em uma Coalizão com [faction name 2].
-Log.Move.Buddy=[faction name] move-se com [X] guerreiro(s) de [faction name 2].
-Log.Outrage=[faction name] causa Ultraje, adicionando uma carta aos apoiadores da <color=#008D3F>Aliança da Floresta</color>.
-Log.Outrage.reveal=[faction name 2] revela sua mão para [faction name] devido ao Ultraje. [faction name] adiciona uma carta do baralho aos seus apoiadores.
-Log.Outrage.reveal.rootbot=[faction name 2] não tem cartas na mão para revelar a [faction name] devido ao Ultraje. [faction name] adiciona uma carta do baralho aos seus apoiadores.
-Log.Outrage.reveal.nocarddrawn=[faction name 2] revela sua mão para [faction name] devido ao Ultraje. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
-Log.Outrage.reveal.rootbot.nocarddrawn=[faction name 2] não tem cartas na mão para revelar a [faction name] devido ao Ultraje. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
-Log.Revolt.Intro=[faction name] inicia uma revolta em uma clareira de [suit icon].
-Log.Revolt.destruction=[faction name] perdeu [pieces].
-Log.Revolt.additions=[faction name] ganha um oficial e [X] guerreiro(s).
-Log.Sympathy=[faction name] gasta [X] apoiadores para espalhar simpatia em uma clareira de [suit icon], pontuando [X2] <style="vptext">PV</style>.
-Log.Mobilize=[faction name] usa Mobilizar para adicionar uma carta aos seus apoiadores.
-Log.Organize=[faction name] usa Organizar para sacrificar um guerreiro por simpatia em uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
-Log.Organize.AutomatedAlliance=[faction name] usa Organizar para sacrificar todos os guerreiros em uma clareira de [suit icon] para espalhar simpatia, pontuando [X] <style="vptext">PV</style>.
-Log.Train=[faction name] treina um oficial.
+Log.Aid=[faction name] - exaurindo [item icon] para ajudar [faction name 2] com uma carta.
+Log.Aid.Item=[faction name] - recebendo [item icon] em troca pela ajuda.
+Log.Slip.Clearing=[faction name] - deslizando para uma clareira de [suit icon].
+Log.Slip.Forest=[faction name] - deslizando para uma floresta.
+Log.Quest=[faction name] - exaurindo [item icon] e [item icon 2] para completar a tarefa [name].
+Log.Quest.Draw.Reward=[faction name] - comprando 2 cartas como recompensa da tarefa.
+Log.Quest.Point.Reward=[faction name] - pontuando [X] <style="vptext">PV</style> como recompensa da tarefa.
+Log.Relationship.1=[faction name] - aumentando a relação com [faction name 2] para nível 1, ganhando 1 <style="vptext">PV</style>.
+Log.Relationship.2=[faction name] - aumentando a relação com [faction name 2] para nível 2, ganhando 2 <style="vptext">PV</style>.
+Log.Relationship.3=[faction name] - aumentando a relação com [faction name 2] para aliado, ganhando 2 <style="vptext">PV</style>.
+Log.Relationship.Hostile=[faction name] - tornando-se hostil à [faction name 2].
+Log.Refresh=[faction name] - reanimando os seguintes itens no Amanhecer: [items].
+Log.Explore=[faction name] - explorando uma ruína em uma clareira de [suit icon], recebendo 1 <style="vptext">PV</style> e obtendo [item icon].
+Log.Strike=[faction name] - atacando [piece] de [faction name 2] em uma clareira de [suit icon].
+Log.Repair=[faction name] - exaurindo <sprite name="hammer"> para reparar [item icon].
+Log.Evenings.Rest=[faction name] - reparando todos os itens com Descanso ao Pôr do Sol.
+Log.Satchel.Discard=[faction name] - removendo os seguintes itens da mochila por estar sobrecarregada: [items].
+Log.Steal=[faction name] - usando Roubo, exaurindo <sprite name="torch"> para pegar uma carta aleatória de [faction name 2].
+Log.Hideout=[faction name] - usando Esconderijo, exaurindo <sprite name="torch"> para reparar [items]. Isso encerra o dia.
+Log.Day.Labor=[faction name] - usando Dia de Trabalho, exaurindo <sprite name="torch"> para pegar uma carta da pilha de descarte e colocá-la na mão.
+Log.Move.Vagabond=[faction name] - exaurindo <sprite name="boot"> para mover-se para uma clareira de [suit icon].
+Log.Vagabond.item.damage.gen=[faction name] - danificando os seguintes itens: [items].
+Log.Enter.Coalition=[faction name] - entrando em uma Coalizão com [faction name 2].
+Log.Move.Buddy=[faction name] - movendo-se com [X] guerreiro(s) de [faction name 2].
+Log.Outrage=[faction name] - causando Ultraje, adicionando uma carta aos apoiadores da <color=#008D3F>Aliança da Floresta</color>.
+Log.Outrage.reveal=[faction name 2] - revelando a mão para [faction name] devido ao Ultraje. [faction name] adiciona uma carta do baralho aos apoiadores.
+Log.Outrage.reveal.rootbot=[faction name 2] - não tem cartas na mão para revelar a [faction name] devido ao Ultraje. [faction name] adiciona uma carta do baralho aos apoiadores.
+Log.Outrage.reveal.nocarddrawn=[faction name 2] - revelando a mão para [faction name] devido ao Ultraje. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
+Log.Outrage.reveal.rootbot.nocarddrawn=[faction name 2] - não tem cartas na mão para revelar a [faction name] devido ao Ultraje. [faction name] não pode adicionar uma carta do baralho aos seus apoiadores porque não há cartas disponíveis.
+Log.Revolt.Intro=[faction name] - iniciando uma revolta em uma clareira de [suit icon].
+Log.Revolt.destruction=[faction name] - perdendo [pieces].
+Log.Revolt.additions=[faction name] - ganhando um oficial e [X] guerreiro(s).
+Log.Sympathy=[faction name] - gastando [X] carta(s) do baralho de apoiadores para espalhar simpatia em uma clareira de [suit icon], pontuando [X2] <style="vptext">PV</style>.
+Log.Mobilize=[faction name] - usando Mobilizar para adicionar uma carta aos apoiadores.
+Log.Organize=[faction name] - usando Organizar para sacrificar um guerreiro por simpatia em uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
+Log.Organize.AutomatedAlliance=[faction name] - usando Organizar para sacrificar todos os guerreiros em uma clareira de [suit icon] para espalhar simpatia, pontuando [X] <style="vptext">PV</style>.
+Log.Train=[faction name] - treinando um oficial.
 Log.Lost.base=Como uma base da <color=#008D3F>Aliança da Floresta</color> foi removida, eles perdem [X] oficiais e descartam [X2] apoiadores correspondentes.
-Log.Generate.Wood=[faction name] geraram [X] madeira(s) durante o Amanhecer.
-Log.Overwork=[faction name] usaram Hora Extra para descartar uma carta de [suit icon] por 1 madeira.
-Log.Field.Hospitals=[faction name] usaram Hospitais de Campanha para devolver [X] guerreiro(S) caído(s) à sua Torre da Guarda.
-Log.Hawks=[faction name] descartam uma carta <sprite name="birdicon"> para realizar uma ação extra.
-Log.Decree.Assignment=[faction name] atribui [suit icon] ao seu decreto de [name].
-Log.Special.Birdsong.Draw=[faction name] compra uma carta durante o Amanhecer porque sua mão estava vazia.
-Log.Special.Birdsong.Roost=[faction name] coloca um ninho e 3 guerreiros em uma clareira de [suit icon] porque não tinha ninhos.
-Log.Turmoil.recruit=[faction name] entra em tumulto porque não conseguiu recrutar em uma clareira de [suit icon].
-Log.Turmoil.move=[faction name] entra em tumulto porque não conseguiu se mover d uma clareira de [suit icon].
-Log.Turmoil.battle=[faction name] entra em tumulto porque não conseguiu batalhar em uma clareira de [suit icon].
-Log.Turmoil.build=[faction name] entra em tumulto porque não conseguiu construir em uma clareira de [suit icon].
-Log.Turmoil.build.noroosts=[faction name] entra em tumulto porque não tinha ninhos restantes em seu suprimento para construir.
-Log.Turmoil.recruit.nowarriors=[faction name] entra em tumulto porque não tinha guerreiros restantes em seu suprimento para recrutar.
-Log.Turmoil.lose.points=[faction name] descarta seu decreto e perde [X] <style="vptext">PV</style>.
-Log.Turmoil.New.Leader=<color=#3a63cb>Dinastia das Rapinas</color> escolhe [name] como seu novo líder, adicionando um <sprite name="birdicon"> aos decretos de [area1] e [area2].
-Log.Despot.Power=[faction name] pontua 1 <style="vptext">PV</style> adicional com a habilidade de líder Déspota.
-Log.Charasmatic.Power=[faction name] coloca um guerreiro adicional com a habilidade de Líder Carismático.
-Log.Commander.hit=[faction name] causa um acerto adicional com a habilidade de Comandante.
-Log.Favor.Craft=[faction name] cria [name] para remover todas as peças inimigas em clareiras de [suit icon].
-Log.Dominance=[faction name] joga uma carta de domínio para mudar sua condição de vitória.
-Log.Armorers=[faction name] descarta Armeiros para ignorar acertos rolados.
-Log.Sappers=[faction name] descarta Armadilheiros para causar um acerto adicional.
-Log.BrutalTactics=[faction name] usa Táticas Brutais para causar um acerto adicional. O defensor pontua 1 <style="vptext">PV</style>.
-Log.RoyalClaim=[faction name] descarta Reivindicação Real para pontuar 1 <style="vptext">PV</style> para cada clareira que governa. Eles pontuam [X] <style="vptext">PV</style>.
-Log.StandandDeliver=[faction name] usa "Mãos ao Alto!" para pegar uma carta aleatória de [faction name 2]. Esse jogador pontua 1 <style="vptext">PV</style>.
-Log.TaxCollector=[faction name] usa Coletor de Taxas para remover um guerreiro e comprar uma carta.
-Log.CommandWarren=[faction name] usa Comando para iniciar uma batalha contra [faction name 2] em uma clareira de [suit icon].
-Log.BetterBurrowBank=[faction name] usa Banco Bom Bocado para comprar uma carta junto com [faction name 2].
-Log.Cobbler=[faction name] usa Sapateiro para se mover.
-Log.Codebreakers=[faction name] usa Decodificadores para olhar a mão de [faction name 2].
-log.order=[faction name] revela [suit icon] como sua ordem.
-log.given.card=[faction name] descarta a carta que recebeu de [faction name 2] e pontua 1 <style="vptext">PV</style>.
-log.nightmare.score=[faction name] pontua 1 <style="vptext">PV</style> pela dificuldade Pesadelo.
+Log.Generate.Wood=[faction name] - gerando [X] madeira(s) durante o Amanhecer.
+Log.Overwork=[faction name] - usando Hora Extra para descartar uma carta de [suit icon] por 1 madeira.
+Log.Field.Hospitals=[faction name] - usando Hospitais de Campanha para devolver [X] guerreiro(s) caídos à Torre da Guarda.
+Log.Hawks=[faction name] - descartando uma carta <sprite name="birdicon"> para realizar uma ação extra.
+Log.Decree.Assignment=[faction name] - atribuindo [suit icon] ao decreto de [name].
+Log.Special.Birdsong.Draw=[faction name] - comprando uma carta durante o Amanhecer porque a mão estava vazia.
+Log.Special.Birdsong.Roost=[faction name] - colocando um ninho e 3 guerreiros em uma clareira de [suit icon] porque não tinha ninhos.
+Log.Turmoil.recruit=[faction name] - entrando em tumulto porque não foi possível recrutar em uma clareira de [suit icon].
+Log.Turmoil.move=[faction name] - entrando em tumulto porque não foi possível se mover de uma clareira de [suit icon].
+Log.Turmoil.battle=[faction name] - entrando em tumulto porque não foi possível batalhar em uma clareira de [suit icon].
+Log.Turmoil.build=[faction name] - entrando em tumulto porque não foi possível construir em uma clareira de [suit icon].
+Log.Turmoil.build.noroosts=[faction name] - entrando em tumulto porque não tinha ninhos restantes em seu suprimento para construir.
+Log.Turmoil.recruit.nowarriors=[faction name] - entrando em tumulto porque não tinha guerreiros restantes em seu suprimento para recrutar.
+Log.Turmoil.lose.points=[faction name] - descartando o decreto, perdendo [X] <style="vptext">PV</style>.
+Log.Turmoil.New.Leader=<color=#3a63cb>Dinastia das Rapinas</color> - selecionando [name] como novo líder, adicionando <sprite name="birdicon"> aos decretos de [area1] e [area2].
+Log.Despot.Power=[faction name] - pontuando 1 <style="vptext">PV</style> adicional com a habilidade de líder Déspota.
+Log.Charasmatic.Power=[faction name] - colocando um guerreiro adicional com a habilidade de Líder Carismático.
+Log.Commander.hit=[faction name] - causando um acerto adicional com a habilidade de Comandante.
+Log.Favor.Craft=[faction name] - criando [name] para remover todas as peças inimigas em clareiras de [suit icon].
+Log.Dominance=[faction name] - jogando uma carta de domínio, mudando a condição de vitória.
+Log.Armorers=[faction name] - descartando Armeiros para ignorar acertos rolados.
+Log.Sappers=[faction name] - descartando Armadilheiros para causar um acerto adicional.
+Log.BrutalTactics=[faction name] - usando Táticas Brutais para causar um acerto adicional. O defensor pontua 1 <style="vptext">PV</style>.
+Log.RoyalClaim=[faction name] - descartando Reivindicação Real para pontuar 1 <style="vptext">PV</style> para cada clareira que governa, pontuando [X] <style="vptext">PV</style>.
+Log.StandandDeliver=[faction name] - usando "Mãos ao Alto!" para pegar uma carta aleatória de [faction name 2]. Esse jogador pontua 1 <style="vptext">PV</style>.
+Log.TaxCollector=[faction name] - usando Coletor de Taxas para remover um guerreiro e comprar uma carta.
+Log.CommandWarren=[faction name] - usando Comando para iniciar uma batalha contra [faction name 2] em uma clareira de [suit icon].
+Log.BetterBurrowBank=[faction name] - usando Banco Bom Bocado para comprar uma carta junto com [faction name 2].
+Log.Cobbler=[faction name] - usando Sapateiro para se mover.
+Log.Codebreakers=[faction name] - usando Decodificadores para olhar a mão de [faction name 2].
+log.order=[faction name] - revelando [suit icon] como sua ordem.
+log.given.card=[faction name] - descartando a carta que recebeu de [faction name 2] e pontuando 1 <style="vptext">PV</style>.
+log.nightmare.score=[faction name] - pontuando 1 <style="vptext">PV</style> pela dificuldade Pesadelo.
 log.escalated.daylight=Dia Expandido
 log.expand=A <color=#CC6633>Marquês Mecânico</color> se expande, comprando uma nova ordem e repetindo o Dia.
-log.evening.score=<color=#CC6633>Marquês Mecânico</color> pontua [X] <style="vptext">PV</style> de sua trilha de construções.
-log.trait.blitz=<color=#CC6633>Marquês Mecânico</color> usa seu traço Blitz para se mover e batalhar.
-Log.trait.Hospitals=<color=#CC6633>Marquês Mecânico</color> usa seu traço Hospital para devolver [X] guerreiros caídos à sua Torre da Guarda.
-log.trait.relentless=<color=#3a63cb>Rapinas Elétricas</color> usam seu traço Implacável para remover todas as peças inimigas indefesas em clareiras com guerreiros Rapinas.
-log.trait.swoop=<color=#3a63cb>Rapinas Elétricas</color> usam seu traço Investida para colocar dois guerreiros em uma clareira de [suit icon].
-log.trait.nobility=<color=#3a63cb>Rapinas Elétricas</color> pontuam [X] <style="vptext">PV</style> com seu traço Nobreza.
-log.trait.wartax=[faction name] perde [X] <style="vptext">PV</style> devido ao traço Imposto de Guerra das <color=#3a63cb>Rapinas Elétricas</color>.
-log.setup.electric.eyrie=<color=#3a63cb>Rapinas Elétricas</color> adicionam [X] cartas <sprite name="birdicon"> à coluna de <sprite name="birdicon"> de seu decreto.
-log.battle.extrahit=<color=#3a63cb>Rapinas Elétricas</color> causam um acerto extra por ter mais cartas atribuídas à coluna ordenada de seu decreto do que qualquer outra.
-log.public.pity=<color=#008D3F>Aliança Automatizada</color> usa Comiseração Pública para espalhar simpatia [X] vezes.
-log.crackdown=<color=#008D3F>Aliança Automatizada</color> perde todos os marcadores de simpatia em clareiras que correspondem ao naipe da base destruída devido à Repressão.
-Log.automated.Outrage=[faction name] causa Ultraje, descartando uma carta.
-Log.automated.Outrage.vp=[faction name] causa Ultraje, mas não tem uma carta correspondente. <color=#008D3F>Aliança Automatizada</color> pontua 1 <style="vptext">PV</style>.
-log.automated.ambush=<color=#008D3F>Aliança Automatizada</color> causa um acerto extra com sua habilidade Emboscada Automatizada.
-log.trait.wildfire=<color=#008D3F>Aliança Automatizada</color> espalha simpatia para uma clareira de [suit icon], mas não pontua com seu traço Incêndio.
-log.generic.exhaust.item=<color=#436979>Automalandro</color> exaure [X] itens.
-log.battletrack=<color=#436979>Automalandro</color> adiciona um item à sua trilha de batalha, aumentando seu potencial de acerto na batalha.
-log.trait.marksmen=<color=#436979>Automalandro</color> causa um acerto imediato usando seu traço Atirador.
-log.trait.helper=O <color=#436979>Automalandro</color> pontua 1 <style="vptext">PV</style> com seu traço Ajudante, e o jogador ajudado compra uma carta adicional.
-log.vagabot.steal=<color=#436979>Automalandro</color> exaure um item para usar sua habilidade Roubo, pegando uma carta aleatória de [faction name].
-log.vagabot.daylabor=<color=#436979>Automalandro</color> exaure um item para usar sua habilidade Dia de Trabalho, criando [name] do monte de descarte e pontuando 1 <style="vptext">PV</style>.
-log.vagabot.hideout=<color=#436979>Automalandro</color> exaure um item para usar sua habilidade Esconderijo, deslizando para uma floresta.
-log.vagabot.explore=<color=#436979>Automalandro</color> move [X] espaços para uma clareira de [suit icon] com uma ruína para explorá-la. Ele exaure [X] itens, pega um [item icon] da ruína e pontua 1 <style="vptext">PV</style>.
-log.vagabot.quest=<color=#436979>Automalandro</color> move [X] espaços para uma clareira de [suit icon] para completar sua tarefa. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova tarefa.
-log.vagabot.evening.refresh=<color=#436979>Automalandro</color> reanima: [items]
-log.vagabot.evening.repair=<color=#436979>Automalandro</color> repara: [items]
+log.evening.score=<color=#CC6633>Marquês Mecânico</color> - pontuando [X] <style="vptext">PV</style> de sua trilha de construções.
+log.trait.blitz=<color=#CC6633>Marquês Mecânico</color> - usando seu traço Blitz para se mover e batalhar.
+Log.trait.Hospitals=<color=#CC6633>Marquês Mecânico</color> - usando seu traço Hospital para devolver [X] guerreiro(s) caído(s) à Torre da Guarda.
+log.trait.relentless=<color=#3a63cb>Rapinas Elétricas</color> - usando seu traço Implacável para remover todas as peças inimigas indefesas em clareiras com guerreiros Rapinas.
+log.trait.swoop=<color=#3a63cb>Rapinas Elétricas</color> - usando seu traço Investida para colocar dois guerreiros em uma clareira de [suit icon].
+log.trait.nobility=<color=#3a63cb>Rapinas Elétricas</color> - pontuando [X] <style="vptext">PV</style> com seu traço Nobreza.
+log.trait.wartax=[faction name] - perdendo [X] <style="vptext">PV</style> devido ao traço Imposto de Guerra das <color=#3a63cb>Rapinas Elétricas</color>.
+log.setup.electric.eyrie=<color=#3a63cb>Rapinas Elétricas</color> - adicionando [X] carta(s) <sprite name="birdicon"> à coluna de <sprite name="birdicon"> de seu decreto.
+log.battle.extrahit=<color=#3a63cb>Rapinas Elétricas</color> - causando um acerto extra por ter mais cartas atribuídas à coluna ordenada de seu decreto do que qualquer outra.
+log.public.pity=<color=#008D3F>Aliança Automatizada</color> - usando Pena Pública para espalhar simpatia [X] vez(es).
+log.crackdown=<color=#008D3F>Aliança Automatizada</color> - perdendo todos os marcadores de simpatia em clareiras que correspondem ao naipe da base destruída devido à Repressão.
+Log.automated.Outrage=[faction name] - causando Ultraje, descartando uma carta.
+Log.automated.Outrage.vp=[faction name] - causando Ultraje, mas não tem uma carta correspondente. <color=#008D3F>Aliança Automatizada</color> pontua 1 <style="vptext">PV</style>.
+log.automated.ambush=<color=#008D3F>Aliança Automatizada</color> - causando um acerto extra com sua habilidade Emboscada Automatizada.
+log.trait.wildfire=<color=#008D3F>Aliança Automatizada</color> - espalhando simpatia para uma clareira de [suit icon], mas sem pontuar com seu traço Incêndio.
+log.generic.exhaust.item=<color=#436979>Automalandro</color> - exaurindo [X] item(s).
+log.battletrack=<color=#436979>Automalandro</color> - adicionando um item à sua trilha de batalha, aumentando seu potencial de acerto na batalha.
+log.trait.marksmen=<color=#436979>Automalandro</color> - causando um acerto imediato usando seu traço Atirador.
+log.trait.helper=<color=#436979>Automalandro</color> - pontuando 1 <style="vptext">PV</style> com seu traço Ajudante, e o jogador ajudado compra uma carta adicional.
+log.vagabot.steal=<color=#436979>Automalandro</color> - exaurindo um item para usar sua habilidade Roubo, pegando uma carta aleatória de [faction name].
+log.vagabot.daylabor=<color=#436979>Automalandro</color> - exaurindo um item para usar sua habilidade Dia de Trabalho, criando [name] do monte de descarte e pontuando 1 <style="vptext">PV</style>.
+log.vagabot.hideout=<color=#436979>Automalandro</color> - exaurindo um item para usar sua habilidade Esconderijo, deslizando para uma floresta.
+log.vagabot.explore=<color=#436979>Automalandro</color> - movendo [X] espaço(s) para uma clareira de [suit icon] com uma ruína para explorá-la. Ele exaure [X] item(s), pega [item icon] da ruína e pontua 1 <style="vptext">PV</style>.
+log.vagabot.quest=<color=#436979>Automalandro</color> - movendo [X] espaço(s) para uma clareira de [suit icon] para completar sua tarefa. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova tarefa.
+log.vagabot.evening.refresh=<color=#436979>Automalandro</color> - reanimando: [items]
+log.vagabot.evening.repair=<color=#436979>Automalandro</color> - reparando: [items]
 log.aiswap.timeout=[name] ficou inativo e foi substituído por uma IA.
 log.aiswap.resign=[name] desistiu e foi substituído por uma IA.
 key.roost=Ninho
-Log.vagabot.aid=<color=#436979>Automalandro</color> exaure [X] item(s) para ajudar [faction name] com [X] cartas do baralho. Automalandro recebe [items] em troca e ganha [X] <style="vptext">PV</style>.
-Log.automated.Sympathy=<color=#008D3F>Aliança Automatizada</color> espalha simpatia para uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
-log.steal.clockwork=<color=#436979>Malandro</color> recebe uma carta do baralho em vez disso.
-log.vagabot.repair.daylight=<color=#436979>Automalandro</color> exaure um item para reparar um item danificado.
-log.vagabot.battle=<color=#436979>Automalandro</color> exaure [X] item(s) para iniciar uma batalha contra [faction name] em uma clareira de [suit icon].
-log.vagabot.battle.move=<color=#436979>Automalandro</color> exaure [X] item(s) para se mover para uma clareira de [suit icon] e iniciar uma batalha contra [faction name].
-log.generic.exhaust.item.one=<color=#436979>Automalandro</color> exaure 1 item.
-log.vagabot.explore.one=<color=#436979>Automalandro</color> move 1 espaço para uma clareira de [suit icon] com uma ruína para explorá-la. Ele exaure 1 item, pega um [item icon] da ruína e pontua 1 <style="vptext">PV</style>.
-Log.vagabot.aid.one=<color=#436979>Automalandro</color> exaure 1 item para ajudar [faction name] com 1 carta do baralho. Automalandro recebe [items] em troca e ganha 1 <style="vptext">PV</style>.
-log.vagabot.battle.one=<color=#436979>Automalandro</color> exaure 1 item para iniciar uma batalha contra [faction name] em uma clareira de [suit icon].
-log.vagabot.battle.move.one=<color=#436979>Automalandro</color> exaure 1 item para se mover para uma clareira de [suit icon] e iniciar uma batalha contra [faction name].
-Log.DiscardOne.eot=[faction name] descarta 1 carta para atender ao limite de tamanho da mão.
-Log.DrawOne=[faction name] compra 1 carta.
-log.setup.electric.eyrie.one=<color=#3a63cb>Rapinas Elétricas</color> adicionam 1 carta <sprite name="birdicon"> à coluna de <sprite name="birdicon"> de seu decreto.
-Log.Nonvagabond.Move.one=[faction name] move 1 guerreiro para uma clareira de [suit icon].
-Log.Field.Hospitals.one=[faction name] usaram Hospitais de Campo para devolver 1 guerreiro caído à sua Torre da Guarda.
-Log.Move.Buddy.one=[faction name] se move com 1 guerreiro de [faction name 2].
-log.public.pity.one=<color=#008D3F>Aliança Automatizada</color> usa Comiseração Pública para espalhar simpatia 1 vez.
-Log.trait.Hospitals.one=<color=#CC6633>Marquês Mecânico</color> usa seu traço Hospital para devolver 1 guerreiro caído à sua Torre da Guarda.
-Log.Sympathy.one=[faction name] gasta 1 simpatizante para espalhar simpatia para uma clareira de [suit icon], pontuando [X2] <style="vptext">PV</style>.
-log.vagabot.quest.one=<color=#436979>Automalandro</color> move 1 espaço para uma clareira de [suit icon] para completar sua tarefa. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova tarefa.
-log.hatch=<color=#3a63cb>Dinastia das Rapinas</color> choca um guerreiro a partir de um ovo em uma clareira de [suit icon].
-log.multi.hatch=<color=#3a63cb>Dinastia das Rapinas</color> choca [X] guerreiros a partir de ovos em uma clareira de [suit icon].
-log.break=[faction name] quebra um ovo por <style="vpnum">1</style> em uma clareira de [suit icon].
-Log.Move.Vagabond.Hostile=[faction name] exaure <sprite name="boot"><sprite name="boot"> para mover-se para uma clareira de [suit icon].
-Log.Move.Vagabond.Dynamic=[faction name] exaure [boots] para mover-se para uma clareira de [suit icon].
-Log.Move.Vagabond.Free=[faction name] move-se para uma clareira de [suit icon] sem custo de botas.
-log.advancedsetup.returncards=[faction name] embaralha 2 cartas de sua mão no baralho.
+Log.vagabot.aid=<color=#436979>Automalandro</color> - exaurindo [X] item(s) para ajudar [faction name] com [X] carta(s) do baralho. Automalandro recebe [items] em troca e ganha [X] <style="vptext">PV</style>.
+Log.automated.Sympathy=<color=#008D3F>Aliança Automatizada</color> - espalhando simpatia para uma clareira de [suit icon], pontuando [X] <style="vptext">PV</style>.
+log.steal.clockwork=<color=#436979>Malandro</color> - recebendo uma carta do baralho em vez disso.
+log.vagabot.repair.daylight=<color=#436979>Automalandro</color> - exaurindo um item para reparar um item danificado.
+log.vagabot.battle=<color=#436979>Automalandro</color> - exaurindo [X] item(s) para iniciar uma batalha contra [faction name] em uma clareira de [suit icon].
+log.vagabot.battle.move=<color=#436979>Automalandro</color> - exaurindo [X] item(s) para se mover para uma clareira de [suit icon] e iniciar uma batalha contra [faction name].
+log.generic.exhaust.item.one=<color=#436979>Automalandro</color> - exaurindo 1 item.
+log.vagabot.explore.one=<color=#436979>Automalandro</color> - movendo 1 espaço para uma clareira de [suit icon] com uma ruína para explorá-la. Ele exaure 1 item, pega um [item icon] da ruína e pontua 1 <style="vptext">PV</style>.
+Log.vagabot.aid.one=<color=#436979>Automalandro</color> - exaurindo 1 item para ajudar [faction name] com 1 carta do baralho. Automalandro recebe [items] em troca e ganha 1 <style="vptext">PV</style>.
+log.vagabot.battle.one=<color=#436979>Automalandro</color> - exaurindo 1 item para iniciar uma batalha contra [faction name] em uma clareira de [suit icon].
+log.vagabot.battle.move.one=<color=#436979>Automalandro</color> - exaurindo 1 item para se mover para uma clareira de [suit icon] e iniciar uma batalha contra [faction name].
+Log.DiscardOne.eot=[faction name] - descartando 1 carta para atender ao limite de tamanho da mão.
+Log.DrawOne=[faction name] - comprando 1 carta.
+log.setup.electric.eyrie.one=<color=#3a63cb>Rapinas Elétricas</color> - adicionando 1 carta <sprite name="birdicon"> à coluna de <sprite name="birdicon"> de seu decreto.
+Log.Nonvagabond.Move.one=[faction name] - movendo 1 guerreiro para uma clareira de [suit icon].
+Log.Field.Hospitals.one=[faction name] - usando Hospitais de Campo para devolver 1 guerreiro caído à Torre da Guarda.
+Log.Move.Buddy.one=[faction name] - se movendo com 1 guerreiro de [faction name 2].
+log.public.pity.one=<color=#008D3F>Aliança Automatizada</color> - usando Pena Pública para espalhar simpatia 1 vez.
+Log.trait.Hospitals.one=<color=#CC6633>Marquês Mecânico</color> - usando seu traço Hospital para devolver 1 guerreiro caído à sua Torre da Guarda.
+Log.Sympathy.one=[faction name] - gastando 1 simpatizante para espalhar simpatia para uma clareira de [suit icon], pontuando [X2] <style="vptext">PV</style>.
+log.vagabot.quest.one=<color=#436979>Automalandro</color> - movendo 1 espaço para uma clareira de [suit icon] para completar sua tarefa. Ele exaure 2 itens, pontua 1 <style="vptext">PV</style> e compra uma nova tarefa.
+log.hatch=<color=#3a63cb>Dinastia das Rapinas</color> - chocando um guerreiro a partir de um ovo em uma clareira de [suit icon].
+log.multi.hatch=<color=#3a63cb>Dinastia das Rapinas</color> - chocando [X] guerreiro(s) a partir de ovos em uma clareira de [suit icon].
+log.break=[faction name] - quebrando um ovo por <style="vpnum">1</style> em uma clareira de [suit icon].
+Log.Move.Vagabond.Hostile=[faction name] - exaurindo <sprite name="boot"><sprite name="boot"> para mover-se para uma clareira de [suit icon].
+Log.Move.Vagabond.Dynamic=[faction name] - exaurindo [boots] para mover-se para uma clareira de [suit icon].
+Log.Move.Vagabond.Free=[faction name] - movendo-se para uma clareira de [suit icon] sem custo de botas.
+log.advancedsetup.returncards=[faction name] - embaralhando 2 cartas de sua mão no baralho.
 log.raid=Uma Emboscada é removida, fazendo com que a Conspiração Corvídea adicione um guerreiro a cada clareira adjacente à clareira de [suit icon] onde foi removida.
 log.player.won=Vitória - [faction name]
 login.versionPrefix=Construir:


### PR DESCRIPTION
Além das mudanças realizadas no Patch 1.33.1, foi necessário criar uma nova branch para alterar

- Mensagens de prompts para todas as facções, mantendo uma forma mais coesa de mostrar as ações e evitar problemas com o gênero, plurais e tempos verbais de certas palavras.
- Algumas linhas continham o valor [players] o que estava gerando erros no código (o correto é [player].
- O Marquês Mecânico estava aparecendo como "Marqueses Mecânicos" em alguns trechos. 
- Terminologia "Corvídeos" alterada para "Conspiração", conforme a tradução oficial da MeepleBR. 
- Ação "Battle, then Delve" dos Guardiões de Ferro aparecia como "Batalhe, depois Escave" em alguns trechos. Alterado para "Batalhe e Escave" conforme padrão PT-BR. 
- "Árbitro" (Malandro) estava aparecendo como "Arbítrio" em alguns trechos. 
- "Descanso ao Anoitecer" (Evening's Rest) alterado para "Descanso ao Pôr do Sol", também conforme tradução oficial. 
- Alguns trechos citavam o serviço "Riverboats" da Companhia Ribeirinha como "Barcos" ao invés de "Botes". 